### PR TITLE
Various error case cleanups

### DIFF
--- a/FluidNC/src/Configuration/Tokenizer.cpp
+++ b/FluidNC/src/Configuration/Tokenizer.cpp
@@ -13,9 +13,6 @@ namespace Configuration {
         while (!IsEndLine()) {
             Inc();
         }
-        if (Eof()) {
-            ParseError("Missing end-of-line");
-        }
     }
 
     Tokenizer::Tokenizer(const char* start, const char* end) : current_(start), end_(end), start_(start), token_() {

--- a/FluidNC/src/FileStream.cpp
+++ b/FluidNC/src/FileStream.cpp
@@ -86,6 +86,9 @@ FileStream::FileStream(const char* filename, const char* mode, const char* defau
         }
         _isSD = true;
     }
+    if (_path.startsWith(actualLocalFs) && _path.length() > (30 + strlen(actualLocalFs))) {
+        log_info("Filename too long");
+    }
     _fd = fopen(_path.c_str(), mode);
     if (!_fd) {
         throw strcmp(mode, "w") ? Error::FsFailedOpenFile : Error::FsFailedCreateFile;

--- a/FluidNC/src/Machine/MachineConfig.h
+++ b/FluidNC/src/Machine/MachineConfig.h
@@ -55,18 +55,18 @@ namespace Machine {
     public:
         MachineConfig() = default;
 
-        Axes*            _axes        = nullptr;
-        Kinematics*      _kinematics  = nullptr;
-        SPIBus*          _spi         = nullptr;
-        I2SOBus*         _i2so        = nullptr;
-        Stepping*        _stepping    = nullptr;
-        CoolantControl*  _coolant     = nullptr;
-        Probe*           _probe       = nullptr;
-        Control*         _control     = nullptr;
-        UserOutputs*     _userOutputs = nullptr;
-        SDCard*          _sdCard      = nullptr;
-        Macros*          _macros      = nullptr;
-        Start*           _start       = nullptr;
+        Axes*                 _axes        = nullptr;
+        Kinematics*           _kinematics  = nullptr;
+        SPIBus*               _spi         = nullptr;
+        I2SOBus*              _i2so        = nullptr;
+        Stepping*             _stepping    = nullptr;
+        CoolantControl*       _coolant     = nullptr;
+        Probe*                _probe       = nullptr;
+        Control*              _control     = nullptr;
+        UserOutputs*          _userOutputs = nullptr;
+        SDCard*               _sdCard      = nullptr;
+        Macros*               _macros      = nullptr;
+        Start*                _start       = nullptr;
         Spindles::SpindleList _spindles;
 
         float _arcTolerance      = 0.002f;
@@ -96,8 +96,9 @@ namespace Machine {
         void afterParse() override;
         void group(Configuration::HandlerBase& handler) override;
 
-        static size_t readFile(const char* file, char*& buffer);
-        static bool   load(const char* file);
+        static bool load();
+        static bool load(const char* file);
+        static bool load(StringRange* input);
 
         ~MachineConfig();
     };

--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -47,7 +47,8 @@ void setup() {
             log_error("Cannot mount the local filesystem");
         }
 
-        bool configOkay = config->load(config_filename->get());
+        bool configOkay = config->load();
+
         make_user_commands();
 
         if (configOkay) {


### PR DESCRIPTION
1. Do not require a newline at the end of the config file, because a lot of people make that mistake
2. Explicit error message if SPIFFS filename is too long
3. Handle configuration parse errors gracefully - load default config without rebooting first