### PR TITLE
TMCStepper library microstep strangeness

### DIFF
--- a/FluidNC/src/Motors/TrinamicSpiDriver.cpp
+++ b/FluidNC/src/Motors/TrinamicSpiDriver.cpp
@@ -168,11 +168,14 @@ namespace MotorDrivers {
             }
         }
 
+
+	// The TMCStepper library uses the value 0 to mean 1x microstepping
+	int usteps = _microsteps == 1 ? 0 : _microsteps;
         if (tmc2130) {
-            tmc2130->microsteps(_microsteps);
+            tmc2130->microsteps(usteps);
             tmc2130->rms_current(run_i_ma, hold_i_percent);
         } else {
-            tmc5160->microsteps(_microsteps);
+            tmc5160->microsteps(usteps);
             tmc5160->rms_current(run_i_ma, hold_i_percent);
         }
     }

--- a/FluidNC/src/Motors/TrinamicUartDriver.cpp
+++ b/FluidNC/src/Motors/TrinamicUartDriver.cpp
@@ -163,11 +163,13 @@ namespace MotorDrivers {
             }
         }
 
-        if (tmc2208) {
-            tmc2208->microsteps(_microsteps);
+	// The TMCStepper library uses the value 0 to mean 1x microstepping
+	int usteps = _microsteps == 1 ? 0 : _microsteps;
+	if (tmc2208) {
+            tmc2208->microsteps(usteps);
             tmc2208->rms_current(run_i_ma, hold_i_percent);
         } else {
-            tmc2209->microsteps(_microsteps);
+            tmc2209->microsteps(usteps);
             tmc2209->rms_current(run_i_ma, hold_i_percent);
         }
     }


### PR DESCRIPTION
This lets you says microsteps: 1  for Trinamic (0 also works).  For some obscure reason, the TMCStepper uses the value 0 to mean 1.  This code compiles but has not been tested on Trinamic hardware.