### PR TITLE
changing permission of esptool executables in install scripts

### DIFF
--- a/install_scripts/install-linux.sh
+++ b/install_scripts/install-linux.sh
@@ -2,6 +2,8 @@
 
 EsptoolPath=../linux-amd64/esptool
 
+if [ ! -x "$EsptoolPath" ]; then chmod +x "$EsptoolPath"; fi
+
 SetupArgs="--chip esp32 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size detect"
 
 Bootloader="0x1000 ../common/bootloader_dio_80m.bin"

--- a/install_scripts/install-macos.sh
+++ b/install_scripts/install-macos.sh
@@ -2,6 +2,8 @@
 
 EsptoolPath=../macos/esptool
 
+if [ ! -x "$EsptoolPath" ]; then chmod +x "$EsptoolPath"; fi
+
 SetupArgs="--chip esp32 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size detect"
 
 Bootloader="0x1000 ../common/bootloader_dio_80m.bin"

--- a/install_scripts/install-win.bat
+++ b/install_scripts/install-win.bat
@@ -2,6 +2,8 @@
 
 set EsptoolPath=..\win64\esptool.exe
 
+icacls %esptoolpath% /grant *S-1-1-0:(x)
+
 set SetupArgs=--chip esp32 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size detect
 
 set Bootloader=0x1000 ..\common\bootloader_dio_80m.bin


### PR DESCRIPTION
This is a solution that works (tested on MacOS) to resolve the problem of not being able to execute the esptool that gets downloaded during installation.

It might not be the way you prefer to go, doing it in build-release.py instead, but I'm not familiar enough with python to do it.

Also note the addition to the batch file isn't tested, and may have incorrect syntax. Was my best effort given I know nothing about scripting a batch file!