### PR TITLE
Turn off wifi power savings in hopes of fixing GPIO36/39 problems.

### DIFF
--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -714,6 +714,7 @@ namespace WebUI {
             WiFi.onEvent(WiFiConfig::WiFiEvent);
             _events_registered = true;
         }
+        esp_wifi_set_ps(WIFI_PS_NONE);
         log_info("WiFi on");
         wifi_services.begin();
         return true;


### PR DESCRIPTION
See https://github.com/espressif/esp-idf/issues/4585 and
https://github.com/bdring/FluidNC/issues/183