### PR TITLE
HttpPrintService

### DIFF
--- a/FluidNC/src/Config.h
+++ b/FluidNC/src/Config.h
@@ -227,3 +227,6 @@ const double PARKING_PULLOUT_INCREMENT = 5.0;    // Spindle pull-out and plunge 
 
 // INCLUDE_OLED_BASIC includes a driver for a modest sized OLED display
 // #define INCLUDE_OLED_BASIC
+
+// INCLUDE_HTTP_PRINT_SERVICE to enable a service to which gcode can be posted.
+#define INCLUDE_HTTP_PRINT_SERVICE

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -43,6 +43,7 @@ namespace Machine {
         handler.section("probe", _probe);
         handler.section("macros", _macros);
         handler.section("start", _start);
+        handler.section("network", _network);
 
         handler.section("user_outputs", _userOutputs);
         // TODO: Consider putting these under a gcode: hierarchy level? Or motion control?

--- a/FluidNC/src/Machine/MachineConfig.h
+++ b/FluidNC/src/Machine/MachineConfig.h
@@ -17,6 +17,7 @@
 #include "../Stepping.h"
 #include "../Stepper.h"
 #include "../Logging.h"
+#include "../Network/Network.h"
 #include "../Config.h"
 #include "Axes.h"
 #include "SPIBus.h"
@@ -63,6 +64,7 @@ namespace Machine {
         SDCard*         _sdCard      = nullptr;
         Macros*         _macros      = nullptr;
         Start*          _start       = nullptr;
+        Network*        _network     = nullptr;
 
         Spindles::SpindleList _spindles;
 

--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -83,6 +83,10 @@ void setup() {
 
             config->_control->init();
 
+            if (config->_network) {
+                config->_network->init();
+            }
+
             memset(motor_steps, 0, sizeof(motor_steps));  // Clear machine position.
 
             machine_init();  // user supplied function for special initialization

--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -83,10 +83,6 @@ void setup() {
 
             config->_control->init();
 
-            if (config->_network) {
-                config->_network->init();
-            }
-
             memset(motor_steps, 0, sizeof(motor_steps));  // Clear machine position.
 
             machine_init();  // user supplied function for special initialization
@@ -133,6 +129,11 @@ void setup() {
         register_client(&WebUI::SerialBT);
 #endif
         WebUI::inputBuffer.begin();
+
+        // Do this after wifi gets a chance to start.
+        if (config->_network) {
+            config->_network->init();
+        }
     } catch (const AssertionFailed& ex) {
         // This means something is terribly broken:
         log_error("Critical error in main_init: " << ex.what());

--- a/FluidNC/src/Network/HttpPrintClient.cpp
+++ b/FluidNC/src/Network/HttpPrintClient.cpp
@@ -1,6 +1,27 @@
 #include "../Config.h"
 
-#include "HttpPrintServer.h"
+#ifdef INCLUDE_HTTP_PRINT_SERVICE
+
+#    include <lwip/sockets.h>
+
+// A workaround for an issue in lwip/sockets.h
+// See https://github.com/espressif/arduino-esp32/issues/4073
+#    undef IPADDR_NONE
+
+#    include "HttpPrintServer.h"
+
+// We expect input like so:
+//
+// POST /test HTTP/1.1
+// Host: foo.example
+// Content-Type: application/x-www-form-urlencoded
+// Content-Length: 7
+//
+// G0 Z1
+//
+// We ignore the header except for Content-Length.
+
+#    define RETRY -1
 
 namespace {
     const char* _state_name[4] = {
@@ -10,22 +31,27 @@ namespace {
         "ABORTED",
     };
 
-    const char content_length[] = "Content_length:";
+    const char content_length[] = "Content-Length:";
+
     const char header_delimiter[] = "\r\n";
+
+    // The print completed successfully.
+    const char ok_200[] = "HTTP/1.1 200 OK\r\n"
+                          "Content-Length: 0\r\n"
+                          "Access-Control-Allow-Origin: *\r\n"
+                          "\r\n";
+
+    // Something went wrong, but the user can correct the problem and try again.
+    const char conflict_207[] = "HTTP/1.1 207 CONFLICT\r\n"
+                                "Content-Length: 0\r\n"
+                                "Access-Control-Allow-Origin: *\r\n"
+                                "\r\n";
 }
 
-HttpPrintClient::HttpPrintClient(WiFiClient wifi_client)
-    : _state(READING_HEADER),
-      _wifi_client(wifi_client),
-      _content_read(0),
-      _content_size(0),
-      _data_read(0),
-      _data_size(0) {
-}
+HttpPrintClient::HttpPrintClient(WiFiClient wifi_client) :
+    _state(READING_HEADER), _wifi_client(wifi_client), _content_read(0), _content_size(0), _data_read(0), _data_size(0) {}
 
-HttpPrintClient::HttpPrintClient()
-    : _state(READING_HEADER) {
-}
+HttpPrintClient::HttpPrintClient() : _state(READING_HEADER) {}
 
 bool HttpPrintClient::is_done() {
     return _state == FINISHED || _state == ABORTED;
@@ -37,39 +63,50 @@ bool HttpPrintClient::is_aborted() {
 
 void HttpPrintClient::set_state(State state) {
     if (_state != state) {
+        // Show the state changes so we can see what's happening via other
+        // clients.
         log_info("HttpPrintClient: " << _state_name[state]);
         _state = state;
+
+        switch (_state) {
+            case READING_HEADER:
+            case READING_DATA:
+                break;
+            case FINISHED: {
+                size_t nw = _wifi_client.write(ok_200, sizeof ok_200 - 1);
+                log_info("nw= " << String(nw));
+                shutdown(_wifi_client.fd(), SHUT_RDWR);
+                break;
+            }
+            case ABORTED: {
+                size_t nw = _wifi_client.write(conflict_207, sizeof conflict_207 - 1);
+                log_info("nw= " << String(nw));
+                shutdown(_wifi_client.fd(), SHUT_RDWR);
+                break;
+            }
+        }
     }
 }
 
 // This is sufficient to drive the client due to how pollClients() just calls
 // read().
 int HttpPrintClient::read() {
-    if (_wifi_client.available() == 0) {
-        if (!_wifi_client.connected()) {
-            // There is nothing to read and we are not connected.
-            _wifi_client.stop();
-            set_state(ABORTED);
-        }
-        return -1;
-    }
     // We need to read the Content-length since we can't detect a half-closed socket.
     switch (_state) {
+        case FINISHED:
+        case ABORTED:
+            return RETRY;
         case READING_HEADER: {
-            // POST /test HTTP/1.1
-            // Host: foo.example
-            // Content-Type: application/x-www-form-urlencoded
-            // Content-Length: 27
-
-            if (_data_size == sizeof _data) {
+            if (is_data_exhausted()) {
                 // The header line was too long, throw away the start.
-                _data_size = 0;
+                reset_data();
             }
 
             int code = _wifi_client.read();
-            if (code == -1) {
-                return -1;
+            if (code == RETRY) {
+                return code;
             }
+
             _data[_data_size++] = code;
 
             if (code == '\n') {
@@ -81,42 +118,38 @@ int HttpPrintClient::read() {
                     // An empty line to terminate the header.
                     set_state(READING_DATA);
                 }
-                _data_size = 0;
+                reset_data();
             }
-            return -1;
+            return RETRY;
         }
         case READING_DATA: {
             int code = peek();
-            if (code != -1) {
+            if (code != RETRY) {
                 _data_read++;
                 _content_read++;
-                if (_content_read == _content_size) {
+                if (is_content_exhausted()) {
                     set_state(FINISHED);
                 }
             }
             return code;
         }
-        case FINISHED:
-            return -1;
-        case ABORTED:
-            return -1;
     }
     // Unreachable
-    return -1;
+    return RETRY;
 }
 
 int HttpPrintClient::peek() {
     if (_state != READING_DATA) {
-        return -1;
+        return RETRY;
     }
-    if (_data_read == _data_size) {
+    if (is_data_exhausted()) {
         if (!_wifi_client.available()) {
             if (!_wifi_client.connected()) {
                 // There is nothing to read and we are not connected.
                 _wifi_client.stop();
                 set_state(ABORTED);
             }
-            return -1;
+            return RETRY;
         }
         _data_read = 0;
         _data_size = _wifi_client.readBytes(_data, sizeof _data);
@@ -125,19 +158,21 @@ int HttpPrintClient::peek() {
 }
 
 void HttpPrintClient::flush() {
-  if (_state != READING_DATA) {
-      return;
-  }
-  _wifi_client.flush();
+    if (_state != READING_DATA) {
+        return;
+    }
+    _wifi_client.flush();
 }
 
 int HttpPrintClient::available() {
-  if (_state != READING_DATA) {
-      return 0;
-  }
-  return _wifi_client.available();
+    if (_state != READING_DATA) {
+        return 0;
+    }
+    return _wifi_client.available();
 }
 
 size_t HttpPrintClient::write(uint8_t) {
-  return 0;
+    return 0;
 }
+
+#endif  // INCLUDE_HTTP_PRINT_SERVICE

--- a/FluidNC/src/Network/HttpPrintClient.cpp
+++ b/FluidNC/src/Network/HttpPrintClient.cpp
@@ -50,7 +50,7 @@ namespace {
 }
 
 HttpPrintClient::HttpPrintClient(WiFiClient wifi_client) :
-    _state(READING_HEADER), _wifi_client(wifi_client), _content_read(0), _content_size(0), _data_read(0), _data_size(0) {}
+    _state(READING_HEADER), _wifi_client(wifi_client), _content_read(0), _content_size(0), _data_read(0), _data_size(0), _aborted(false) {}
 
 HttpPrintClient::HttpPrintClient() : _state(READING_HEADER) {}
 

--- a/FluidNC/src/Network/HttpPrintClient.cpp
+++ b/FluidNC/src/Network/HttpPrintClient.cpp
@@ -1,0 +1,95 @@
+#include "../Config.h"
+
+#include "HttpPrintServer.h"
+
+// Opens a connection and then ignores a header terminated by \r\n\r\n.
+// The remainder of the data is output via single character read().
+// isFinished() indicates that the client is closed and exhausted.
+
+HttpPrintClient::HttpPrintClient(WiFiClient wifi_client)
+    : _state(READING_HEADER),
+      _wifi_client(wifi_client) {
+}
+
+HttpPrintClient::HttpPrintClient()
+    : _state(DISCONNECTED) {
+}
+
+bool HttpPrintClient::isFinished() {
+    return _state == DISCONNECTED;
+}
+
+// This is sufficient to drive the client due to how pollClients() just calls
+// read().
+int HttpPrintClient::read() {
+    log_info("HttpPrintClient state=" << _state);
+    if (_wifi_client.available() == 0) {
+        if (!_wifi_client.connected()) {
+            // There is nothing to read and we are not connected.
+            _wifi_client.stop();
+            _state = DISCONNECTED;
+        }
+        return -1;
+    }
+    switch (_state) {
+    case READING_HEADER:
+        if (_wifi_client.read() == '\r') {
+            _state = READING_HEADER_1;
+        } else {
+            _state = READING_HEADER;
+        }
+        return -1;
+    case READING_HEADER_1:  // we have read \r
+        if (_wifi_client.read() == '\n') {
+            _state = READING_HEADER_2;
+        } else {
+            _state = READING_HEADER;
+        }
+        return -1;
+    case READING_HEADER_2: // we have read \r\n
+        if (_wifi_client.read() == '\r') {
+            _state = READING_HEADER_3;
+        } else {
+            _state = READING_HEADER;
+        }
+        return -1;
+    case READING_HEADER_3: // we have read \r\n\r
+        if (_wifi_client.read() == '\n') {
+            _state = READING_DATA;
+        } else {
+            _state = READING_HEADER;
+        }
+        return -1;
+    case READING_DATA:
+        return _wifi_client.read();
+    case DISCONNECTED:
+        return -1;
+    }
+    // Unreachable
+    return -1;
+}
+
+int HttpPrintClient::peek() {
+  if (_state != READING_DATA) {
+      return -1;
+  }
+  return _wifi_client.peek();
+}
+
+void HttpPrintClient::flush() {
+  if (_state != READING_DATA) {
+      return;
+  }
+  _wifi_client.flush();
+}
+
+int HttpPrintClient::available() {
+  if (_state != READING_DATA) {
+      return 0;
+  }
+  return _wifi_client.available();
+}
+
+size_t HttpPrintClient::write(uint8_t) {
+  return 0;
+}

--- a/FluidNC/src/Network/HttpPrintClient.cpp
+++ b/FluidNC/src/Network/HttpPrintClient.cpp
@@ -1,125 +1,170 @@
-#include "../Config.h"
+#include <WebServer.h>
 
 #include "HttpPrintServer.h"
+
+#include "../Config.h"
 
 // Opens a connection and then ignores a header terminated by \r\n\r\n.
 // The remainder of the data is output via single character read().
 // isFinished() indicates that the client is closed and exhausted.
 
-HttpPrintClient::HttpPrintClient(WiFiClient wifi_client)
-    : _state(READING_HEADER),
-      _wifi_client(wifi_client) {
+HttpPrintClient::HttpPrintClient(WebServer* web_server)
+    : _state(IDLE),
+      _web_server(web_server),
+      _uploaded_data_read(0),
+      _uploaded_data_size(0) {
 }
 
-HttpPrintClient::HttpPrintClient()
-    : _state(DISCONNECTED) {
-}
-
-bool HttpPrintClient::isFinished() {
-    return _state == DISCONNECTED;
-}
-
-void HttpPrintClient::setState(State state) {
+void HttpPrintClient::set_state(State state) {
     if (_state != state) {
         switch (state) {
-        case READING_HEADER:
-            log_info("HttpPrintClient: READING_HEADER");
-            break;
-        case READING_HEADER_1:
-            log_info("HttpPrintClient: READING_HEADER_1");
-            break;
-        case READING_HEADER_2:
-            log_info("HttpPrintClient: READING_HEADER_2");
-            break;
-        case READING_HEADER_3:
-            log_info("HttpPrintClient: READING_HEADER_3");
-            break;
-        case READING_DATA:
-            log_info("HttpPrintClient: READING_DATA");
-            break;
-        case DISCONNECTED:
-            log_info("HttpPrintClient: DISCONNECTED");
-            break;
-        default:
-            log_info("HttpPrintClient: <Unknown State>");
-            break;
+            case IDLE:
+                log_info("HttpPrintClient: IDLE");
+                break;
+            case PRINTING:
+                log_info("HttpPrintClient: PRINTING");
+                break;
+            case FINISHED:
+                log_info("HttpPrintClient: FINISHED");
+                break;
+            case ABORTED:
+                log_info("HttpPrintClient: ABORTED");
+                break;
+            default:
+                log_info("HttpPrintClient: <Unknown State>");
+                break;
         }
     }
     _state = state;
 }
 
-// This is sufficient to drive the client due to how pollClients() just calls
-// read().
-int HttpPrintClient::read() {
-    if (_wifi_client.available() == 0) {
-        if (!_wifi_client.connected()) {
-            // There is nothing to read and we are not connected.
-            _wifi_client.stop();
-            setState(DISCONNECTED);
-        }
-        return -1;
+bool HttpPrintClient::isDone() {
+    return _state == FINISHED || _state == ABORTED;
+}
+
+bool HttpPrintClient::isAborted() {
+    return _state == ABORTED;
+}
+
+void HttpPrintClient::handle_upload() {
+    HTTPUpload& upload = _web_server->upload();
+    log_info("HttpPrintClient: read=" << _uploaded_data_read << " size=" << _uploaded_data_size);
+    switch (upload.status) {
+        case UPLOAD_FILE_START:
+            log_info("HttpPrintClient: UPLOAD_FILE_START");
+            switch (_state) {
+                case PRINTING:
+                case FINISHING:
+                case FINISHED:
+                case ABORTED:
+                    log_info("HttpPrintClient: UPLOAD_FILE_START while " << _state_name[_state]);
+                    set_state(ABORTED);
+                    break;
+                case IDLE:
+                    set_state(PRINTING);
+                    break;
+            }
+            break;
+        case UPLOAD_FILE_WRITE:
+            log_info("HttpPrintClient: UPLOAD_FILE_WRITE data=" << String((char *)upload.buf).substring(0, 20));
+            switch (_state) {
+                case IDLE:
+                case FINISHING:
+                case FINISHED:
+                case ABORTED:
+                    log_info("HttpPrintClient: UPLOAD_FILE_WRITE while " << _state_name[_state]);
+                    set_state(ABORTED);
+                    break;
+                case PRINTING:
+                    if (_uploaded_data_read != _uploaded_data_size) {
+                        log_info("HttpPrintClient: Received data while buffer not empty.");
+                        set_state(ABORTED);
+                        break;
+                    }
+                    // Unfortunately as soon as we return the upload buffer
+                    // will be invalidated, so we need to stash the data.
+                    //
+                    // If we used WiFiClient directly this could be avoided
+                    // but then we'd need to re-implement all of the upload
+                    // protocol.
+                    memcpy(_uploaded_data, upload.buf, upload.currentSize);
+                    _uploaded_data_read = 0;
+                    _uploaded_data_size = upload.currentSize;
+                    break;
+            }
+            break;
+        case UPLOAD_FILE_END:
+            log_info("HttpPrintClient: UPLOAD_FILE_END");
+            switch (_state) {
+                case IDLE:
+                case FINISHING:
+                case FINISHED:
+                case ABORTED:
+                    log_info("HttpPrintClient: UPLOAD_FILE_END while " << _state_name[_state]);
+                    set_state(ABORTED);
+                    break;
+                case PRINTING:
+                    if (_uploaded_data_read < _uploaded_data_size) {
+                        set_state(FINISHING);
+                    } else {
+                        set_state(FINISHED);
+                    }
+                    break;
+            }
+            break;
+        case UPLOAD_FILE_ABORTED:
+            log_info("HttpPrintClient: UPLOAD_FILE_ABORTED while " << _state_name[_state]);
+            set_state(ABORTED);
+            break;
     }
-    // We need to read the Content-length since we can't detect a half-closed socket.
-    switch (_state) {
-    case READING_HEADER:
-        if (_wifi_client.read() == '\r') {
-            setState(READING_HEADER_1);
-        } else {
-            setState(READING_HEADER);
-        }
-        return -1;
-    case READING_HEADER_1:  // we have read \r
-        if (_wifi_client.read() == '\n') {
-            setState(READING_HEADER_2);
-        } else {
-            setState(READING_HEADER);
-        }
-        return -1;
-    case READING_HEADER_2: // we have read \r\n
-        if (_wifi_client.read() == '\r') {
-            setState(READING_HEADER_3);
-        } else {
-            setState(READING_HEADER);
-        }
-        return -1;
-    case READING_HEADER_3: // we have read \r\n\r
-        if (_wifi_client.read() == '\n') {
-            setState(READING_DATA);
-        } else {
-            setState(READING_HEADER);
-        }
-        return -1;
-    case READING_DATA: {
-        return _wifi_client.read();
-    }
-    case DISCONNECTED:
-        return -1;
-    }
-    // Unreachable
-    return -1;
 }
 
 int HttpPrintClient::peek() {
-  if (_state != READING_DATA) {
-      return -1;
-  }
-  return _wifi_client.peek();
+    HTTPUpload& upload = _web_server->upload();
+    if (_state == PRINTING &&_uploaded_data_read < _uploaded_data_size) {
+        return _uploaded_data[_uploaded_data_read];
+    }
+    // Permit the web server to advance.
+    log_info("HttpPrintClient::peek advance");
+    _web_server->handleClient();
+    // Delegate to the next cycle.
+    return -1;
+}
+
+int HttpPrintClient::read() {
+    int code = peek();
+    if (code != -1) {
+        _uploaded_data_read++;
+        log_info("HttpPrintClient::read read=" << _uploaded_data_read << " size=" << _uploaded_data_size);
+        if (_state == FINISHING && _uploaded_data_read == _uploaded_data_size) {
+            set_state(FINISHED);
+        }
+    }
+    return code;
 }
 
 void HttpPrintClient::flush() {
-  if (_state != READING_DATA) {
-      return;
-  }
-  _wifi_client.flush();
+    // Do nothing.
 }
 
 int HttpPrintClient::available() {
-  if (_state != READING_DATA) {
-      return 0;
-  }
-  return _wifi_client.available();
+    if (_state != PRINTING) {
+        // Permit the web server to advance.
+        log_info("HttpPrintClient::available advance");
+        _web_server->handleClient();
+        return 0;
+    }
+    return _uploaded_data_size - _uploaded_data_read;
 }
 
 size_t HttpPrintClient::write(uint8_t) {
-  return 0;
+    return 0;
 }
+
+const char* HttpPrintClient::_state_name[5] = {
+    "IDLE",
+    "PRINTING",
+    "FINISHING",
+    "FINISHED",
+    "ABORTED",
+};

--- a/FluidNC/src/Network/HttpPrintClient.cpp
+++ b/FluidNC/src/Network/HttpPrintClient.cpp
@@ -59,6 +59,7 @@ int HttpPrintClient::read() {
         }
         return -1;
     }
+    // We need to read the Content-length since we can't detect a half-closed socket.
     switch (_state) {
     case READING_HEADER:
         if (_wifi_client.read() == '\r') {

--- a/FluidNC/src/Network/HttpPrintClient.h
+++ b/FluidNC/src/Network/HttpPrintClient.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <WebServer.h>
+#include <WiFi.h>
 
 #include "../Serial.h"
 
@@ -10,21 +10,19 @@
 
 class HttpPrintClient : public Stream {
     enum State {
-        IDLE,
-        PRINTING,
-        FINISHING,
+        READING_HEADER,
+        READING_DATA,
         FINISHED,
         ABORTED,
     };
 
     public:
-    HttpPrintClient(WebServer* server);
+    HttpPrintClient();
+    HttpPrintClient(WiFiClient wifi_client);
 
-    // Advise of an upload state change.
-    void handle_upload();
-
-    bool isAborted();
-    bool isDone();
+    // All possible data has been read.
+    bool is_done();
+    bool is_aborted();
 
     // Stream interface.
     int read() override;
@@ -37,10 +35,11 @@ class HttpPrintClient : public Stream {
     void set_state(State state);
 
     enum State _state;
-    WebServer* _web_server;  // Not owned.
-    size_t _uploaded_data_read;
-    size_t _uploaded_data_size;
-    uint8_t _uploaded_data[HTTP_UPLOAD_BUFLEN];
+    WiFiClient _wifi_client;
 
-    static const char* _state_name[5];
+    long _content_read;
+    long _content_size;
+    char _data[128];
+    size_t _data_read;
+    size_t _data_size;
 };

--- a/FluidNC/src/Network/HttpPrintClient.h
+++ b/FluidNC/src/Network/HttpPrintClient.h
@@ -1,8 +1,12 @@
 #pragma once
 
-#include <WiFi.h>
+#include "../Config.h"
 
-#include "../Serial.h"
+#ifdef INCLUDE_HTTP_PRINT_SERVICE
+
+#    include <WiFi.h>
+
+#    include "../Serial.h"
 
 // Opens a connection and then ignores a header terminated by \r\n\r\n.
 // The remainder of the data is output via single character read().
@@ -16,7 +20,7 @@ class HttpPrintClient : public Stream {
         ABORTED,
     };
 
-    public:
+public:
     HttpPrintClient();
     HttpPrintClient(WiFiClient wifi_client);
 
@@ -25,21 +29,30 @@ class HttpPrintClient : public Stream {
     bool is_aborted();
 
     // Stream interface.
-    int read() override;
-    int peek() override;
-    void flush() override;
-    int available() override;
+    int    read() override;
+    int    peek() override;
+    void   flush() override;
+    int    available() override;
     size_t write(uint8_t) override;
 
-    private:
+private:
     void set_state(State state);
+
+    inline size_t is_content_exhausted() const { return _content_size == _content_read; }
+    inline size_t is_data_exhausted() const { return _data_size == _data_read; }
+    inline void   reset_data() {
+        _data_read = 0;
+        _data_size = 0;
+    }
 
     enum State _state;
     WiFiClient _wifi_client;
 
-    long _content_read;
-    long _content_size;
-    char _data[128];
+    long   _content_read;
+    long   _content_size;
+    char   _data[128];
     size_t _data_read;
     size_t _data_size;
 };
+
+#endif  // INCLUDE_HTTP_PRINT_SERVICE

--- a/FluidNC/src/Network/HttpPrintClient.h
+++ b/FluidNC/src/Network/HttpPrintClient.h
@@ -16,8 +16,8 @@ class HttpPrintClient : public Stream {
     enum State {
         READING_HEADER,
         READING_DATA,
+        FINISHING,
         FINISHED,
-        ABORTED,
     };
 
 public:
@@ -53,6 +53,7 @@ private:
     char   _data[128];
     size_t _data_read;
     size_t _data_size;
+    bool   _aborted;
 };
 
 #endif  // INCLUDE_HTTP_PRINT_SERVICE

--- a/FluidNC/src/Network/HttpPrintClient.h
+++ b/FluidNC/src/Network/HttpPrintClient.h
@@ -33,6 +33,8 @@ class HttpPrintClient : public Stream {
     size_t write(uint8_t) override;
 
     private:
+    void setState(State state);
+
     enum State _state;
     WiFiClient _wifi_client;
 };

--- a/FluidNC/src/Network/HttpPrintClient.h
+++ b/FluidNC/src/Network/HttpPrintClient.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <WiFi.h>
+
+#include "../Serial.h"
+
+// Opens a connection and then ignores a header terminated by \r\n\r\n.
+// The remainder of the data is output via single character read().
+// isFinished() indicates that the client is closed and exhausted.
+
+class HttpPrintClient : public Stream {
+    enum State {
+        READING_HEADER,
+        READING_HEADER_1, // \r
+        READING_HEADER_2, // \r\n
+        READING_HEADER_3, // \r\n\r
+        READING_DATA,
+        DISCONNECTED,
+    };
+
+    public:
+    HttpPrintClient();
+    HttpPrintClient(WiFiClient wifi_client);
+
+    // All possible data has been read.
+    bool isFinished();
+
+    // Stream interface.
+    int read() override;
+    int peek() override;
+    void flush() override;
+    int available() override;
+    size_t write(uint8_t) override;
+
+    private:
+    enum State _state;
+    WiFiClient _wifi_client;
+};

--- a/FluidNC/src/Network/HttpPrintServer.cpp
+++ b/FluidNC/src/Network/HttpPrintServer.cpp
@@ -1,0 +1,89 @@
+#include "../Config.h"
+#include "../Settings.h"
+
+#include "HttpPrintServer.h"
+
+HttpPrintServer::HttpPrintServer()
+    : _state(STOPPED),
+      _port(-1) {
+}
+
+bool HttpPrintServer::begin() {
+    if (_state != UNSTARTED) {
+        return false;
+    }
+    _server = WiFiServer(_port);
+    _server.begin();
+    _state = IDLE;
+    return true;
+}
+
+void HttpPrintServer::stop() {
+    if (_state == STOPPED) {
+        return;
+    }
+    _server.stop();
+    _state = STOPPED;
+}
+
+void HttpPrintServer::handle() {
+    switch (_state) {
+    case UNSTARTED:
+        return;
+    case IDLE:
+        if (_server.hasClient()) {
+            _client = HttpPrintClient(_server.available());
+            _state = PRINTING;
+            _input_client = register_client(&_client);
+        }
+        return;
+    case PRINTING:
+        if (_client.isFinished()) {
+            unregister_client(_input_client);
+            delete _input_client;
+            _input_client = nullptr;
+            _state = IDLE;
+        }
+        return;
+    case STOPPED:
+        return;
+    }
+}
+
+void HttpPrintServer::init() {
+    log_info("HttpPrintServer init");
+    // Without a yaml configuration this will default to -1 which will disable the server.
+    // A NVS setting will override the yaml configuration.
+    _port_setting = new IntSetting(
+        "HttpPrintServer Port",         // Description
+        WEBSET,                         // Share NVS storage with WebUI
+        WA,                             // Admin Write, User Read
+        "NHPSP1",                       // Not quite sure how this gets used.
+        "network/HttpPrintServer/port", // Which path takes precedence?
+        _port,                          // Default to what we read from yaml.
+        1,                              // Minimum value
+        65001,                          // Maximum value
+        NULL);                          // No checker.
+    // And extract the value.
+    // I guess the server will need a restart for update.
+    _port = _port_setting->get();
+    // And start the server.
+    begin();
+    log_info("HttpPrintServer port=" << _port);
+}
+
+const char* HttpPrintServer::name() const {
+    return "HttpPrintServer";
+}
+
+void HttpPrintServer::validate() const {
+    // Do nothing.
+}
+
+void HttpPrintServer::group(Configuration::HandlerBase& handler) {
+    handler.item("port", _port);
+}
+
+void HttpPrintServer::afterParse() {
+    // Do nothing.
+}

--- a/FluidNC/src/Network/HttpPrintServer.cpp
+++ b/FluidNC/src/Network/HttpPrintServer.cpp
@@ -1,73 +1,152 @@
+#include <WebServer.h>
+
 #include "../Config.h"
+#include "../Protocol.h"
 #include "../Settings.h"
 
 #include "HttpPrintServer.h"
 
 HttpPrintServer::HttpPrintServer()
     : _state(UNSTARTED),
-      _port(-1) {
+      _port(-1),
+      _web_server(nullptr),
+      _print_client(nullptr),
+      _input_client(nullptr) {
+}
+
+HttpPrintServer::~HttpPrintServer() {
+    close_print_client();
+    close_web_server();
+}
+
+void HttpPrintServer::close_print_client() {
+    if (_input_client) {
+      unregister_client(_input_client);
+      delete _input_client;
+      _input_client = nullptr;
+    }
+    if (_print_client) {
+      delete _print_client;
+      _print_client = nullptr;
+    }
+}
+
+void HttpPrintServer::close_web_server() {
+    if (_web_server) {
+        delete _web_server;
+        _web_server = nullptr;
+    }
 }
 
 bool HttpPrintServer::begin() {
     if (_state != UNSTARTED || _port == -1) {
         return false;
     }
-    _server = WiFiServer(_port);
-    _server.begin();
-    setState(IDLE);
+    _web_server = new WebServer(_port);
+    _web_server->on("/", [&]() { print_form(); });
+    _web_server->on("/print", HTTP_POST, [&]() { print_response(); }, [&]() { print_upload(); });
+    _web_server->begin();
+    set_state(IDLE);
     return true;
 }
+
+void HttpPrintServer::print_form() {
+  _web_server->send(
+      200,
+      "text/html",
+      R"form(
+<html>
+ <body>
+  <form action='/print' method='post' enctype='multipart/form-data'>
+   <input type='file' name='gcode'>
+   <br>
+   <br>
+   <button type='submit'>
+    Print GCode
+   </button>
+   <br>
+  </form>
+ </body>
+</html>
+
+)form");
+}
+
+void HttpPrintServer::print_upload() {
+    switch (_state) {
+        case ABORTED:
+        case UNSTARTED:
+        case STOPPED:
+            // These should be impossible.
+            log_info("HttpPrintServer: Received upload while " << _state_name[_state]);
+            set_state(ABORTED);
+            return;
+        case IDLE:
+            log_info("Setting state to UPLOADING");
+            set_state(UPLOADING);
+            log_info("State is " << _state_name[_state]);
+            _print_client = new HttpPrintClient(_web_server);
+            _input_client = register_client(_print_client);
+            // Fall through.
+        case UPLOADING:
+            _print_client->handle_upload();
+            return;
+    }
+}
+
+void HttpPrintServer::print_response() {
+    switch (_state) {
+        case UPLOADING:
+            if (_print_client->isAborted()) {
+                log_info("HttpPrintServer: Upload aborted");
+                _web_server->send(409);
+            } else {
+                log_info("HttpPrintServer: Upload completed");
+                _web_server->send(200);
+            }
+            return;
+        default:
+            return;
+    }
+}
+
 
 void HttpPrintServer::stop() {
     if (_state == STOPPED) {
         return;
     }
-    _server.stop();
-    setState(STOPPED);
+    _web_server->stop();
+    close_print_client();
+    close_web_server();
+    set_state(STOPPED);
 }
 
 void HttpPrintServer::handle() {
     switch (_state) {
+    case ABORTED:
+    case STOPPED:
     case UNSTARTED:
         return;
     case IDLE:
-        if (_server.hasClient()) {
-            _client = HttpPrintClient(_server.available());
-            setState(PRINTING);
-            _input_client = register_client(&_client);
-        }
+        log_info("HttpPrintServer::handle advance");
+        _web_server->handleClient();
         return;
-    case PRINTING:
-        if (_client.isFinished()) {
-            unregister_client(_input_client);
-            delete _input_client;
-            _input_client = nullptr;
-            setState(IDLE);
+    case UPLOADING:
+        _print_client->handle_upload();
+        if (_print_client->isDone()) {
+            close_print_client();
+            set_state(IDLE);
         }
-        return;
-    case STOPPED:
         return;
     }
 }
 
-void HttpPrintServer::setState(State state) {
+void HttpPrintServer::set_state(State state) {
     if (_state != state) {
-        switch (state) {
-        case UNSTARTED:
-            log_info("HttpPrintServer: UNSTARTED");
-            break;
-        case IDLE:
-            log_info("HttpPrintServer: IDLE");
-            break;
-        case PRINTING:
-            log_info("HttpPrintServer: PRINTING");
-            break;
-        case STOPPED:
-            log_info("HttpPrintServer: STOPPED");
-            break;
-        default:
-            log_info("HttpPrintServer: <Unknown State>");
-            break;
+        log_info("HttpPrintServer: " << _state_name[_state]);
+        if (_state == ABORTED) {
+            // Place a hold for user attention.
+            rtFeedHold = true;
         }
     }
     _state = state;
@@ -110,3 +189,11 @@ void HttpPrintServer::group(Configuration::HandlerBase& handler) {
 void HttpPrintServer::afterParse() {
     // Do nothing.
 }
+
+const char* HttpPrintServer::_state_name[5] = {
+    "UNSTARTED",
+    "IDLE",
+    "UPLOADING",
+    "STOPPED",
+    "ABORTED",
+};

--- a/FluidNC/src/Network/HttpPrintServer.cpp
+++ b/FluidNC/src/Network/HttpPrintServer.cpp
@@ -16,10 +16,10 @@ namespace {
     };
 }
 
-HttpPrintServer::HttpPrintServer() : _state(UNSTARTED), _port(-1) {}
+HttpPrintServer::HttpPrintServer() : _state(UNSTARTED), _port(0) {}
 
 bool HttpPrintServer::begin() {
-    if (_state != UNSTARTED || _port == -1) {
+    if (_state != UNSTARTED || _port == 0) {
         return false;
     }
     _server = WiFiServer(_port);
@@ -73,21 +73,6 @@ void HttpPrintServer::setState(State state) {
 
 void HttpPrintServer::init() {
     log_info("HttpPrintServer init");
-    // Without a yaml configuration this will default to -1 which will disable the server.
-    // A NVS setting will override the yaml configuration.
-    _port_setting = new IntSetting("HttpPrintServer Port",          // Description
-                                   WEBSET,                          // Share NVS storage with WebUI
-                                   WA,                              // Admin Write, User Read
-                                   "NHPSP1",                        // Not quite sure how this gets used.
-                                   "network/HttpPrintServer/port",  // Which path takes precedence?
-                                   _port,                           // Default to what we read from yaml.
-                                   1,                               // Minimum value
-                                   65001,                           // Maximum value
-                                   NULL);                           // No checker.
-    // And extract the value.
-    // I guess the server will need a restart for update.
-    _port = _port_setting->get();
-    // And start the server.
     begin();
     log_info("HttpPrintServer port=" << _port);
 }

--- a/FluidNC/src/Network/HttpPrintServer.h
+++ b/FluidNC/src/Network/HttpPrintServer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <WebServer.h>
+#include <WiFi.h>
 
 #include "../Configuration/Configurable.h"
 #include "../Serial.h"
@@ -15,17 +15,12 @@ class HttpPrintServer : public Configuration::Configurable {
     enum State {
       UNSTARTED,
       IDLE,
-      UPLOADING,
+      PRINTING,
       STOPPED,
-      ABORTED,
     };
 
     public:
     HttpPrintServer();
-    virtual ~HttpPrintServer();
-
-    void close_print_client();
-    void close_web_server();
 
     // The server will now start accepting connections.
     bool begin();
@@ -36,11 +31,6 @@ class HttpPrintServer : public Configuration::Configurable {
     // Call this periodically to allow new connections to be established.
     void handle();
 
-    // Called for file upload.
-    void print_form();
-    void print_upload();
-    void print_response();
-
     void init();
 
     // Configuration
@@ -50,14 +40,12 @@ class HttpPrintServer : public Configuration::Configurable {
     void group(Configuration::HandlerBase& handler) override;
 
     private:
-    void set_state(State state);
+    void setState(State state);
 
     enum State _state;
     int _port;
-    WebServer* _web_server;
-    HttpPrintClient* _print_client;
+    WiFiServer _server;
+    HttpPrintClient _client;
     InputClient* _input_client; // Owned
     IntSetting* _port_setting;  // NVS override setting
-
-    static const char* _state_name[5];
 };

--- a/FluidNC/src/Network/HttpPrintServer.h
+++ b/FluidNC/src/Network/HttpPrintServer.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <WiFi.h>
+
+#include "../Configuration/Configurable.h"
+#include "../Serial.h"
+#include "../Settings.h"
+#include "HttpPrintClient.h"
+
+// The HttpPrintServer expects a text/plain encoded POST.
+// It ignores the header and streams the content until EOF.
+
+class HttpPrintServer : public Configuration::Configurable {
+    private:
+    enum State {
+      UNSTARTED,
+      IDLE,
+      PRINTING,
+      STOPPED,
+    };
+
+    public:
+    HttpPrintServer();
+
+    // The server will now start accepting connections.
+    bool begin();
+
+    // The server will accept no new connections.
+    void stop();
+
+    // Call this periodically to allow new connections to be established.
+    void handle();
+
+    void init();
+
+    // Configuration
+    const char* name() const;
+    void validate() const override;
+    void afterParse() override;
+    void group(Configuration::HandlerBase& handler) override;
+
+    private:
+    enum State _state;
+    int _port;
+    WiFiServer _server;
+    HttpPrintClient _client;
+    InputClient* _input_client; // Owned
+    IntSetting* _port_setting;  // NVS override setting
+};

--- a/FluidNC/src/Network/HttpPrintServer.h
+++ b/FluidNC/src/Network/HttpPrintServer.h
@@ -1,25 +1,26 @@
 #pragma once
 
-#include <WiFi.h>
+#include "../Config.h"
 
-#include "../Configuration/Configurable.h"
-#include "../Serial.h"
-#include "../Settings.h"
-#include "HttpPrintClient.h"
+#ifdef INCLUDE_HTTP_PRINT_SERVICE
 
-// The HttpPrintServer expects a text/plain encoded POST.
-// It ignores the header and streams the content until EOF.
+#    include <WiFi.h>
+
+#    include "../Configuration/Configurable.h"
+#    include "../Serial.h"
+#    include "../Settings.h"
+#    include "HttpPrintClient.h"
 
 class HttpPrintServer : public Configuration::Configurable {
-    private:
+private:
     enum State {
-      UNSTARTED,
-      IDLE,
-      PRINTING,
-      STOPPED,
+        UNSTARTED,
+        IDLE,
+        PRINTING,
+        STOPPED,
     };
 
-    public:
+public:
     HttpPrintServer();
 
     // The server will now start accepting connections.
@@ -31,21 +32,22 @@ class HttpPrintServer : public Configuration::Configurable {
     // Call this periodically to allow new connections to be established.
     void handle();
 
-    void init();
-
     // Configuration
     const char* name() const;
-    void validate() const override;
-    void afterParse() override;
-    void group(Configuration::HandlerBase& handler) override;
+    void        validate() const override;
+    void        afterParse() override;
+    void        group(Configuration::HandlerBase& handler) override;
+    void        init();
 
-    private:
+private:
     void setState(State state);
 
-    enum State _state;
-    int _port;
-    WiFiServer _server;
+    enum State      _state;
+    int             _port;
+    WiFiServer      _server;
     HttpPrintClient _client;
-    InputClient* _input_client; // Owned
-    IntSetting* _port_setting;  // NVS override setting
+    InputClient*    _input_client;  // Owned
+    IntSetting*     _port_setting;  // NVS override setting
 };
+
+#endif  // INCLUDE_HTTP_PRINT_SERVICE

--- a/FluidNC/src/Network/HttpPrintServer.h
+++ b/FluidNC/src/Network/HttpPrintServer.h
@@ -40,6 +40,8 @@ class HttpPrintServer : public Configuration::Configurable {
     void group(Configuration::HandlerBase& handler) override;
 
     private:
+    void setState(State state);
+
     enum State _state;
     int _port;
     WiFiServer _server;

--- a/FluidNC/src/Network/HttpPrintServer.h
+++ b/FluidNC/src/Network/HttpPrintServer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <WiFi.h>
+#include <WebServer.h>
 
 #include "../Configuration/Configurable.h"
 #include "../Serial.h"
@@ -15,12 +15,17 @@ class HttpPrintServer : public Configuration::Configurable {
     enum State {
       UNSTARTED,
       IDLE,
-      PRINTING,
+      UPLOADING,
       STOPPED,
+      ABORTED,
     };
 
     public:
     HttpPrintServer();
+    virtual ~HttpPrintServer();
+
+    void close_print_client();
+    void close_web_server();
 
     // The server will now start accepting connections.
     bool begin();
@@ -31,6 +36,11 @@ class HttpPrintServer : public Configuration::Configurable {
     // Call this periodically to allow new connections to be established.
     void handle();
 
+    // Called for file upload.
+    void print_form();
+    void print_upload();
+    void print_response();
+
     void init();
 
     // Configuration
@@ -40,12 +50,14 @@ class HttpPrintServer : public Configuration::Configurable {
     void group(Configuration::HandlerBase& handler) override;
 
     private:
-    void setState(State state);
+    void set_state(State state);
 
     enum State _state;
     int _port;
-    WiFiServer _server;
-    HttpPrintClient _client;
+    WebServer* _web_server;
+    HttpPrintClient* _print_client;
     InputClient* _input_client; // Owned
     IntSetting* _port_setting;  // NVS override setting
+
+    static const char* _state_name[5];
 };

--- a/FluidNC/src/Network/HttpPrintServer.h
+++ b/FluidNC/src/Network/HttpPrintServer.h
@@ -8,8 +8,18 @@
 
 #    include "../Configuration/Configurable.h"
 #    include "../Serial.h"
-#    include "../Settings.h"
 #    include "HttpPrintClient.h"
+
+// This provides a service for streaming gcode for printing via http post.
+//
+// See 'print.html' for an example of how to call the print service from a
+// browser.
+//
+// Example yaml configuration:
+//
+// network:
+//   HttpPrintServer:
+//     port: 88
 
 class HttpPrintServer : public Configuration::Configurable {
 private:
@@ -47,7 +57,6 @@ private:
     WiFiServer      _server;
     HttpPrintClient _client;
     InputClient*    _input_client;  // Owned
-    IntSetting*     _port_setting;  // NVS override setting
 };
 
 #endif  // INCLUDE_HTTP_PRINT_SERVICE

--- a/FluidNC/src/Network/Network.cpp
+++ b/FluidNC/src/Network/Network.cpp
@@ -3,8 +3,6 @@
 #include "../Settings.h"
 
 void Network::init() {
-  // Do nothing.
-  log_info("Network init");
   if (_http_print_server) {
     _http_print_server->init();
   }

--- a/FluidNC/src/Network/Network.cpp
+++ b/FluidNC/src/Network/Network.cpp
@@ -1,0 +1,27 @@
+#include "Network.h"
+#include "../Logging.h"
+#include "../Settings.h"
+
+void Network::init() {
+  // Do nothing.
+  log_info("Network init");
+  if (_http_print_server) {
+    _http_print_server->init();
+  }
+}
+
+const char* Network::name() const {
+    return "network";
+}
+
+void Network::validate() const {
+  // Do nothing.
+}
+
+void Network::group(Configuration::HandlerBase& handler) {
+    handler.section("HttpPrintServer", _http_print_server);
+}
+
+void Network::afterParse() {
+  // Do nothing.
+}

--- a/FluidNC/src/Network/Network.cpp
+++ b/FluidNC/src/Network/Network.cpp
@@ -12,8 +12,7 @@ void Network::init() {
     if (_http_print_server) {
         _http_print_server->init();
     }
-#endif // INCLUDE_HTTP_PRINT_SERVICE
-
+#endif  // INCLUDE_HTTP_PRINT_SERVICE
 }
 
 void Network::handle() {
@@ -21,7 +20,7 @@ void Network::handle() {
     if (_http_print_server) {
         _http_print_server->handle();
     }
-#endif // INCLUDE_HTTP_PRINT_SERVICE
+#endif  // INCLUDE_HTTP_PRINT_SERVICE
 }
 
 const char* Network::name() const {

--- a/FluidNC/src/Network/Network.cpp
+++ b/FluidNC/src/Network/Network.cpp
@@ -10,6 +10,12 @@ void Network::init() {
   }
 }
 
+void Network::handle() {
+    if (_http_print_server) {
+        _http_print_server->handle();
+    }
+}
+
 const char* Network::name() const {
     return "network";
 }

--- a/FluidNC/src/Network/Network.cpp
+++ b/FluidNC/src/Network/Network.cpp
@@ -1,13 +1,15 @@
+#include "../Config.h"
+
 #include "Network.h"
 #include "../Logging.h"
 #include "../Settings.h"
 
 void Network::init() {
-  // Do nothing.
-  log_info("Network init");
-  if (_http_print_server) {
-    _http_print_server->init();
-  }
+    // Do nothing.
+    log_info("Network init");
+    if (_http_print_server) {
+        _http_print_server->init();
+    }
 }
 
 void Network::handle() {
@@ -21,7 +23,7 @@ const char* Network::name() const {
 }
 
 void Network::validate() const {
-  // Do nothing.
+    // Do nothing.
 }
 
 void Network::group(Configuration::HandlerBase& handler) {
@@ -29,5 +31,5 @@ void Network::group(Configuration::HandlerBase& handler) {
 }
 
 void Network::afterParse() {
-  // Do nothing.
+    // Do nothing.
 }

--- a/FluidNC/src/Network/Network.cpp
+++ b/FluidNC/src/Network/Network.cpp
@@ -7,15 +7,21 @@
 void Network::init() {
     // Do nothing.
     log_info("Network init");
+
+#ifdef INCLUDE_HTTP_PRINT_SERVICE
     if (_http_print_server) {
         _http_print_server->init();
     }
+#endif // INCLUDE_HTTP_PRINT_SERVICE
+
 }
 
 void Network::handle() {
+#ifdef INCLUDE_HTTP_PRINT_SERVICE
     if (_http_print_server) {
         _http_print_server->handle();
     }
+#endif // INCLUDE_HTTP_PRINT_SERVICE
 }
 
 const char* Network::name() const {
@@ -27,7 +33,9 @@ void Network::validate() const {
 }
 
 void Network::group(Configuration::HandlerBase& handler) {
+#ifdef INCLUDE_HTTP_PRINT_SERVICE
     handler.section("HttpPrintServer", _http_print_server);
+#endif
 }
 
 void Network::afterParse() {

--- a/FluidNC/src/Network/Network.cpp
+++ b/FluidNC/src/Network/Network.cpp
@@ -3,6 +3,8 @@
 #include "../Settings.h"
 
 void Network::init() {
+  // Do nothing.
+  log_info("Network init");
   if (_http_print_server) {
     _http_print_server->init();
   }

--- a/FluidNC/src/Network/Network.h
+++ b/FluidNC/src/Network/Network.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "../Config.h"
+
 #include "../Configuration/Configurable.h"
 
 #include "HttpPrintServer.h"
 
 class Network : public Configuration::Configurable {
-    public:
+public:
     Network() = default;
 
     Network(const Network&) = delete;
@@ -18,13 +20,13 @@ class Network : public Configuration::Configurable {
 
     // Configuration
     const char* name() const;
-    void validate() const override;
-    void afterParse() override;
-    void group(Configuration::HandlerBase& handler) override;
+    void        validate() const override;
+    void        afterParse() override;
+    void        group(Configuration::HandlerBase& handler) override;
 
     // Virtual base classes require a virtual destructor.
     virtual ~Network() {}
 
-    private:
+private:
     HttpPrintServer* _http_print_server;
 };

--- a/FluidNC/src/Network/Network.h
+++ b/FluidNC/src/Network/Network.h
@@ -28,5 +28,7 @@ public:
     virtual ~Network() {}
 
 private:
+#ifdef INCLUDE_HTTP_PRINT_SERVICE
     HttpPrintServer* _http_print_server;
+#endif
 };

--- a/FluidNC/src/Network/Network.h
+++ b/FluidNC/src/Network/Network.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "../Configuration/Configurable.h"
+
+#include "HttpPrintServer.h"
+
+class Network : public Configuration::Configurable {
+    public:
+    Network() = default;
+
+    Network(const Network&) = delete;
+    Network(Network&&)      = delete;
+    Network& operator=(const Network&) = delete;
+    Network& operator=(Network&&) = delete;
+
+    void init();
+
+    // Configuration
+    const char* name() const;
+    void validate() const override;
+    void afterParse() override;
+    void group(Configuration::HandlerBase& handler) override;
+
+    // Virtual base classes require a virtual destructor.
+    virtual ~Network() {}
+
+    private:
+    HttpPrintServer* _http_print_server;
+};

--- a/FluidNC/src/Network/Network.h
+++ b/FluidNC/src/Network/Network.h
@@ -14,6 +14,7 @@ class Network : public Configuration::Configurable {
     Network& operator=(Network&&) = delete;
 
     void init();
+    void handle();
 
     // Configuration
     const char* name() const;

--- a/FluidNC/src/Network/print.html
+++ b/FluidNC/src/Network/print.html
@@ -1,0 +1,25 @@
+<html>
+ <body>
+  A trivial example to send gcode to be printed via post.
+  <script>
+    // Change this url.
+    const url = 'http://192.168.31.235:88/';
+    const print = async (url, body) => {
+      alert('Will print');
+      try {
+        const response = await fetch(url, { mode: 'cors', method: "post", body });
+        if (response.ok) {
+          alert('Print succeeded');
+        } else {
+          alert(`Print failed: ${response.status}`);
+        }
+      } catch (error) {
+        alert(error);
+      }
+    }
+    print(url,
+          'G0 Z0\r\n' +
+          'G0 Z1\r\n');
+  </script>
+ </body>
+</html>

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -161,6 +161,7 @@ void protocol_main_loop() {
 #endif
             // auth_level can be upgraded by supplying a password on the command line
             report_status_message(execute_line(ic->_line, *out, WebUI::AuthenticationLevel::LEVEL_GUEST), *out);
+            log_info("ProbeState=" << (probeState == ProbeState::Active));
         }
         // If there are no more lines to be processed and executed,
         // auto-cycle start, if enabled, any queued moves.
@@ -183,6 +184,7 @@ void protocol_main_loop() {
 
         if (idleEndTime && (getCpuTicks() - idleEndTime) > 0) {
             idleEndTime = 0;  //
+            log_info("Disabling idle steppers");
             config->_axes->set_disable(true);
         }
     }
@@ -204,7 +206,7 @@ void protocol_buffer_synchronize() {
 
 // Auto-cycle start triggers when there is a motion ready to execute and if the main program is not
 // actively parsing commands.
-// NOTE: This function is called from the main loop, buffer sync, and mc_line() only and executes
+// NOTE: This function is called from the main loop, buffer sync, and mc_move_motors() only and executes
 // when one of these conditions exist respectively: There are no more blocks sent (i.e. streaming
 // is finished, single commands), a command that needs to wait for the motions in the buffer to
 // execute calls a buffer sync, or the planner buffer is full and ready to go.
@@ -785,7 +787,7 @@ static void protocol_exec_rt_suspend() {
         if (sys.abort) {
             return;
         }
-        // if a jogCancel comes in and we have a jog "in-flight" (parsed and handed over to mc_line()),
+        // if a jogCancel comes in and we have a jog "in-flight" (parsed and handed over to mc_move_motors()),
         //  then we need to cancel it before it reaches the planner.  otherwise we may try to move way out of
         //  normal bounds, especially with senders that issue a series of jog commands before sending a cancel.
         if (sys.suspend.bit.jogCancel) {

--- a/FluidNC/src/Report.h
+++ b/FluidNC/src/Report.h
@@ -23,7 +23,7 @@
 // NOTE: Only use this for debugging purposes!! When echoing, this takes up valuable resources and can effect
 // performance. If absolutely needed for normal operation, the serial write buffer should be greatly increased
 // to help minimize transmission waiting within the serial write protocol.
-//#define DEBUG_REPORT_ECHO_LINE_RECEIVED // Default disabled. Uncomment to enable.
+#define DEBUG_REPORT_ECHO_LINE_RECEIVED // Default disabled. Uncomment to enable.
 
 // This is similar to DEBUG_REPORT_ECHO_LINE_RECEIVED and subject to all its caveats,
 // but instead of echoing the pre-parsed line, it echos the raw line exactly as

--- a/FluidNC/src/Serial.cpp
+++ b/FluidNC/src/Serial.cpp
@@ -198,8 +198,20 @@ InputClient* sdClient = new InputClient(nullptr);
 
 std::vector<InputClient*> clientq;
 
-void register_client(Stream* client_stream) {
+InputClient* register_client(Stream* client_stream) {
     clientq.push_back(new InputClient(client_stream));
+    return clientq.back();
+}
+bool unregister_client(InputClient* input_client) {
+    for (int index = 0; index < clientq.size(); index++) {
+        if (clientq[index] == input_client) {
+            // Swap the client out of the vector.
+            clientq[index] = clientq.back();
+            clientq.pop_back();
+            return true;
+        }
+    }
+    return false;
 }
 void client_init() {
     register_client(&Uart0);               // USB Serial

--- a/FluidNC/src/Serial.cpp
+++ b/FluidNC/src/Serial.cpp
@@ -280,6 +280,10 @@ InputClient* pollClients() {
     WebUI::wifi_services.handle();  // OTA, web_server, telnet_server polling
 #endif
 
+    if (config->_network) {
+        config->_network->handle();
+    }
+
     // _readyNext indicates that input is coming from a file and
     // the GCode system is ready for another line.
     if (sdcard && sdcard->_readyNext) {

--- a/FluidNC/src/Serial.h
+++ b/FluidNC/src/Serial.h
@@ -78,6 +78,10 @@ public:
     size_t write(const uint8_t* buffer, size_t length) override;
 };
 
-void register_client(Stream* client_stream);
+// Returns InputClient suitable for use with unregister_client.
+InputClient* register_client(Stream* client_stream);
+
+// Returns true if input_client were removed.
+bool unregister_client(InputClient* input_client);
 
 extern AllClients allClients;


### PR DESCRIPTION
This provides a service which allows gcode to be streamed via HTTP POST.

It is compiled conditionally via INCLUDE_HTTP_PRINT_SERVICE.

It is not part of WebUI but could be invoked by WebUI, or from an unrelated web site.

The service enforces a single client connection and should place the machine in a hold if the upload is aborted.

When a connection is made a client is added to the serial client list, and this is removed once the connection has completed.

This is not implemented using WebServer since WebServer upload does not allow flow control to be driven by the protocol loop.