### PR TITLE
Multiple probes WIP [not for pull!]

### DIFF
--- a/FluidNC/src/ControlPin.cpp
+++ b/FluidNC/src/ControlPin.cpp
@@ -5,7 +5,7 @@
 #include <esp_attr.h>        // IRAM_ATTR
 #include <esp32-hal-gpio.h>  // CHANGE
 
-void IRAM_ATTR ControlPin::handleISR() {
+void IRAM_ATTR ControlPin::handleISR(int32_t deltaTime) {
     bool pinState = _pin.read();
     _value        = pinState;
     if (pinState) {
@@ -23,7 +23,7 @@ void ControlPin::init() {
         attr = attr | Pin::Attr::PullUp;
     }
     _pin.setAttr(attr);
-    _pin.attachInterrupt<ControlPin, &ControlPin::handleISR>(this, CHANGE);
+    _pin.attachInterrupt<ControlPin, &ControlPin::handleISR>(this);
     _rtVariable = false;
     _value      = _pin.read();
     // Control pins must start in inactive state

--- a/FluidNC/src/ControlPin.h
+++ b/FluidNC/src/ControlPin.h
@@ -9,7 +9,7 @@ private:
     volatile bool& _rtVariable;
     const char*    _legend;
 
-    void handleISR();
+    void handleISR(int32_t deltaTime);
 
 public:
     ControlPin(volatile bool& rtVariable, const char* legend, char letter) :

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -318,7 +318,7 @@ Error gc_execute_line(char* line, Channel& channel) {
                                 gc_block.modal.motion = Motion::ProbeAway;
                                 break;
                             case 50:
-                                gc_block.modal.motion = Motion::ProbeAway;
+                                gc_block.modal.motion = Motion::ProbeAwayNoError;
                                 break;
                             default:
                                 FAIL(Error::GcodeUnsupportedCommand);

--- a/FluidNC/src/Machine/LimitPin.cpp
+++ b/FluidNC/src/Machine/LimitPin.cpp
@@ -44,7 +44,7 @@ namespace Machine {
         _legend = String("    " + sDir + " Limit");
     }
 
-    void IRAM_ATTR LimitPin::handleISR() {
+    void IRAM_ATTR LimitPin::handleISR(int32_t deltaTime) {
         read();
         if (sys.state != State::Alarm && sys.state != State::ConfigAlarm && sys.state != State::Homing) {
             if (_pHardLimits && rtAlarm == ExecAlarm::None) {
@@ -95,7 +95,7 @@ namespace Machine {
             attr = attr | Pin::Attr::PullUp;
         }
         _pin.setAttr(attr);
-        _pin.attachInterrupt<LimitPin, &LimitPin::handleISR>(this, CHANGE);
+        _pin.attachInterrupt<LimitPin, &LimitPin::handleISR>(this);
 
         read();
     }

--- a/FluidNC/src/Machine/LimitPin.h
+++ b/FluidNC/src/Machine/LimitPin.h
@@ -20,7 +20,7 @@ namespace Machine {
         volatile uint32_t* _posLimits = nullptr;
         volatile uint32_t* _negLimits = nullptr;
 
-        void IRAM_ATTR handleISR();
+        void IRAM_ATTR handleISR(int32_t deltaTime);
 
         void read();
 

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -360,6 +360,9 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, uint8_t par
     Stepper::reset();      // Reset step segment buffer.
     plan_reset();          // Reset planner buffer. Zero planner positions. Ensure probing motion is cleared.
     plan_sync_position();  // Sync planner position to current machine position.
+
+    config->_probe->stop_probe();
+
     if (MESSAGE_PROBE_COORDINATES) {
         // All done! Output the probe position as message.
         report_probe_parameters(allChannels);

--- a/FluidNC/src/Motors/TrinamicSpiDriver.cpp
+++ b/FluidNC/src/Motors/TrinamicSpiDriver.cpp
@@ -271,8 +271,8 @@ namespace MotorDrivers {
 
         // The bit locations differ somewhat between different chips.
         // The layout is the same for TMC2130 and TMC5160
-        TMC2130_n ::DRV_STATUS_t status { 0 };  // a useful struct to access the bits.
-        status.sr = tmc2130 ? tmc2130->DRV_STATUS() : tmc5160->DRV_STATUS();
+        // TMC2130_n ::DRV_STATUS_t status { 0 };  // a useful struct to access the bits.
+        // status.sr = tmc2130 ? tmc2130->DRV_STATUS() : tmc5160->DRV_STATUS();
 
         // these only report if there is a fault condition
         // report_open_load(status.ola, status.olb);

--- a/FluidNC/src/Motors/TrinamicUartDriver.cpp
+++ b/FluidNC/src/Motors/TrinamicUartDriver.cpp
@@ -241,8 +241,8 @@ namespace MotorDrivers {
                                 << " mm/min SG_Setting:" << constrain(_stallguard, -64, 63));
         }
 
-        TMC2208_n ::DRV_STATUS_t status { 0 };  // a useful struct to access the bits.
-        status.sr = tmc2208 ? tmc2208->DRV_STATUS() : tmc2209->DRV_STATUS();
+        // TMC2208_n ::DRV_STATUS_t status { 0 };  // a useful struct to access the bits.
+        // status.sr = tmc2208 ? tmc2208->DRV_STATUS() : tmc2209->DRV_STATUS();
 
         // these only report if there is a fault condition
         // report_open_load(status.ola, status.olb);

--- a/FluidNC/src/Pin.h
+++ b/FluidNC/src/Pin.h
@@ -38,16 +38,9 @@ class String;
 // one-stop-go-to-shop for an pin.
 class Pin {
     // Helper for handling callbacks and mapping them to the proper class:
-    template <typename ThisType, void (ThisType::*Callback)()>
+    template <typename ThisType, void (ThisType::*Callback)(int32_t)>
     struct InterruptCallbackHelper {
-        static void IRAM_ATTR callback(void* ptr) { (static_cast<ThisType*>(ptr)->*Callback)(); }
-    };
-
-    // Helper for handling callbacks and mapping them to the proper class. This one is just meant
-    // for backward compatibility:
-    template <void (*Callback)()>
-    struct InterruptCallbackHelper2 {
-        static void IRAM_ATTR callback(void* /*ptr*/) { Callback(); }
+        static void IRAM_ATTR callback(void* ptr, int32_t delta) { (static_cast<ThisType*>(ptr)->*Callback)(delta); }
     };
 
     // The undefined pin and error pin are two special pins. Error pins always throw an error when they are used.
@@ -123,13 +116,10 @@ public:
 
     // ISR handlers. Map methods on 'this' types.
 
-    template <typename ThisType, void (ThisType::*Callback)()>
-    void attachInterrupt(ThisType* arg, int mode) {
-        _detail->attachInterrupt(InterruptCallbackHelper<ThisType, Callback>::callback, arg, mode);
+    template <typename ThisType, void (ThisType::*Callback)(int32_t)>
+    void attachInterrupt(ThisType* arg) {
+        _detail->attachInterrupt(InterruptCallbackHelper<ThisType, Callback>::callback, arg);
     }
-
-    // Backward compatibility ISR handler:
-    void attachInterrupt(void (*callback)(void*), int mode, void* arg = nullptr) const { _detail->attachInterrupt(callback, arg, mode); }
 
     void detachInterrupt() const { _detail->detachInterrupt(); }
 

--- a/FluidNC/src/Pins/DebugPinDetail.cpp
+++ b/FluidNC/src/Pins/DebugPinDetail.cpp
@@ -75,24 +75,24 @@ namespace Pins {
 
     PinAttributes DebugPinDetail::getAttr() const { return _implementation->getAttr(); }
 
-    void DebugPinDetail::CallbackHandler::handle(void* arg) {
+    void DebugPinDetail::CallbackHandler::handle(void* arg, int32_t ticksDelta) {
         auto handler = static_cast<CallbackHandler*>(arg);
         if (handler->_myPin->shouldEvent()) {
             WriteSerial("Received ISR on %s", handler->_myPin->toString().c_str());
         }
-        handler->callback(handler->argument);
+        handler->callback(handler->argument, ticksDelta);
     }
 
     // ISR's:
-    void DebugPinDetail::attachInterrupt(void (*callback)(void*), void* arg, int mode) {
+    void DebugPinDetail::attachInterrupt(void (*callback)(void*, int32_t), void* arg) {
         _isrHandler._myPin   = this;
         _isrHandler.argument = arg;
         _isrHandler.callback = callback;
 
         if (shouldEvent()) {
-            WriteSerial("Attaching interrupt to pin %s, mode %d", toString().c_str(), mode);
+            WriteSerial("Attaching interrupt to pin %s", toString().c_str());
         }
-        _implementation->attachInterrupt(_isrHandler.handle, &_isrHandler, mode);
+        _implementation->attachInterrupt(_isrHandler.handle, &_isrHandler);
     }
     void DebugPinDetail::detachInterrupt() { _implementation->detachInterrupt(); }
 

--- a/FluidNC/src/Pins/DebugPinDetail.h
+++ b/FluidNC/src/Pins/DebugPinDetail.h
@@ -14,14 +14,14 @@ namespace Pins {
         bool     _isHigh;
 
         struct CallbackHandler {
-            void (*callback)(void* arg);
+            void (*callback)(void* arg, int32_t ticksDelta);
             void*           argument;
             DebugPinDetail* _myPin;
 
-            static void handle(void* arg);
+            static void handle(void* arg, int32_t ticksDelta);
         } _isrHandler;
 
-        friend void CallbackHandler::handle(void* arg);
+        friend void CallbackHandler::handle(void* arg, int32_t ticksDelta);
 
         bool shouldEvent();
 
@@ -39,7 +39,7 @@ namespace Pins {
         PinAttributes getAttr() const override;
 
         // ISR's:
-        void attachInterrupt(void (*callback)(void*), void* arg, int mode) override;
+        void attachInterrupt(void (*callback)(void*, int32_t), void* arg) override;
         void detachInterrupt() override;
 
         String toString() override { return _implementation->toString(); }

--- a/FluidNC/src/Pins/GPIOPinDetail.h
+++ b/FluidNC/src/Pins/GPIOPinDetail.h
@@ -15,6 +15,20 @@ namespace Pins {
 
         static std::vector<bool> _claimed;
 
+        using ISRCallback        = void (*)(void*, int32_t);
+        ISRCallback _isrCallback = nullptr;
+        void*       _isrArgument = nullptr;
+
+        static void IRAM_ATTR ISRCallbackHandler(void* arg) {
+            auto gpio = static_cast<GPIOPinDetail*>(arg);
+            if (gpio) {
+                auto c = gpio->_isrCallback;  // store in local to avoid thread issues
+                if (c) {
+                    (*c)(gpio->_isrArgument, 0);
+                }
+            }
+        }
+
     public:
         static const int nGPIOPins = 40;
 
@@ -23,13 +37,13 @@ namespace Pins {
         PinCapabilities capabilities() const override;
 
         // I/O:
-        void          write(int high) override;
+        void write(int high) override;
         int IRAM_ATTR read() override;
         void          setAttr(PinAttributes value) override;
         PinAttributes getAttr() const override;
 
         // ISR's:
-        void attachInterrupt(void (*callback)(void*), void* arg, int mode) override;
+        void attachInterrupt(void (*callback)(void*, int32_t), void* arg) override;
         void detachInterrupt() override;
 
         String toString() override;

--- a/FluidNC/src/Pins/PinDetail.cpp
+++ b/FluidNC/src/Pins/PinDetail.cpp
@@ -7,13 +7,14 @@
 #include <esp_attr.h>  // IRAM_ATTR
 
 namespace Pins {
-    void PinDetail::attachInterrupt(void (*callback)(void*), void* arg, int mode) {
+    void PinDetail::attachInterrupt(void (*callback)(void*, int), void* arg) {
         Assert(false, "Interrupts are not supported by pin %d", _index);
     }
+    
     void PinDetail::detachInterrupt() {
         Assert(false, "Interrupts are not supported by pin %d", _index);
-        ;
     }
+
     void IRAM_ATTR PinDetail::synchronousWrite(int high) { write(high); }
 
 }

--- a/FluidNC/src/Pins/PinDetail.h
+++ b/FluidNC/src/Pins/PinDetail.h
@@ -38,7 +38,7 @@ namespace Pins {
         virtual PinAttributes getAttr() const              = 0;
 
         // ISR's.
-        virtual void attachInterrupt(void (*callback)(void*), void* arg, int mode);
+        virtual void attachInterrupt(void (*callback)(void*, int), void* arg);
         virtual void detachInterrupt();
 
         virtual String toString() = 0;

--- a/FluidNC/src/Probe.cpp
+++ b/FluidNC/src/Probe.cpp
@@ -23,6 +23,21 @@ void IRAM_ATTR Probe::tripProbe(Probe* userData, int32_t tickDelta) {
 
 void Probe::set_direction(bool is_away) {
     _isProbeAway = is_away;
+
+    for (auto it : _probes) {
+        // We have to think this over properly!!! Check all? Check some? What if some
+        // thing tripped that was not in the vector?
+        if (it->start_cycle(is_away)) {
+            // put in vector?
+        }
+    }
+}
+
+void Probe::stop_probe() {
+    for (auto it : _probes) {
+        // We have to think this over properly!!!
+        it->stop_cycle();
+    }
 }
 
 // Returns the probe pin state. Triggered = true. Called by gcode parser.
@@ -34,6 +49,10 @@ bool Probe::get_state() {
 // This function must be extremely efficient as to not bog down the stepper ISR.
 // Should be called only in situations where the probe pin is known to be defined.
 bool IRAM_ATTR Probe::tripped() {
+    // TODO: Trip index instead of just 'tripped'? Makes sense, see 'set_direction' above.
+    // Or do we just want to trigger 'tripped' if anything changes? That's actually quite 
+    // simple...
+
     return _probeTripped ^ _isProbeAway;
 }
 

--- a/FluidNC/src/Probe.cpp
+++ b/FluidNC/src/Probe.cpp
@@ -10,14 +10,15 @@
 void Probe::init() {
     static bool show_init_msg = true;  // used to show message only once.
 
-    if (_probePin.defined()) {
-        _probePin.setAttr(Pin::Attr::Input);
-
-        if (show_init_msg) {
-            _probePin.report("Probe Pin:");
-            show_init_msg = false;
-        }
+    for (auto it : _probes) {
+        Probes::TripProbe ptr = &Probe::tripProbe;
+        it->init(ptr, this);
     }
+}
+
+void IRAM_ATTR Probe::tripProbe(Probe* userData, int32_t tickDelta) {
+    auto p           = static_cast<Probe*>(userData);
+    p->_probeTripped = true;
 }
 
 void Probe::set_direction(bool is_away) {
@@ -26,19 +27,24 @@ void Probe::set_direction(bool is_away) {
 
 // Returns the probe pin state. Triggered = true. Called by gcode parser.
 bool Probe::get_state() {
-    return _probePin.read();
+    return _probeTripped;
 }
 
 // Returns true if the probe pin is tripped, accounting for the direction (away or not).
 // This function must be extremely efficient as to not bog down the stepper ISR.
 // Should be called only in situations where the probe pin is known to be defined.
 bool IRAM_ATTR Probe::tripped() {
-    return _probePin.read() ^ _isProbeAway;
+    return _probeTripped ^ _isProbeAway;
 }
 
-void Probe::validate() const {}
+void Probe::validate() const {
+    for (auto it : _probes) {
+        it->validate();
+    }
+}
 
 void Probe::group(Configuration::HandlerBase& handler) {
-    handler.item("pin", _probePin);
-    handler.item("check_mode_start", _check_mode_start);
+    Probes::ProbeFactory::factory(handler, _probes);
+
+    handler.item("check_mode_start", _check_mode_start);  // TODO FIXME
 }

--- a/FluidNC/src/Probe.h
+++ b/FluidNC/src/Probe.h
@@ -43,6 +43,8 @@ public:
     // setup probing direction G38.2 vs. G38.4
     void set_direction(bool is_away);
 
+    void stop_probe();
+
     // Returns probe pin state. Triggered = true. Called by gcode parser and probe state monitor.
     bool get_state();
 

--- a/FluidNC/src/Probe.h
+++ b/FluidNC/src/Probe.h
@@ -6,6 +6,7 @@
 
 #include "Configuration/HandlerBase.h"
 #include "Configuration/Configurable.h"
+#include "Probes/ProbeDriver.h"
 
 #include <cstdint>
 
@@ -15,23 +16,26 @@ enum class ProbeState : uint8_t {
     Active = 1,  // Actively watching the input pin.
 };
 
+using ProbeList = std::vector<Probes::ProbeDriver*>;
+
 class Probe : public Configuration::Configurable {
     // Inverts the probe pin state depending on user settings and probing cycle mode.
-    bool _isProbeAway = false;
+    volatile bool _isProbeAway  = false;
+    volatile bool _probeTripped = false;
 
-    // Configurable
-    Pin _probePin;
+    ProbeList _probes;
 
 public:
     // Configurable
     bool _check_mode_start = true;
+
     // _check_mode_start configures the position after a probing cycle
     // during check mode. false sets the position to the probe target,
     // true sets the position to the start position.
 
     Probe() = default;
 
-    bool exists() const { return _probePin.defined(); }
+    bool exists() const { return !_probes.empty(); }
 
     // Probe pin initialization routine.
     void init();
@@ -44,6 +48,8 @@ public:
 
     // Returns true if the probe pin is tripped, depending on the direction (away or not)
     bool IRAM_ATTR tripped();
+
+    static void IRAM_ATTR tripProbe(Probe* userData, int32_t tickDelta);
 
     // Configuration handlers.
     void validate() const override;

--- a/FluidNC/src/Probes/ProbeDriver.cpp
+++ b/FluidNC/src/Probes/ProbeDriver.cpp
@@ -1,0 +1,12 @@
+#include "ProbeDriver.h"
+
+namespace Probes {
+    void IRAM_ATTR ProbeDriver::tripISR(int32_t tickDelta) { (*callback_)(tickDelta); }
+
+    String ProbeDriver::probeName() const { return probeName_; }
+
+    void ProbeDriver::init(TripProbe* callback) { callback_ = callback; }
+    void IRAM_ATTR ProbeDriver::trip(int32_t tickDelta) { (*callback_)(tickDelta); }
+
+    ProbeDriver::~ProbeDriver() {}
+}

--- a/FluidNC/src/Probes/ProbeDriver.cpp
+++ b/FluidNC/src/Probes/ProbeDriver.cpp
@@ -1,12 +1,15 @@
 #include "ProbeDriver.h"
 
 namespace Probes {
-    void IRAM_ATTR ProbeDriver::tripISR(int32_t tickDelta) { (*callback_)(tickDelta); }
+    void IRAM_ATTR ProbeDriver::tripISR(int32_t tickDelta) { (*callback_)(callbackUserData_, tickDelta); }
 
     String ProbeDriver::probeName() const { return probeName_; }
 
-    void ProbeDriver::init(TripProbe* callback) { callback_ = callback; }
-    void IRAM_ATTR ProbeDriver::trip(int32_t tickDelta) { (*callback_)(tickDelta); }
+    void ProbeDriver::init(TripProbe callback, Probe* userData) {
+        callback_         = callback;
+        callbackUserData_ = userData;
+    }
+    void IRAM_ATTR ProbeDriver::trip(int32_t tickDelta) { (*callback_)(callbackUserData_, tickDelta); }
 
     ProbeDriver::~ProbeDriver() {}
 }

--- a/FluidNC/src/Probes/ProbeDriver.h
+++ b/FluidNC/src/Probes/ProbeDriver.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/FluidNC/src/Probes/ProbeDriver.h
+++ b/FluidNC/src/Probes/ProbeDriver.h
@@ -14,13 +14,16 @@
 #include <WString.h>   // String
 #include <esp_attr.h>  // IRAM_ATTR
 
+class Probe;
+
 namespace Probes {
-    using TripProbe = void (*)(int32_t tickDelta);
+    using TripProbe = void (*)(Probe* userData, int32_t tickDelta);
 
     class ProbeDriver : public Configuration::Configurable {
     protected:
-        String     probeName_;
-        TripProbe* callback_ = nullptr;
+        String    probeName_;
+        TripProbe callback_         = nullptr;
+        Probe*    callbackUserData_ = nullptr;
 
     public:
         ProbeDriver()                     = default;
@@ -34,7 +37,7 @@ namespace Probes {
 
         virtual const char* name() const = 0;
 
-        virtual void init(TripProbe* callback);
+        virtual void init(TripProbe callback, Probe* userData);
         virtual void start_cycle() = 0;
         virtual void stop_cycle()  = 0;
         virtual bool is_tripped()  = 0;

--- a/FluidNC/src/Probes/ProbeDriver.h
+++ b/FluidNC/src/Probes/ProbeDriver.h
@@ -38,7 +38,7 @@ namespace Probes {
         virtual const char* name() const = 0;
 
         virtual void init(TripProbe callback, Probe* userData);
-        virtual void start_cycle() = 0;
+        virtual bool start_cycle(bool away) = 0;
         virtual void stop_cycle()  = 0;
         virtual bool is_tripped()  = 0;
 

--- a/FluidNC/src/Probes/ProbeDriver.h
+++ b/FluidNC/src/Probes/ProbeDriver.h
@@ -1,1 +1,48 @@
+// Copyright (c) 2021 -	Stefan de Bruijn
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
 #pragma once
+
+#include "../Config.h"
+#include "../Assert.h"
+#include "../Configuration/GenericFactory.h"
+#include "../Configuration/HandlerBase.h"
+#include "../Configuration/Configurable.h"
+#include "../Pin.h"
+
+#include <cstdint>     // int32_t
+#include <WString.h>   // String
+#include <esp_attr.h>  // IRAM_ATTR
+
+namespace Probes {
+    using TripProbe = void (*)(int32_t tickDelta);
+
+    class ProbeDriver : public Configuration::Configurable {
+    protected:
+        String     probeName_;
+        TripProbe* callback_ = nullptr;
+
+    public:
+        ProbeDriver()                     = default;
+        ProbeDriver(const ProbeDriver& o) = delete;
+        ProbeDriver(ProbeDriver&& o)      = delete;
+
+        // ISR function. Should not be used directly.
+        void IRAM_ATTR tripISR(int32_t tickDelta);
+
+        String probeName() const;
+
+        virtual const char* name() const = 0;
+
+        virtual void init(TripProbe* callback);
+        virtual void start_cycle() = 0;
+        virtual void stop_cycle()  = 0;
+        virtual bool is_tripped()  = 0;
+
+        void IRAM_ATTR trip(int32_t tickDelta);
+
+        virtual ~ProbeDriver();
+    };
+
+    using ProbeFactory = Configuration::GenericFactory<ProbeDriver>;
+}

--- a/FluidNC/src/Probes/SimpleProbe.h
+++ b/FluidNC/src/Probes/SimpleProbe.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2021 -	Stefan de Bruijn
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "../Config.h"
+#include "../Assert.h"
+#include "../Configuration/GenericFactory.h"
+#include "../Configuration/HandlerBase.h"
+#include "../Configuration/Configurable.h"
+#include "../Pin.h"
+
+#include <cstdint>     // int32_t
+#include <WString.h>   // String
+#include <esp_attr.h>  // IRAM_ATTR
+
+namespace Probes {
+    using TripProbe = void IRAM_ATTR (*)(int32_t tickDelta);
+
+    class ProbeDriver : public Configuration::Configurable {
+    protected:
+        String     probeName_;
+        TripProbe* callback_ = nullptr;
+
+        void IRAM_ATTR tripISR() { callback_(0); }
+
+    public:
+        ProbeDriver()                     = default;
+        ProbeDriver(const ProbeDriver& o) = delete;
+        ProbeDriver(ProbeDriver&& o)      = delete;
+
+        String probeName() const { return probeName_; }
+
+        virtual const char* name() const = 0;
+
+        virtual void init(TripProbe* callback) { callback_ = callback; }
+        virtual void start_cycle() = 0;
+        virtual void stop_cycle()  = 0;
+        virtual bool is_tripped()  = 0;
+
+        void IRAM_ATTR trip(int32_t tickDelta) { callback_(tickDelta); }
+
+        virtual ~ProbeDriver() {}
+    };
+
+    using ProbeFactory = Configuration::GenericFactory<ProbeDriver>;
+
+    class SimpleProbe : public ProbeDriver {
+        Pin _probePin;
+
+    public:
+        const char* name() const override { return "simple_probe"; }
+
+        void validate() const override {}
+        void group(Configuration::HandlerBase& handler) override {
+            handler.item("pin", _probePin);
+            handler.item("check_mode_start", _check_mode_start);
+        }
+
+        void init(TripProbe* callback) {
+            ProbeDriver::init(callback);
+            _probePin.attachInterrupt<SimpleProbe, &SimpleProbe::tripISR>(this, CHANGE);
+        }
+        void start_cycle() {}
+        void stop_cycle() {}
+        bool is_tripped() { return _probePin.read(); }
+
+        ~SimpleProbe() {}
+    };
+
+    class ToolSetter : public SimpleProbe {
+        // TODO: Soft limits; we need the tool setter height to calculate the soft limit
+        float _height;
+
+    public:
+        const char* name() const override { return "tool_setter"; }
+
+        // Configuration handlers:
+        void validate() const override { SimpleProbe::validate(handler); }
+        void group(Configuration::HandlerBase& handler) override {
+            SimpleProbe::group(handler);
+            handler.item("tool_setter_height", _height);
+        }
+
+        void init(TripProbe* callback) { SimpleProbe::init(callback); }
+        void start_cycle() {
+            // TODO FIXME: reset soft limits to original
+        }
+        void stop_cycle() {
+            // TODO FIXME: set soft limits with height
+        }
+
+        bool is_tripped() { return _probePin.read(); }
+
+        ~ToolSetter() {}
+    };
+
+    class BLTouch : public SimpleProbe {
+        // servo pwm config
+
+    public:
+        const char* name() const override { return "bl_touch"; }
+
+        // Configuration handlers:
+        void validate() const override { SimpleProbe::validate(handler); }
+        void group(Configuration::HandlerBase& handler) override {
+            SimpleProbe::group(handler);
+            // pwm config
+        }
+
+        void init(TripProbe* callback) {
+            SimpleProbe::init(callback);
+
+            // init servo to 0
+        }
+        void start_cycle() {
+            // set servo to 1
+        }
+        void stop_cycle() {
+            // set servo to 0
+        }
+        bool is_tripped() { return _probePin.read(); }
+
+        ~BLTouch() {}
+    };
+
+}

--- a/FluidNC/src/Probes/SimpleProbe.h
+++ b/FluidNC/src/Probes/SimpleProbe.h
@@ -14,7 +14,7 @@ namespace Probes {
         void validate() const override;
         void group(Configuration::HandlerBase& handler) override;
 
-        void init(TripProbe* callback);
+        void init(TripProbe callback);
         void start_cycle();
         void stop_cycle();
         bool is_tripped();

--- a/FluidNC/src/Probes/SimpleProbe.h
+++ b/FluidNC/src/Probes/SimpleProbe.h
@@ -15,7 +15,7 @@ namespace Probes {
         void group(Configuration::HandlerBase& handler) override;
 
         void init(TripProbe callback);
-        void start_cycle();
+        bool start_cycle(bool away);
         void stop_cycle();
         bool is_tripped();
 

--- a/FluidNC/src/Probes/SimpleProve.cpp
+++ b/FluidNC/src/Probes/SimpleProve.cpp
@@ -1,0 +1,25 @@
+#include "SimpleProbe.h"
+
+namespace Probes {
+    const char* SimpleProbe::name() const { return "simple_probe"; }
+
+    void SimpleProbe::validate() const {}
+    void SimpleProbe::group(Configuration::HandlerBase& handler) {
+        handler.item("pin", _probePin);
+        handler.item("check_mode_start", _checkModeStart);
+    }
+
+    void SimpleProbe::init(TripProbe* callback) {
+        ProbeDriver::init(callback);
+        _probePin.attachInterrupt<ProbeDriver, &ProbeDriver::tripISR>(this);
+    }
+
+    void SimpleProbe::start_cycle() {}
+    void SimpleProbe::stop_cycle() {}
+    bool SimpleProbe::is_tripped() { return _probePin.read(); }
+
+    // Configuration registration
+    namespace {
+        ProbeFactory::InstanceBuilder<SimpleProbe> registration("simple_probe");
+    }
+}

--- a/FluidNC/src/Probes/SimpleProve.cpp
+++ b/FluidNC/src/Probes/SimpleProve.cpp
@@ -9,8 +9,17 @@ namespace Probes {
         handler.item("check_mode_start", _checkModeStart);
     }
 
-    void SimpleProbe::init(TripProbe* callback) {
-        ProbeDriver::init(callback);
+    void SimpleProbe::init(TripProbe callback) {
+        if (_probePin.defined()) {
+            _probePin.setAttr(Pin::Attr::Input);
+        }
+
+        // if (show_init_msg) {
+        //     _probePin.report("Probe Pin:");
+        //     show_init_msg = false;
+        // }
+
+        ProbeDriver::init(callback, callbackUserData_);
         _probePin.attachInterrupt<ProbeDriver, &ProbeDriver::tripISR>(this);
     }
 

--- a/FluidNC/src/Probes/SimpleProve.cpp
+++ b/FluidNC/src/Probes/SimpleProve.cpp
@@ -23,7 +23,11 @@ namespace Probes {
         _probePin.attachInterrupt<ProbeDriver, &ProbeDriver::tripISR>(this);
     }
 
-    void SimpleProbe::start_cycle() {}
+    bool SimpleProbe::start_cycle(bool away) { 
+        // away should be !is_tripped -- or we have an issue.
+        return is_tripped() != away;
+
+    }
     void SimpleProbe::stop_cycle() {}
     bool SimpleProbe::is_tripped() { return _probePin.read(); }
 

--- a/FluidNC/src/Probes/ToolSetter.cpp
+++ b/FluidNC/src/Probes/ToolSetter.cpp
@@ -1,0 +1,31 @@
+#include "ToolSetter.h"
+
+namespace Probes {
+    const char* ToolSetter::name() const { return "tool_setter"; }
+
+    // Configuration handlers:
+    void ToolSetter::validate() const { SimpleProbe::validate(); }
+    void ToolSetter::group(Configuration::HandlerBase& handler) {
+        SimpleProbe::group(handler);
+        handler.item("tool_setter_height", _height);
+    }
+
+    void ToolSetter::init(TripProbe* callback) { SimpleProbe::init(callback); }
+    void ToolSetter::start_cycle() {
+        // TODO FIXME: reset soft limits to original
+        SimpleProbe::start_cycle();
+    }
+    void ToolSetter::stop_cycle() {
+        SimpleProbe::stop_cycle();
+        // TODO FIXME: set soft limits with height
+    }
+
+    bool ToolSetter::is_tripped() { return _probePin.read(); }
+
+    ToolSetter::~ToolSetter() {}
+
+    // Configuration registration
+    namespace {
+        ProbeFactory::InstanceBuilder<ToolSetter> registration("tool_setter");
+    }
+}

--- a/FluidNC/src/Probes/ToolSetter.cpp
+++ b/FluidNC/src/Probes/ToolSetter.cpp
@@ -10,7 +10,7 @@ namespace Probes {
         handler.item("tool_setter_height", _height);
     }
 
-    void ToolSetter::init(TripProbe* callback) { SimpleProbe::init(callback); }
+    void ToolSetter::init(TripProbe callback) { SimpleProbe::init(callback); }
     void ToolSetter::start_cycle() {
         // TODO FIXME: reset soft limits to original
         SimpleProbe::start_cycle();

--- a/FluidNC/src/Probes/ToolSetter.cpp
+++ b/FluidNC/src/Probes/ToolSetter.cpp
@@ -11,9 +11,9 @@ namespace Probes {
     }
 
     void ToolSetter::init(TripProbe callback) { SimpleProbe::init(callback); }
-    void ToolSetter::start_cycle() {
+    bool ToolSetter::start_cycle(bool away) {
         // TODO FIXME: reset soft limits to original
-        SimpleProbe::start_cycle();
+        SimpleProbe::start_cycle(away);
     }
     void ToolSetter::stop_cycle() {
         SimpleProbe::stop_cycle();

--- a/FluidNC/src/Probes/ToolSetter.h
+++ b/FluidNC/src/Probes/ToolSetter.h
@@ -14,7 +14,7 @@ namespace Probes {
         void validate() const override;
         void group(Configuration::HandlerBase& handler) override;
 
-        void init(TripProbe* callback);
+        void init(TripProbe callback);
         void start_cycle();
         void stop_cycle();
         bool is_tripped();

--- a/FluidNC/src/Probes/ToolSetter.h
+++ b/FluidNC/src/Probes/ToolSetter.h
@@ -15,7 +15,7 @@ namespace Probes {
         void group(Configuration::HandlerBase& handler) override;
 
         void init(TripProbe callback);
-        void start_cycle();
+        bool start_cycle(bool away);
         void stop_cycle();
         bool is_tripped();
 

--- a/FluidNC/src/Probes/ToolSetter.h
+++ b/FluidNC/src/Probes/ToolSetter.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include "ProbeDriver.h"
+#include "SimpleProbe.h"
 
 namespace Probes {
-    class SimpleProbe : public ProbeDriver {
-    protected:
-        Pin _probePin;
-        bool _checkModeStart;
+    class ToolSetter : public SimpleProbe {
+        // TODO: Soft limits; we need the tool setter height to calculate the soft limit
+        float _height;
 
     public:
         const char* name() const override;
 
+        // Configuration handlers:
         void validate() const override;
         void group(Configuration::HandlerBase& handler) override;
 
@@ -19,6 +19,6 @@ namespace Probes {
         void stop_cycle();
         bool is_tripped();
 
-        ~SimpleProbe() override {}
+        ~ToolSetter() override;
     };
 }


### PR DESCRIPTION
WIP for support of multiple probes. Basically the idea is to have multiple probes in the 'probes' section. The probes combined just work like the old probe functionality.

The API of ISR's was changed to make future changes easier with timing / debouncing. The only ISR that is being used is the 'change' ISR, which now is the only ISR in the pin class. Other ISR's are just irrelevant. For probing this is especially important, because the exact moment of the ISR has to be captured (and not the time when the ISR was resolved into the precise pin - which is the case for f.ex. pin extenders and more advanced probes like BLTouch). 

For now, only the SimpleProbe is implemented. Tool setter is a simple probe for now.