### PR TITLE
Vfd ovrd fix

### DIFF
--- a/FluidNC/src/Spindles/VFDSpindle.cpp
+++ b/FluidNC/src/Spindles/VFDSpindle.cpp
@@ -392,6 +392,7 @@ namespace Spindles {
     }
 
     void VFD::set_mode(SpindleState mode, bool critical) {
+        _last_override_value = sys.spindle_speed_ovr;  // sync these on mode changes
         if (vfd_cmd_queue) {
             VFDaction action;
             action.action   = actionSetMode;

--- a/FluidNC/src/Spindles/VFDSpindle.h
+++ b/FluidNC/src/Spindles/VFDSpindle.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Spindle.h"
+#include "../Types.h"
 
 #include "../Uart.h"
 
@@ -22,7 +23,9 @@ namespace Spindles {
         void set_mode(SpindleState mode, bool critical);
         bool get_pins_and_settings();
 
-        int32_t _current_dev_speed = -1;
+        int32_t  _current_dev_speed   = -1;
+        uint32_t _last_speed          = 0;
+        Percent  _last_override_value = 100;  // no override is 100 percent
 
         static QueueHandle_t vfd_cmd_queue;
         static TaskHandle_t  vfd_cmdTaskHandle;
@@ -64,7 +67,6 @@ namespace Spindles {
         virtual response_parser get_current_speed(ModbusCommand& data) { return nullptr; }
         virtual response_parser get_current_direction(ModbusCommand& data) { return nullptr; }
         virtual response_parser get_status_ok(ModbusCommand& data) = 0;
-        
         virtual bool            safety_polling() const { return true; }
 
         // The constructor sets these


### PR DESCRIPTION
Spindle speed overrides do not pause motion to wait for speed sync.