### PR TITLE
Update reference to isr_count

### DIFF
--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -661,7 +661,7 @@ void report_realtime_status(Print& client) {
         client << "|SD:" << config->_sdCard->percent_complete() << "," << config->_sdCard->filename();
     }
 #ifdef DEBUG_STEPPER_ISR
-    client << "|ISRs:" << Stepper::isr_count;
+    client << "|ISRs:" << config->_stepping->isr_count;
 #endif
 #ifdef DEBUG_REPORT_HEAP
     client << "|Heap:" << esp.getHeapSize();


### PR DESCRIPTION
isr_count seems to have moved, which breaks Report.cpp when DEBUG_STEPPER_ISR is defined.

This updates the reference to the new location, restoring functionality.