### PR TITLE
Fixed problems with String(float, digits) crashes

### DIFF
--- a/FluidNC/src/Configuration/JsonGenerator.cpp
+++ b/FluidNC/src/Configuration/JsonGenerator.cpp
@@ -76,6 +76,11 @@ namespace Configuration {
     void JsonGenerator::item(const char* name, float& value, float minValue, float maxValue) {
         enter(name);
         // WebUI does not explicitly recognize the R type, but nevertheless handles it correctly.
+        if (value > 999999.999f) {
+            value = 999999.999f;
+        } else if (value < -999999.999f) {
+            value = -999999.999f;
+        }
         _encoder.begin_webui(_currentPath, _currentPath, "R", String(value, 3).c_str());
         _encoder.end_object();
         leave();
@@ -114,7 +119,7 @@ namespace Configuration {
 
     void JsonGenerator::item(const char* name, int& value, EnumItem* e) {
         enter(name);
-        int         selected_val = 0;
+        int selected_val = 0;
         //const char* str          = "unknown";
         for (auto e2 = e; e2->name; ++e2) {
             if (value == e2->value) {

--- a/FluidNC/src/MyIOStream.h
+++ b/FluidNC/src/MyIOStream.h
@@ -5,6 +5,17 @@
 #include <Print.h>
 #include "Pin.h"
 
+class IOPrecision {
+public:
+    int _digits = 3;
+};
+extern IOPrecision ioPrecision;
+
+inline IOPrecision* setprecision(int digits) {
+    ioPrecision._digits = digits;
+    return &ioPrecision;
+}
+
 inline Print& operator<<(Print& lhs, char c) {
     lhs.print(c);
     return lhs;
@@ -36,16 +47,22 @@ inline Print& operator<<(Print& lhs, uint64_t v) {
 }
 
 inline Print& operator<<(Print& lhs, float v) {
-    lhs.print(v, 3);
+    lhs.print(v, ioPrecision._digits);
+    ioPrecision._digits = 3;
     return lhs;
 }
 
 inline Print& operator<<(Print& lhs, double v) {
-    lhs.print(v, 3);
+    lhs.print(v, ioPrecision._digits);
+    ioPrecision._digits = 3;
     return lhs;
 }
 
 inline Print& operator<<(Print& lhs, const Pin& v) {
     lhs.print(v.name());
+    return lhs;
+}
+
+inline Print& operator<<(Print& lhs, IOPrecision* digits) {
     return lhs;
 }

--- a/FluidNC/src/NutsBolts.cpp
+++ b/FluidNC/src/NutsBolts.cpp
@@ -195,11 +195,23 @@ char* trim(char* str) {
 String formatBytes(uint64_t bytes) {
     if (bytes < 1024) {
         return String((uint16_t)bytes) + " B";
-    } else if (bytes < (1024 * 1024)) {
-        return String((float)(bytes / 1024.0), 2) + " KB";
-    } else if (bytes < (1024 * 1024 * 1024)) {
-        return String((float)(bytes / 1024.0 / 1024.0), 2) + " MB";
-    } else {
-        return String((float)(bytes / 1024.0 / 1024.0 / 1024.0), 2) + " GB";
     }
+    float b = bytes;
+    b /= 1024;
+    if (b < 1024) {
+        return String(b, 2) + " KB";
+    }
+    b /= 1024;
+    if (b < 1024) {
+        return String(b, 2) + " MB";
+    }
+    b /= 1024;
+    if (b < 1024) {
+        return String(b, 2) + " GB";
+    }
+    b /= 1024;
+    if (b > 99999) {
+        b = 99999;
+    }
+    return String(b, 2) + " TB";
 }

--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -40,6 +40,8 @@
 #include <cstdio>
 #include <cstdarg>
 
+IOPrecision ioPrecision;
+
 #ifdef DEBUG_REPORT_HEAP
 EspClass esp;
 #endif
@@ -79,44 +81,21 @@ Counter report_wco_counter = 0;
 static const int coordStringLen = 20;
 static const int axesStringLen  = coordStringLen * MAX_N_AXIS;
 
-// formats axis values into a string and returns that string in rpt
-// NOTE: rpt should have at least size: axesStringLen
-static void report_util_axis_values(float* axis_value, char* rpt) {
-    char        axisVal[coordStringLen];
-    float       unit_conv = 1.0;      // unit conversion multiplier..default is mm
-    const char* format    = "%4.3f";  // Default - report mm to 3 decimal places
-    rpt[0]                = '\0';
-    if (config->_reportInches) {
-        unit_conv = 1.0f / MM_PER_INCH;
-        format    = "%4.4f";  // Report inches to 4 decimal places
-    }
-    auto n_axis = config->_axes->_numberAxis;
-    for (size_t idx = 0; idx < n_axis; idx++) {
-        snprintf(axisVal, coordStringLen - 1, format, axis_value[idx] * unit_conv);
-        strcat(rpt, axisVal);
-        if (idx < (n_axis - 1)) {
-            strcat(rpt, ",");
-        }
-    }
-}
-
-// This version returns the axis values as a String
-static String report_util_axis_values(const float* axis_value) {
-    String rpt       = "";
-    float  unit_conv = 1.0;  // unit conversion multiplier..default is mm
-    int    decimals  = 3;    // Default - report mm to 3 decimal places
+// Sends the axis values to the output channel
+static void report_util_axis_values(const float* axis_value, Print& channel) {
+    float unit_conv = 1.0;  // unit conversion multiplier..default is mm
+    int   decimals  = 3;    // Default - report mm to 3 decimal places
     if (config->_reportInches) {
         unit_conv = 1.0f / MM_PER_INCH;
         decimals  = 4;  // Report inches to 4 decimal places
     }
     auto n_axis = config->_axes->_numberAxis;
     for (size_t idx = 0; idx < n_axis; idx++) {
-        rpt += String(axis_value[idx] * unit_conv, decimals);
+        channel << setprecision(decimals) << (axis_value[idx] * unit_conv);
         if (idx < (n_axis - 1)) {
-            rpt += ",";
+            channel << ",";
         }
     }
-    return rpt;
 }
 
 // Handles the primary confirmation protocol response for streaming interfaces and human-feedback.
@@ -212,26 +191,30 @@ void report_probe_parameters(Print& channel) {
     // get the machine position and put them into a string and append to the probe report
     float print_position[MAX_N_AXIS];
     motor_steps_to_mpos(print_position, probe_steps);
-    client << "[PRB:" << report_util_axis_values(print_position) << ":" << probe_succeeded << "]\n";
+    channel << "[PRB:";
+    report_util_axis_values(print_position, channel);
+    channel << ":" << probe_succeeded << "]\n";
 }
 
 // Prints NGC parameters (coordinate offsets, probing)
 void report_ngc_parameters(Print& channel) {
     // Print persistent offsets G54 - G59, G28, and G30
     for (auto coord_select = CoordIndex::Begin; coord_select < CoordIndex::End; ++coord_select) {
-        client << '[' << coords[coord_select]->getName() << ":";
-        client << report_util_axis_values(coords[coord_select]->get());
-        client << "]\n";
+        channel << '[' << coords[coord_select]->getName() << ":";
+        report_util_axis_values(coords[coord_select]->get(), channel);
+        channel << "]\n";
     }
     // Print non-persistent G92,G92.1
-    channel << "[G92:" << report_util_axis_values(gc_state.coord_offset) << "]\n";
+    channel << "[G92:";
+    report_util_axis_values(gc_state.coord_offset, channel);
+    channel << "]\n";
     // Print tool length offset
     channel << "[TLO:";
     float tlo = gc_state.tool_length_offset;
     if (config->_reportInches) {
         tlo *= INCH_PER_MM;
     }
-    channel << String(tlo, 3) << "]\n";
+    channel << setprecision(3) << tlo << "]\n";
     report_probe_parameters(channel);
 }
 
@@ -378,10 +361,10 @@ void report_gcode_modes(Print& channel) {
     }
 
     channel << " T" << gc_state.tool;
-    // XXX WMB format according to config->_reportInches ? %.1f : %.0f
-    client << " F" << int32_t(gc_state.feed_rate);
-    client << " S" << uint32_t(gc_state.spindle_speed);
-    client << "]\n";
+    int digits = config->_reportInches ? 1 : 0;
+    channel << " F" << setprecision(digits) << gc_state.feed_rate;
+    channel << " S" << uint32_t(gc_state.spindle_speed);
+    channel << "]\n";
 }
 
 // Prints build info line
@@ -502,11 +485,14 @@ const char* state_name() {
     return "";
 }
 
-String pinString() {
-    String pins = "";
-
+static void pinString(Print& channel) {
+    bool prefixNeeded = true;
     if (config->_probe->get_state()) {
-        pins += 'P';
+        if (prefixNeeded) {
+            prefixNeeded = false;
+            channel << "|Pn:";
+        }
+        channel << 'P';
     }
 
     MotorMask lim_pin_state = limits_get_state();
@@ -514,13 +500,16 @@ String pinString() {
         auto n_axis = config->_axes->_numberAxis;
         for (int i = 0; i < n_axis; i++) {
             if (bitnum_is_true(lim_pin_state, i) || bitnum_is_true(lim_pin_state, i + 16)) {
-                pins += config->_axes->axisName(i);
+                if (prefixNeeded) {
+                    prefixNeeded = false;
+                    channel << "|Pn:";
+                }
+                channel << config->_axes->axisName(i);
             }
         }
     }
 
-    pins += config->_control->report();
-    return pins;
+    channel << config->_control->report();
 }
 
 // Prints real-time data. This function grabs a real-time snapshot of the stepper subprogram
@@ -539,7 +528,7 @@ void report_realtime_status(Print& channel) {
         channel << "|WPos:";
         mpos_to_wpos(print_position);
     }
-    channel << report_util_axis_values(print_position);
+    report_util_axis_values(print_position, channel);
 
     // Returns planner and serial read buffer states.
 #if 0
@@ -565,13 +554,9 @@ void report_realtime_status(Print& channel) {
     if (config->_reportInches) {
         rate /= MM_PER_INCH;
     }
-    // XXX WMB rate %.0f
-    client << "|FS:" << int32_t(rate) << "," << sys.spindle_speed;
+    channel << "|FS:" << setprecision(0) << rate << "," << sys.spindle_speed;
 
-    String pins = pinString();
-    if (pins.length()) {
-        channel << "|Pn:" << pins;
-    }
+    pinString(channel);
 
     if (report_wco_counter > 0) {
         report_wco_counter--;
@@ -590,7 +575,8 @@ void report_realtime_status(Print& channel) {
         if (report_ovr_counter == 0) {
             report_ovr_counter = 1;  // Set override on next report.
         }
-        channel << "|WCO:" << report_util_axis_values(get_wco());
+        channel << "|WCO:";
+        report_util_axis_values(get_wco(), channel);
     }
 
     if (report_ovr_counter > 0) {
@@ -637,8 +623,7 @@ void report_realtime_status(Print& channel) {
         }
     }
     if (infile) {
-        // XXX WMB FORMAT 4.2f
-        channel << "|SD:" << infile->percent_complete() << "," << infile->path();
+        channel << "|SD:" << setprecision(2) << infile->percent_complete() << "," << infile->path();
     }
 #ifdef DEBUG_STEPPER_ISR
     channel << "|ISRs:" << config->_stepping->isr_count;


### PR DESCRIPTION
The main approach was to eliminate the use of String(float, digits)
in favor of supporting setprecision(digits) in iostreams.