### PR TITLE
Fixed spurious speed map message

### DIFF
--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -638,19 +638,21 @@ Error do_command_or_setting(const char* key, char* value, WebUI::AuthenticationL
         config->group(rts);
 
         if (rts.isHandled_) {
-            try {
-                Configuration::Validator validator;
-                config->validate();
-                config->group(validator);
-            } catch (std::exception& ex) {
-                log_error("Validation error: " << ex.what());
-                return Error::ConfigurationInvalid;
+            if (value) {
+                // Validate only if something changed, not for display
+                try {
+                    Configuration::Validator validator;
+                    config->validate();
+                    config->group(validator);
+                } catch (std::exception& ex) {
+                    log_error("Validation error: " << ex.what());
+                    return Error::ConfigurationInvalid;
+                }
+
+                Configuration::AfterParse afterParseHandler;
+                config->afterParse();
+                config->group(afterParseHandler);
             }
-
-            Configuration::AfterParse afterParseHandler;
-            config->afterParse();
-            config->group(afterParseHandler);
-
             return Error::Ok;
         }
     } catch (const Configuration::ParseException& ex) {

--- a/FluidNC/src/Spindles/NullSpindle.cpp
+++ b/FluidNC/src/Spindles/NullSpindle.cpp
@@ -13,21 +13,20 @@
 
 namespace Spindles {
     // ======================= Null ==============================
-    // Null is just bunch of do nothing (ignore) methods to be used when you don't want a spindle
+    // Null is just a bunch of do nothing (ignore) methods to be used when you don't want a spindle
 
     void Null::init() {
         is_reversable = false;
         config_message();
-        if (_speeds.size() == 0) {
-            _speeds.push_back({ 0, 0 });
-        }
+        _speeds.clear();
     }
     void IRAM_ATTR Null::setSpeedfromISR(uint32_t dev_speed) {};
     void           Null::setState(SpindleState state, SpindleSpeed speed) {
         _current_state    = state;
         sys.spindle_speed = speed;
     }
-    void Null::config_message() { /*log_info("No spindle");*/ }
+    void Null::config_message() { /*log_info("No spindle");*/
+    }
 
     // Configuration registration
     namespace {


### PR DESCRIPTION
To repro the problem, use a no-spindle config then send $/board .
It will show  [MSG:ERR: Speed map max speed is 0. Using default]

The fix is twofold.  First, we change the displayer so it does
not run afterParse when a tree item is displayed but not changed.
Second, we fix NullSpindle so it has an empty speed map, instead
of the kind of map that results in the map being defaulted.