### PR TITLE
Limit stepper disable cancel to when the protocol buffer is not empty

### DIFF
--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -458,13 +458,12 @@ static void protocol_do_initiate_cycle() {
         sys.state         = State::Cycle;
         Stepper::prep_buffer();  // Initialize step segment buffer before beginning cycle.
         Stepper::wake_up();
+        // Make sure the steppers can't be scheduled for a shutdown while this cycle is running.
+        protocol_cancel_disable_steppers();
     } else {                    // Otherwise, do nothing. Set and resume IDLE state.
         sys.suspend.value = 0;  // Break suspend state.
         sys.state         = State::Idle;
     }
-
-    // Make sure the steppers can't be scheduled for a shutdown while this cycle is running.
-    protocol_cancel_disable_steppers();
 }
 
 // The handlers for rtFeedHold, rtMotionCancel, and rtsDafetyDoor clear rtCycleStart to


### PR DESCRIPTION
Before this fix a sequence of commands like

```gcode
G1 X1 F1
!
```

can be used to put the machine in a hold state such that run will move to idle without a stepper idle timeout in place, meaning that the steppers will stay on indefinitely until another command is sent.