### PR TITLE
Set the limits for unhomed systems to be symmetric around the origin.

### DIFF
--- a/FluidNC/src/Motors/RcServo.cpp
+++ b/FluidNC/src/Motors/RcServo.cpp
@@ -125,8 +125,6 @@ namespace MotorDrivers {
         //log_info("su " << servo_pulse_len);
 
         _write_pwm(servo_pulse_len);
-
-        log_info("Servo: mpos=" << mpos << " servo_pulse_len=" << servo_pulse_len);
     }
 
     void RcServo::read_settings() {


### PR DESCRIPTION
Currently axes without homing are assumed, for the purposes of setting limits, to have homed so that the origin is at the extreme positive position.

This means that unhomed motors, like RcServos, end up with max_travel = 100 translating into a range of -100 to 0, which is mildly astonishing.

This change makes it so that unhomed systems are assumed to have homed in the central position, so that max_travel 100 implies a range of -50 to 50.

This means that an RcServo on the Z axis would be centered at Z0.

Closes #66