### PR TITLE
Fix typos and invalid pin assignments in MKS example.

### DIFF
--- a/example_configs/MKS_DLC32_2_ABC.yaml
+++ b/example_configs/MKS_DLC32_2_ABC.yaml
@@ -33,7 +33,7 @@ axes:
       hard_limits: false
       pulloff_mm:1.000
       stepstick:
-        step_pin:  is2o.1
+        step_pin:  i2so.1
         direction_pin: I2SO.2
 
   y:
@@ -99,7 +99,7 @@ spi:
   sck_pin: gpio.14
 
 sdcard:
-  card_detect_pin: gpio.39
+  card_detect_pin: NO_PIN
   cs_pin: gpio.15
 
 probe:


### PR DESCRIPTION
Resolving typos as described in #246 
