### PR TITLE
Move radio stuff outside try/catch

### DIFF
--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -112,14 +112,15 @@ void setup() {
             config->_probe->init();
         }
 
-        WebUI::wifi_config.begin();
-        WebUI::bt_config.begin();
-        WebUI::inputBuffer.begin();
     } catch (const AssertionFailed& ex) {
         // This means something is terribly broken:
         log_error("Critical error in main_init: " << ex.what());
         sys.state = State::ConfigAlarm;
     }
+
+    WebUI::wifi_config.begin();
+    WebUI::bt_config.begin();
+    WebUI::inputBuffer.begin();
 }
 
 static void reset_variables() {


### PR DESCRIPTION
If you have a config problem, you want the radios to still work, so the user can fix the problem easier.