### PR TITLE
Increase number of macros availible

### DIFF
--- a/FluidNC/src/Control.cpp
+++ b/FluidNC/src/Control.cpp
@@ -8,7 +8,9 @@
 Control::Control() :
     _safetyDoor(rtSafetyDoor, "Door", 'D'), _reset(rtReset, "Reset", 'R'), _feedHold(rtFeedHold, "FeedHold", 'H'),
     _cycleStart(rtCycleStart, "CycleStart", 'S'), _macro0(rtButtonMacro0, "Macro 0", '0'), _macro1(rtButtonMacro1, "Macro 1", '1'),
-    _macro2(rtButtonMacro2, "Macro 2", '2'), _macro3(rtButtonMacro3, "Macro 3", '3') {}
+    _macro2(rtButtonMacro2, "Macro 2", '2'), _macro3(rtButtonMacro3, "Macro 3", '3'), _macro4(rtButtonMacro4, "Macro 4", '4'),
+    _macro5(rtButtonMacro5, "Macro 5", '5'), _macro6(rtButtonMacro6, "Macro 6", '6'), _macro7(rtButtonMacro7, "Macro 7", '7'),
+    _macro8(rtButtonMacro8, "Macro 8", '8'), _macro9(rtButtonMacro9, "Macro 9", '9') {}
 
 void Control::init() {
     _safetyDoor.init();
@@ -19,6 +21,12 @@ void Control::init() {
     _macro1.init();
     _macro2.init();
     _macro3.init();
+    _macro4.init();
+    _macro5.init();
+    _macro6.init();
+    _macro7.init();
+    _macro8.init();
+    _macro9.init();
 }
 
 void Control::group(Configuration::HandlerBase& handler) {
@@ -30,16 +38,24 @@ void Control::group(Configuration::HandlerBase& handler) {
     handler.item("macro1_pin", _macro1._pin);
     handler.item("macro2_pin", _macro2._pin);
     handler.item("macro3_pin", _macro3._pin);
+    handler.item("macro4_pin", _macro4._pin);
+    handler.item("macro5_pin", _macro5._pin);
+    handler.item("macro6_pin", _macro6._pin);
+    handler.item("macro7_pin", _macro7._pin);
+    handler.item("macro8_pin", _macro8._pin);
+    handler.item("macro9_pin", _macro9._pin);
 }
 
 String Control::report() {
-    return _safetyDoor.report() + _safetyDoor.report() + _reset.report() + _feedHold.report() + _cycleStart.report() + _macro0.report() +
-           _macro1.report() + _macro2.report() + _macro3.report();
+    return _safetyDoor.report() + _safetyDoor.report() + _reset.report() + _feedHold.report() + _cycleStart.report() + 
+            _macro0.report() + _macro1.report() + _macro2.report() + _macro3.report() + _macro4.report() +
+            _macro5.report() + _macro6.report() + _macro7.report() + _macro8.report() + _macro9.report();
 }
 
 bool Control::stuck() {
-    return _safetyDoor.get() || _reset.get() || _feedHold.get() || _cycleStart.get() || _macro0.get() || _macro1.get() || _macro2.get() ||
-           _macro3.get();
+    return _safetyDoor.get() || _reset.get() || _feedHold.get() || _cycleStart.get() ||
+           _macro0.get() || _macro1.get() || _macro2.get() ||_macro3.get() || _macro4.get() ||
+           _macro5.get() || _macro6.get() || _macro7.get() || _macro8.get() || _macro9.get();
 }
 
 // Returns if safety door is ajar(T) or closed(F), based on pin state.

--- a/FluidNC/src/Control.h
+++ b/FluidNC/src/Control.h
@@ -18,6 +18,12 @@ public:
     ControlPin _macro1;
     ControlPin _macro2;
     ControlPin _macro3;
+    ControlPin _macro4;
+    ControlPin _macro5;
+    ControlPin _macro6;
+    ControlPin _macro7;
+    ControlPin _macro8;
+    ControlPin _macro9;
 
 public:
     Control();

--- a/FluidNC/src/Machine/Macros.h
+++ b/FluidNC/src/Machine/Macros.h
@@ -62,6 +62,12 @@ namespace Machine {
             handler.item("macro1", _macro[1]);
             handler.item("macro2", _macro[2]);
             handler.item("macro3", _macro[3]);
+            handler.item("macro4", _macro[4]);
+            handler.item("macro5", _macro[5]);
+            handler.item("macro6", _macro[6]);
+            handler.item("macro7", _macro[7]);
+            handler.item("macro8", _macro[8]);
+            handler.item("macro9", _macro[9]);
         }
 
         ~Macros() {}

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -55,6 +55,12 @@ volatile bool rtButtonMacro0;
 volatile bool rtButtonMacro1;
 volatile bool rtButtonMacro2;
 volatile bool rtButtonMacro3;
+volatile bool rtButtonMacro4;
+volatile bool rtButtonMacro5;
+volatile bool rtButtonMacro6;
+volatile bool rtButtonMacro7;
+volatile bool rtButtonMacro8;
+volatile bool rtButtonMacro9;
 
 static void protocol_exec_rt_suspend();
 
@@ -720,7 +726,31 @@ void protocol_exec_rt_system() {
         rtButtonMacro3 = false;
         protocol_do_macro(3);
     }
-
+    if (rtButtonMacro4) {
+        rtButtonMacro4 = false;
+        protocol_do_macro(4);
+    }
+    if (rtButtonMacro5) {
+        rtButtonMacro5 = false;
+        protocol_do_macro(5);
+    }
+    if (rtButtonMacro6) {
+        rtButtonMacro6 = false;
+        protocol_do_macro(6);
+    }
+    if (rtButtonMacro7) {
+        rtButtonMacro7 = false;
+        protocol_do_macro(7);
+    }
+    if (rtButtonMacro8) {
+        rtButtonMacro8 = false;
+        protocol_do_macro(8);
+    }
+    if (rtButtonMacro9) {
+        rtButtonMacro9 = false;
+        protocol_do_macro(9);
+    }    
+    
     protocol_execute_overrides();
 
 #ifdef DEBUG_PROTOCOL

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -52,6 +52,12 @@ extern volatile bool rtButtonMacro0;
 extern volatile bool rtButtonMacro1;
 extern volatile bool rtButtonMacro2;
 extern volatile bool rtButtonMacro3;
+extern volatile bool rtButtonMacro4;
+extern volatile bool rtButtonMacro5;
+extern volatile bool rtButtonMacro6;
+extern volatile bool rtButtonMacro7;
+extern volatile bool rtButtonMacro8;
+extern volatile bool rtButtonMacro9;
 
 #ifdef DEBUG_REPORT_REALTIME
 extern volatile bool rtExecDebug;

--- a/example_configs/6_Pack_2130_XYZABC.yaml
+++ b/example_configs/6_Pack_2130_XYZABC.yaml
@@ -279,6 +279,12 @@ control:
   macro1_pin: NO_PIN
   macro2_pin: NO_PIN
   macro3_pin: NO_PIN
+  macro4_pin: NO_PIN
+  macro5_pin: NO_PIN
+  macro6_pin: NO_PIN
+  macro7_pin: NO_PIN
+  macro8_pin: NO_PIN
+  macro9_pin: NO_PIN
 
 coolant:
   flood_pin: i2so.24
@@ -296,6 +302,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 
 start:

--- a/example_configs/6_Pack_stepstick_XYZABC.yaml
+++ b/example_configs/6_Pack_stepstick_XYZABC.yaml
@@ -201,6 +201,12 @@ control:
   macro1_pin: NO_PIN
   macro2_pin: NO_PIN
   macro3_pin: NO_PIN
+  macro4_pin: NO_PIN
+  macro5_pin: NO_PIN
+  macro6_pin: NO_PIN
+  macro7_pin: NO_PIN
+  macro8_pin: NO_PIN
+  macro9_pin: NO_PIN
 
 coolant:
   flood_pin: i2so.24
@@ -218,6 +224,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 
 start:

--- a/example_configs/6_Pack_test.yaml
+++ b/example_configs/6_Pack_test.yaml
@@ -279,6 +279,12 @@ control:
   macro1_pin: NO_PIN
   macro2_pin: NO_PIN
   macro3_pin: NO_PIN
+  macro4_pin: NO_PIN
+  macro5_pin: NO_PIN
+  macro6_pin: NO_PIN
+  macro7_pin: NO_PIN
+  macro8_pin: NO_PIN
+  macro9_pin: NO_PIN
 
 coolant:
   flood_pin: i2so.24
@@ -296,6 +302,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
   
 user_outputs:
   analog0_pin: NO_PIN

--- a/example_configs/6_pack_TMC2130.yaml
+++ b/example_configs/6_pack_TMC2130.yaml
@@ -152,6 +152,12 @@ control:
   macro1_pin: NO_PIN
   macro2_pin: NO_PIN
   macro3_pin: NO_PIN
+  macro4_pin: NO_PIN
+  macro5_pin: NO_PIN
+  macro6_pin: NO_PIN
+  macro7_pin: NO_PIN
+  macro8_pin: NO_PIN
+  macro9_pin: NO_PIN
 
 coolant:
   flood_pin: NO_PIN
@@ -169,6 +175,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 user_outputs:
   analog0_pin: NO_PIN

--- a/example_configs/6_pack_TMC5160.yaml
+++ b/example_configs/6_pack_TMC5160.yaml
@@ -152,6 +152,12 @@ control:
   macro1_pin: NO_PIN
   macro2_pin: NO_PIN
   macro3_pin: NO_PIN
+  macro4_pin: NO_PIN
+  macro5_pin: NO_PIN
+  macro6_pin: NO_PIN
+  macro7_pin: NO_PIN
+  macro8_pin: NO_PIN
+  macro9_pin: NO_PIN
 
 probe:
   pin: NO_PIN
@@ -164,6 +170,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 user_outputs:
   analog0_pin: NO_PIN

--- a/example_configs/6_pack_TMC5160_Huanyang.yaml
+++ b/example_configs/6_pack_TMC5160_Huanyang.yaml
@@ -149,6 +149,12 @@ control:
   macro1_pin: NO_PIN
   macro2_pin: NO_PIN
   macro3_pin: NO_PIN
+  macro4_pin: NO_PIN
+  macro5_pin: NO_PIN
+  macro6_pin: NO_PIN
+  macro7_pin: NO_PIN
+  macro8_pin: NO_PIN
+  macro9_pin: NO_PIN
 
 probe:
   pin: NO_PIN
@@ -161,6 +167,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 user_outputs:
   analog0_pin: NO_PIN

--- a/example_configs/6_pack_TMC5160_XYYZ.yaml
+++ b/example_configs/6_pack_TMC5160_XYYZ.yaml
@@ -176,6 +176,12 @@ control:
   macro1_pin: NO_PIN
   macro2_pin: NO_PIN
   macro3_pin: NO_PIN
+  macro4_pin: NO_PIN
+  macro5_pin: NO_PIN
+  macro6_pin: NO_PIN
+  macro7_pin: NO_PIN
+  macro8_pin: NO_PIN
+  macro9_pin: NO_PIN
 
 probe:
   pin: NO_PIN
@@ -188,6 +194,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 user_outputs:
   analog0_pin: NO_PIN

--- a/example_configs/6_pack_external_huanyang.yaml
+++ b/example_configs/6_pack_external_huanyang.yaml
@@ -113,6 +113,12 @@ control:
   macro1_pin: NO_PIN
   macro2_pin: NO_PIN
   macro3_pin: NO_PIN
+  macro4_pin: NO_PIN
+  macro5_pin: NO_PIN
+  macro6_pin: NO_PIN
+  macro7_pin: NO_PIN
+  macro8_pin: NO_PIN
+  macro9_pin: NO_PIN
 
 coolant:
   flood_pin: NO_PIN
@@ -130,6 +136,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 user_outputs:
   analog0_pin: NO_PIN

--- a/example_configs/TMC2130_SPI_Daisy.yaml
+++ b/example_configs/TMC2130_SPI_Daisy.yaml
@@ -190,6 +190,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 start:
   must_home: false

--- a/example_configs/TMC2209.yaml
+++ b/example_configs/TMC2209.yaml
@@ -143,6 +143,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 user_outputs:
   analog0: NO_PIN

--- a/example_configs/TMC2209_pen.yaml
+++ b/example_configs/TMC2209_pen.yaml
@@ -146,6 +146,12 @@ control:
   macro1_pin: NO_PIN
   macro2_pin: NO_PIN
   macro3_pin: NO_PIN
+  macro4_pin: NO_PIN
+  macro5_pin: NO_PIN
+  macro6_pin: NO_PIN
+  macro7_pin: NO_PIN
+  macro8_pin: NO_PIN
+  macro9_pin: NO_PIN
 
 probe:
   pin: NO_PIN
@@ -158,6 +164,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 user_outputs:
   analog0_pin: NO_PIN

--- a/example_configs/test_drive_SD.yaml
+++ b/example_configs/test_drive_SD.yaml
@@ -56,6 +56,12 @@ macros:
   macro1:
   macro2:
   macro3:
+  macro4:
+  macro5:
+  macro6:
+  macro7:
+  macro8:
+  macro9:
 
 user_outputs:
   analog0: NO_PIN


### PR DESCRIPTION
This is a simple code duplication to increase the number of hard coded user definable button macros.  It is in preperation for the support of I/O input expanders. 
Having the possibility to use many more input pins opens up some new use cases and functionality to existing projects. This is a great move for having physical buttons to control things like tool selection or loading on ATC, as well as jog functions and more.
This is linked to https://github.com/bdring/FluidNC/issues/101