### PR TITLE
one liner - add name of offending pin to critical error message

### DIFF
--- a/FluidNC/src/Pin.h
+++ b/FluidNC/src/Pin.h
@@ -103,7 +103,7 @@ public:
     // External libraries normally use digitalWrite, digitalRead and setMode. Since we cannot handle that behavior, we
     // just give back the pinnum_t for getNative.
     inline pinnum_t getNative(Capabilities expectedBehavior) const {
-        Assert(_detail->capabilities().has(expectedBehavior), "Requested pin does not have the expected behavior.");
+        Assert(_detail->capabilities().has(expectedBehavior), "Requested pin %s does not have the expected behavior.",name().c_str());
         return _detail->_index;
     }
 


### PR DESCRIPTION
Hey there all,

This is a simple change to show WHICH pin has thrown the exception, helpful in debugging yaml files.

- Patrick
- 