### PR TITLE
Backlash correction proposal

### DIFF
--- a/FluidNC/src/Backlash.cpp
+++ b/FluidNC/src/Backlash.cpp
@@ -85,12 +85,8 @@ bool backlash_Compensate_befor_target(float* target, plan_line_data_t *pl_data){
 
     if(backlash_comp_needed){
         log_debug( "BS_COMP (" << backlash_comp_target[0] << " ," << backlash_comp_target[1] << " ," << backlash_comp_target[2]<< " )!!");
-        //mc_line(backlash_comp_target, pl_data_backlash);
         plan_buffer_line(backlash_comp_target, pl_data_backlash);
     }
-    // else {
-    //     log_debug("No Backlash compensation..!!");
-    // }
     return true;
 }
 
@@ -110,7 +106,7 @@ void backlash_Reset_for_homing(bool approach, uint8_t homing_mask) {
     for (int axis = 0; axis < config->_axes->_numberAxis; axis++) {
         if(config->_axes->_axis[axis]->_homing != nullptr ){
             if (bitnum_is_true(homing_mask, axis)) {
-                float t_pos = steps_to_mpos( motor_steps[axis], axis ); /// axis_settings[axis]->steps_per_mm->get();
+                float t_pos = steps_to_mpos( motor_steps[axis], axis );
                 if(t_pos != backlash_data[axis].prev_target){
                     if(approach){
                         backlash_data[axis].prev_direction   = !config->_axes->_axis[axis]->_homing->_positiveDirection ? MotionDirection::Negative : MotionDirection::Positive;
@@ -124,7 +120,6 @@ void backlash_Reset_for_homing(bool approach, uint8_t homing_mask) {
             }
         }
     }
-    //grbl_msg_sendf ( CLIENT_ALL, MsgLevel::Info, "BKSL Initi to (%3.3f, %3.3f, %3.3f) after homing!! ", backlash_data[0].prev_target, backlash_data[1].prev_target, backlash_data[2].prev_target );
 }
 
 //When ever the mechine origin is reset (homing) bcklash also need to reset

--- a/FluidNC/src/Backlash.cpp
+++ b/FluidNC/src/Backlash.cpp
@@ -16,21 +16,25 @@ void backlash_ini() {
         memset(&backlash_data[i], 0, sizeof(backlash_data_t));  // Clear planner struct
         backlash_data[i].backlash_enable    = true;
         backlash_data[i].prev_direction     = MotionDirection::Nutral; //DIR_NEUTRAL;
-        backlash_data[i].prev_target        = 0.000;
+        backlash_data[i].prev_target        = 0.0f;
     }
 }
 
+//This method check if the intended motion to target require any backlash correction
+//if needed it will create intermedeate (secret*) plan_buffer_line() call for the required correction motion.
+//this corrrection motion is supposed to be hidden from the system as much as possible.
+//This method should be called by plan_buffer_line() for all the none backlash motions, 
+//so that all the motion direction changes and previos positions of the machine are tracked. 
 bool backlash_Compensate_befor_target(float* target, plan_line_data_t *pl_data){
-    // Initialize planner data struct forbacklash motion blocks.
+    // Initialize planner data struct for backlash motion blocks.
     plan_line_data_t  plan_data_backlash;
     plan_line_data_t* pl_data_backlash = &plan_data_backlash;
     memcpy(pl_data_backlash, pl_data, sizeof(plan_line_data_t)); 
 
     bool backlash_comp_needed = false;
 
-    //pl_data_backlash->is_backlash_motion = true;  
     //the backlash correction is hidden from any future GRBL or gcode calculations, 
-    //in effect it is almost like a hardware correction which is not visible to software. 
+    //in effect it should look like a hardware correction which is not visible to software. 
     pl_data_backlash->motion.backlashMotion = 1;
 
     if(pl_data_backlash->motion.systemMotion == 1){
@@ -40,9 +44,6 @@ bool backlash_Compensate_befor_target(float* target, plan_line_data_t *pl_data){
 
     float backlash_comp_target[config->_axes->_numberAxis] ={0.0}; //comensated position to move based on mechine backlash before starting to move to target
     for (int axis = 0; axis < config->_axes->_numberAxis; axis++) {
-        // if(axis <3)
-        //     log_debug("BS_CHK Axis: " << axis<< " TGT(" <<  target[axis]<<  "), PRV_TGT( " << backlash_data[axis].prev_target<< ")");
-
         if(target[axis] > backlash_data[axis].prev_target){ //Current move positive
             if(backlash_data[axis].prev_direction == MotionDirection::Negative ){ //Previous move negative, so we need to comp backlash 
                 backlash_data[axis].backlash_enable = true;
@@ -86,7 +87,6 @@ bool backlash_Compensate_befor_target(float* target, plan_line_data_t *pl_data){
         log_debug( "BS_COMP (" << backlash_comp_target[0] << " ," << backlash_comp_target[1] << " ," << backlash_comp_target[2]<< " )!!");
         //mc_line(backlash_comp_target, pl_data_backlash);
         plan_buffer_line(backlash_comp_target, pl_data_backlash);
-        //st_prep_buffer(); //Finish backlash motion rightaway, this is needed to support systemmotions to support backlash. 
     }
     // else {
     //     log_debug("No Backlash compensation..!!");
@@ -96,14 +96,17 @@ bool backlash_Compensate_befor_target(float* target, plan_line_data_t *pl_data){
 
 void backlash_Reset_after_probe() {
     for (int axis = 0; axis < config->_axes->_numberAxis; axis++) {
-        //Since probe ended by system previous direction didnt change
-        backlash_data[axis].prev_target      = steps_to_mpos( motor_steps[axis], axis ); //sys_position[axis] / axis_settings[axis]->steps_per_mm->get();
+        //Assume the probing motion stopped by system and this method gett called before any further motions
+        //no chnage to the prev_direction here .  
+        backlash_data[axis].prev_target      = steps_to_mpos( motor_steps[axis], axis );
     }
     log_debug("BKSL Initi to (" << backlash_data[0].prev_target << ", " <<  backlash_data[1].prev_target <<  ", " << backlash_data[2].prev_target << ") after Probe .." );
 }
 
+//This method should be called atleast by the last homing motion, so that it can keep trck of direction chnages.
+//Assuming approach is approaching the limit switch and if homing is configured for the given axis, 
+//this method will initialize the baclash setting properly.
 void backlash_Reset_for_homing(bool approach, uint8_t homing_mask) {
-    //backlash_Reset(); //For now. But we know what exactly happened in homing so we can set proper values
     for (int axis = 0; axis < config->_axes->_numberAxis; axis++) {
         if(config->_axes->_axis[axis]->_homing != nullptr ){
             if (bitnum_is_true(homing_mask, axis)) {
@@ -125,6 +128,7 @@ void backlash_Reset_for_homing(bool approach, uint8_t homing_mask) {
 }
 
 //When ever the mechine origin is reset (homing) bcklash also need to reset
+//Defunct
 void backlash_Reset() {
     log_debug( "Reset Backlash..!!");
     for (int i = 0; i < config->_axes->_numberAxis; i++) {
@@ -133,35 +137,28 @@ void backlash_Reset() {
     }
 }
 
+//Defunct
 void backlash_Reset_after_homecycle() {
-    //backlash_Reset(); //For now. But we know what exactly happened in homing so we can set proper values
-    //grbl_msg_sendf(CLIENT_ALL, MsgLevel::Info, "Reset Backlash for homing!!");
-    for (int axis = 0; axis < config->_axes->_numberAxis; axis++) { //config->_axes->_axis[axis]->_backlash
+    for (int axis = 0; axis < config->_axes->_numberAxis; axis++) {
         if(config->_axes->_axis[axis]->_homing != nullptr ){
-            if(motor_steps[axis]  > config->_axes->_axis[axis]->_homing->_mpos) //axis_settings[axis]->home_mpos->get()
+            if(motor_steps[axis]  > config->_axes->_axis[axis]->_homing->_mpos)
                 backlash_data[axis].prev_direction   =  MotionDirection::Positive;
             else if(motor_steps[axis]  < config->_axes->_axis[axis]->_homing->_mpos)
                 backlash_data[axis].prev_direction   =  MotionDirection::Negative;
             else
                 backlash_data[axis].prev_direction   =  MotionDirection::Nutral;
-            backlash_data[axis].prev_target      = steps_to_mpos( motor_steps[axis], axis ); //sys_position[axis] / axis_settings[axis]->steps_per_mm->get();
+            backlash_data[axis].prev_target      = steps_to_mpos( motor_steps[axis], axis );
         }
         log_debug("BKSL Init to ("<< backlash_data[0].prev_target << ", " << backlash_data[1].prev_target << ", " << backlash_data[2].prev_target << ") after homing!! " );
     }
 }
 
+//Defunct
 void backlash_Reset_systemMotion(int32_t* sys_pos) {
-    //backlash_Reset(); //For now. But we know what exactly happened in homing so we can set proper values
     log_debug( "Reset Backlash for homing!!");
     for (int axis = 0; axis < config->_axes->_numberAxis; axis++) {
-        // if(sys_position[axis]  > axis_settings[axis]->home_mpos->get())
-        //     backlash_data[axis].prev_direction   =  MotionDirection::Positive;
-        // else if(sys_position[axis]  < axis_settings[axis]->home_mpos->get())
-        //     backlash_data[axis].prev_direction   =  MotionDirection::Negative;
-        // else
-        //     backlash_data[axis].prev_direction   =  MotionDirection::Nutral;
         backlash_data[axis].prev_direction     = (sys_pos[axis]> 0 ) ? MotionDirection::Positive : MotionDirection::Negative;
-        backlash_data[axis].prev_target        = steps_to_mpos(sys_pos[axis], axis); //sys_pos[axis] / axis_settings[axis]->steps_per_mm->get();
+        backlash_data[axis].prev_target        = steps_to_mpos(sys_pos[axis], axis);
     }
     log_debug("BKSL Sys init (" << sys_pos[0] <<", " << sys_pos[1] << ", " << sys_pos[2] << ") . ");
 }

--- a/FluidNC/src/Backlash.cpp
+++ b/FluidNC/src/Backlash.cpp
@@ -1,0 +1,167 @@
+
+/**
+ * Created by Nandana Perera
+ * Git: nxPerera
+ */
+
+#include "Backlash.h"
+#include "NutsBolts.h"
+#include "Config.h"                 // MAX_N_AXIS
+#include "Machine/MachineConfig.h"  // config#include "Machine/MachineConfig.h"  // config
+
+backlash_data_t backlash_data[MAX_N_AXIS];  
+
+void backlash_ini() {   
+    for (int i = 0; i < config->_axes->_numberAxis; i++) {
+        memset(&backlash_data[i], 0, sizeof(backlash_data_t));  // Clear planner struct
+        backlash_data[i].backlash_enable    = true;
+        backlash_data[i].prev_direction     = MotionDirection::Nutral; //DIR_NEUTRAL;
+        backlash_data[i].prev_target        = 0.000;
+    }
+}
+
+bool backlash_Compensate_befor_target(float* target, plan_line_data_t *pl_data){
+    // Initialize planner data struct forbacklash motion blocks.
+    plan_line_data_t  plan_data_backlash;
+    plan_line_data_t* pl_data_backlash = &plan_data_backlash;
+    memcpy(pl_data_backlash, pl_data, sizeof(plan_line_data_t)); 
+
+    bool backlash_comp_needed = false;
+
+    //pl_data_backlash->is_backlash_motion = true;  
+    //the backlash correction is hidden from any future GRBL or gcode calculations, 
+    //in effect it is almost like a hardware correction which is not visible to software. 
+    pl_data_backlash->motion.backlashMotion = 1;
+
+    if(pl_data_backlash->motion.systemMotion == 1){
+        log_debug("BS_CHK DBUG: Backlash correction for a systemMotion!!");
+    }
+    //log_debug("BS_CHK DBUG: pl_data= "<< pl_data->motion.backlashMotion << "vs pl_data_backlash= "<< pl_data_backlash->motion.backlashMotion << " " );
+
+    float backlash_comp_target[config->_axes->_numberAxis] ={0.0}; //comensated position to move based on mechine backlash before starting to move to target
+    for (int axis = 0; axis < config->_axes->_numberAxis; axis++) {
+        // if(axis <3)
+        //     log_debug("BS_CHK Axis: " << axis<< " TGT(" <<  target[axis]<<  "), PRV_TGT( " << backlash_data[axis].prev_target<< ")");
+
+        if(target[axis] > backlash_data[axis].prev_target){ //Current move positive
+            if(backlash_data[axis].prev_direction == MotionDirection::Negative ){ //Previous move negative, so we need to comp backlash 
+                backlash_data[axis].backlash_enable = true;
+                if( config->_axes->_axis[axis]->_backlash > 0 ){
+                    backlash_comp_needed = true;
+                }
+            }
+            else
+                backlash_data[axis].backlash_enable = false;
+
+            backlash_data[axis].prev_direction = MotionDirection::Positive;
+        }
+        else if(target[axis] < backlash_data[axis].prev_target){ //Current move negative
+            if(backlash_data[axis].prev_direction == MotionDirection::Positive  ){
+                backlash_data[axis].backlash_enable = true;
+                if(config->_axes->_axis[axis]->_backlash > 0 ){
+                    backlash_comp_needed = true;
+                }
+            }
+            else
+                backlash_data[axis].backlash_enable = false;
+
+            backlash_data[axis].prev_direction = MotionDirection::Negative;
+        }
+        else
+            backlash_data[axis].backlash_enable = false;
+
+        if(backlash_data[axis].backlash_enable){
+            if(backlash_data[axis].prev_direction == MotionDirection::Positive)
+                backlash_comp_target[axis]  = backlash_data[axis].prev_target + config->_axes->_axis[axis]->_backlash;
+            else
+                backlash_comp_target[axis]  = backlash_data[axis].prev_target - config->_axes->_axis[axis]->_backlash;
+        }
+        else
+            backlash_comp_target[axis]  = backlash_data[axis].prev_target ;
+
+        backlash_data[axis].prev_target = target[axis];
+    }
+
+    if(backlash_comp_needed){
+        log_debug( "BS_COMP (" << backlash_comp_target[0] << " ," << backlash_comp_target[1] << " ," << backlash_comp_target[2]<< " )!!");
+        //mc_line(backlash_comp_target, pl_data_backlash);
+        plan_buffer_line(backlash_comp_target, pl_data_backlash);
+        //st_prep_buffer(); //Finish backlash motion rightaway, this is needed to support systemmotions to support backlash. 
+    }
+    // else {
+    //     log_debug("No Backlash compensation..!!");
+    // }
+    return true;
+}
+
+void backlash_Reset_after_probe() {
+    for (int axis = 0; axis < config->_axes->_numberAxis; axis++) {
+        //Since probe ended by system previous direction didnt change
+        backlash_data[axis].prev_target      = steps_to_mpos( motor_steps[axis], axis ); //sys_position[axis] / axis_settings[axis]->steps_per_mm->get();
+    }
+    log_debug("BKSL Initi to (" << backlash_data[0].prev_target << ", " <<  backlash_data[1].prev_target <<  ", " << backlash_data[2].prev_target << ") after Probe .." );
+}
+
+void backlash_Reset_for_homing(bool approach, uint8_t homing_mask) {
+    //backlash_Reset(); //For now. But we know what exactly happened in homing so we can set proper values
+    for (int axis = 0; axis < config->_axes->_numberAxis; axis++) {
+        if(config->_axes->_axis[axis]->_homing != nullptr ){
+            if (bitnum_is_true(homing_mask, axis)) {
+                float t_pos = steps_to_mpos( motor_steps[axis], axis ); /// axis_settings[axis]->steps_per_mm->get();
+                if(t_pos != backlash_data[axis].prev_target){
+                    if(approach){
+                        backlash_data[axis].prev_direction   = !config->_axes->_axis[axis]->_homing->_positiveDirection ? MotionDirection::Negative : MotionDirection::Positive;
+                    }
+                    else {
+                        backlash_data[axis].prev_direction   =  !config->_axes->_axis[axis]->_homing->_positiveDirection ? MotionDirection::Positive : MotionDirection::Negative ;
+                    }
+                    backlash_data[axis].prev_target    = t_pos;
+                }
+                log_debug("BKSL Init axis " << axis << "  to [" << backlash_data[axis].prev_target << ", " << static_cast<int8_t>(backlash_data[axis].prev_direction)  << "] on approaching " << approach << "  for homing " );
+            }
+        }
+    }
+    //grbl_msg_sendf ( CLIENT_ALL, MsgLevel::Info, "BKSL Initi to (%3.3f, %3.3f, %3.3f) after homing!! ", backlash_data[0].prev_target, backlash_data[1].prev_target, backlash_data[2].prev_target );
+}
+
+//When ever the mechine origin is reset (homing) bcklash also need to reset
+void backlash_Reset() {
+    log_debug( "Reset Backlash..!!");
+    for (int i = 0; i < config->_axes->_numberAxis; i++) {
+        backlash_data[i].prev_direction     = MotionDirection::Nutral; 
+        backlash_data[i].prev_target        = 0.000;
+    }
+}
+
+void backlash_Reset_after_homecycle() {
+    //backlash_Reset(); //For now. But we know what exactly happened in homing so we can set proper values
+    //grbl_msg_sendf(CLIENT_ALL, MsgLevel::Info, "Reset Backlash for homing!!");
+    for (int axis = 0; axis < config->_axes->_numberAxis; axis++) { //config->_axes->_axis[axis]->_backlash
+        if(config->_axes->_axis[axis]->_homing != nullptr ){
+            if(motor_steps[axis]  > config->_axes->_axis[axis]->_homing->_mpos) //axis_settings[axis]->home_mpos->get()
+                backlash_data[axis].prev_direction   =  MotionDirection::Positive;
+            else if(motor_steps[axis]  < config->_axes->_axis[axis]->_homing->_mpos)
+                backlash_data[axis].prev_direction   =  MotionDirection::Negative;
+            else
+                backlash_data[axis].prev_direction   =  MotionDirection::Nutral;
+            backlash_data[axis].prev_target      = steps_to_mpos( motor_steps[axis], axis ); //sys_position[axis] / axis_settings[axis]->steps_per_mm->get();
+        }
+        log_debug("BKSL Init to ("<< backlash_data[0].prev_target << ", " << backlash_data[1].prev_target << ", " << backlash_data[2].prev_target << ") after homing!! " );
+    }
+}
+
+void backlash_Reset_systemMotion(int32_t* sys_pos) {
+    //backlash_Reset(); //For now. But we know what exactly happened in homing so we can set proper values
+    log_debug( "Reset Backlash for homing!!");
+    for (int axis = 0; axis < config->_axes->_numberAxis; axis++) {
+        // if(sys_position[axis]  > axis_settings[axis]->home_mpos->get())
+        //     backlash_data[axis].prev_direction   =  MotionDirection::Positive;
+        // else if(sys_position[axis]  < axis_settings[axis]->home_mpos->get())
+        //     backlash_data[axis].prev_direction   =  MotionDirection::Negative;
+        // else
+        //     backlash_data[axis].prev_direction   =  MotionDirection::Nutral;
+        backlash_data[axis].prev_direction     = (sys_pos[axis]> 0 ) ? MotionDirection::Positive : MotionDirection::Negative;
+        backlash_data[axis].prev_target        = steps_to_mpos(sys_pos[axis], axis); //sys_pos[axis] / axis_settings[axis]->steps_per_mm->get();
+    }
+    log_debug("BKSL Sys init (" << sys_pos[0] <<", " << sys_pos[1] << ", " << sys_pos[2] << ") . ");
+}

--- a/FluidNC/src/Backlash.h
+++ b/FluidNC/src/Backlash.h
@@ -1,0 +1,32 @@
+#pragma once
+
+/**
+ * Created by Nandana Perera
+ * Git: nxPerera
+ */
+
+
+#include <cstdint>
+#include "Planner.h"
+
+enum class MotionDirection : int8_t {
+    Nutral      =  0,     // Not sure what happened before :)
+    Positive    =  1,     // moved cordinate value increasing direction 
+    Negative    = -1,     // moved cordinate value decreasing direction
+};
+
+typedef struct {
+    float           prev_target;
+    MotionDirection prev_direction;
+    uint8_t         backlash_enable;
+} backlash_data_t;
+
+extern backlash_data_t backlash_data[MAX_N_AXIS];  
+void backlash_ini();
+void backlash_Reset();
+void backlash_Reset_after_probe();
+void backlash_Reset_after_homecycle();
+void backlash_Reset_systemMotion(int32_t* sys_pos);
+void backlash_Reset_for_homing(bool approach, uint8_t homing_mask);
+bool backlash_Compensate_befor_target(float* target, plan_line_data_t *pl_data);
+

--- a/FluidNC/src/Machine/Axis.cpp
+++ b/FluidNC/src/Machine/Axis.cpp
@@ -11,6 +11,7 @@ namespace Machine {
         handler.item("acceleration", _acceleration);
         handler.item("max_travel", _maxTravel);
         handler.item("soft_limits", _softLimits);
+        handler.item("backlash", _backlash);
         handler.section("homing", _homing);
 
         char tmp[7];

--- a/FluidNC/src/Machine/Axis.h
+++ b/FluidNC/src/Machine/Axis.h
@@ -34,6 +34,7 @@ namespace Machine {
         float _acceleration = 25.0f;
         float _maxTravel    = 200.0f;
         bool  _softLimits   = false;
+        float _backlash     = 0.0f;
 
         // Configuration system helpers:
         void group(Configuration::HandlerBase& handler) override;

--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -137,6 +137,7 @@ namespace Machine {
             return;
         }
 
+        MotorMask movingMoters = remainingMotors;
         uint32_t settling_ms = plan_move(remainingMotors, approach, seek, customPulloff);
 
         config->_axes->lock_motors(0xffffffff);
@@ -184,6 +185,7 @@ namespace Machine {
 
         Stepper::reset();       // Immediately force kill steppers and reset step segment buffer.
         delay_ms(settling_ms);  // Delay to allow transient dynamics to dissipate.
+        backlash_Reset_for_homing(approach, movingMoters);
     }
 
     // This homing mode is the POG style squaring

--- a/FluidNC/src/Machine/MachineConfig.h
+++ b/FluidNC/src/Machine/MachineConfig.h
@@ -18,6 +18,7 @@
 #include "../Stepper.h"
 #include "../Logging.h"
 #include "../Config.h"
+#include "../Backlash.h"
 #include "Axes.h"
 #include "SPIBus.h"
 #include "I2SOBus.h"

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -13,6 +13,7 @@
 #include "Planner.h"         // plan_reset, etc
 #include "I2SOut.h"          // i2s_out_reset
 #include "Platform.h"        // WEAK_LINK
+#include "Backlash.h"
 
 // M_PI is not defined in standard C/C++ but some compilers
 // support it anyway.  The following suppresses Intellisense
@@ -285,6 +286,7 @@ void mc_homing_cycle(AxisMask axis_mask) {
     // Sync gcode parser and planner positions to homed position.
     gc_sync_position();
     plan_sync_position();
+    //backlash_Reset_after_homecycle();
     // This give kinematics a chance to do something after normal homing
     kinematics_post_homing();
 }
@@ -354,6 +356,7 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, uint8_t par
         probe_succeeded = true;  // Indicate to system the probing cycle completed successfully.
     }
     probeState = ProbeState::Off;  // Ensure probe state monitor is disabled.
+    backlash_Reset_after_probe();
     protocol_execute_realtime();   // Check and execute run-time commands
     // Reset the stepper and planner buffers to remove the remainder of the probe motion.
     Stepper::reset();      // Reset step segment buffer.

--- a/FluidNC/src/Planner.h
+++ b/FluidNC/src/Planner.h
@@ -24,6 +24,7 @@ struct PlMotion {
     uint8_t systemMotion : 1;    // Single motion. Circumvents planner state. Used by home/park.
     uint8_t noFeedOverride : 1;  // Motion does not honor feed override.
     uint8_t inverseTime : 1;     // Interprets feed rate value as inverse time when set.
+    uint8_t backlashMotion : 1;  // used for Backlash correction motions.
 };
 
 // This struct stores a linear movement of a g-code block motion with its critical "nominal" values

--- a/FluidNC/src/Stepper.cpp
+++ b/FluidNC/src/Stepper.cpp
@@ -239,7 +239,7 @@ void IRAM_ATTR Stepper::pulse_func() {
         if (st.counter[axis] > st.exec_block->step_event_count) {
             set_bitnum(st.step_outbits, axis);
             st.counter[axis] -= st.exec_block->step_event_count;
-            //Do not chnage the motor_steps for backlash steps so that backlash motion is hidden for the rest of the motions
+            //Skip syncing motor_steps for backlash motion steps so that the backlash motion is hidden for the rest of the cnc motions
             //TODO: verify if this will  messup the Bresenham line algorithm.
             if(!st.exec_block->is_backlash_motion){ 
                 if (bitnum_is_true(st.exec_block->direction_bits, axis)) {

--- a/FluidNC/src/Stepper.cpp
+++ b/FluidNC/src/Stepper.cpp
@@ -239,12 +239,12 @@ void IRAM_ATTR Stepper::pulse_func() {
         if (st.counter[axis] > st.exec_block->step_event_count) {
             set_bitnum(st.step_outbits, axis);
             st.counter[axis] -= st.exec_block->step_event_count;
-            if (bitnum_is_true(st.exec_block->direction_bits, axis)) {
-                if(!st.exec_block->is_backlash_motion){ //Do not chnage the sysposition on backlash steps
+            //Do not chnage the motor_steps for backlash steps so that backlash motion is hidden for the rest of the motions
+            //TODO: verify if this will  messup the Bresenham line algorithm.
+            if(!st.exec_block->is_backlash_motion){ 
+                if (bitnum_is_true(st.exec_block->direction_bits, axis)) {
                     motor_steps[axis]--;
-                }
-            } else {
-                if(!st.exec_block->is_backlash_motion){ //Do not chnage the sysposition on backlash steps
+                } else {
                     motor_steps[axis]++;
                 }
             }


### PR DESCRIPTION
This change will create intermediate (secret) plan_buffer_line() call when a backlash correction is required for a given  motion and this correction motion is supposed to be hidden from the system as much as possible (this is achieved by skipping the motor_steps increment/decrement at  Stepper::pulse_func() method for backlash steps). I have considered the risk of messing up  Bresenham line algorithm by this skipping steps. Even if that's the case it is localized only to the backlash motion. 
In order to define a backlash correction use /Axes/<x,y,z,a,..>/backlash=<correction_value> in config.yaml . Apart from system motions backlash correction is applied to all the cnc motions when defined it in the configuration.  This implementation tracks the motion changes while probing and homing. Backlash correction is applied to probe moves.  