### PR TITLE
Cancel pending stepper disable on wake_up

### DIFF
--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -502,8 +502,6 @@ static void protocol_do_initiate_cycle() {
         sys.state         = State::Cycle;
         Stepper::prep_buffer();  // Initialize step segment buffer before beginning cycle.
         Stepper::wake_up();
-        // Make sure the steppers can't be scheduled for a shutdown while this cycle is running.
-        protocol_cancel_disable_steppers();
     } else {                    // Otherwise, do nothing. Set and resume IDLE state.
         sys.suspend.value = 0;  // Break suspend state.
         sys.state         = State::Idle;

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -36,6 +36,7 @@ void protocol_buffer_synchronize();
 
 // Disables the stepper motors or schedules it to happen
 void protocol_disable_steppers();
+void protocol_cancel_disable_steppers();
 
 extern volatile bool rtStatusReport;
 extern volatile bool rtCycleStart;

--- a/FluidNC/src/Stepper.cpp
+++ b/FluidNC/src/Stepper.cpp
@@ -302,6 +302,8 @@ void IRAM_ATTR Stepper::pulse_func() {
 // enabled. Startup init and limits call this function but shouldn't start the cycle.
 void Stepper::wake_up() {
     //log_info("st_wake_up");
+    // Cancel any pending stepper disable
+    protocol_cancel_disable_steppers();
     // Enable stepper drivers.
     config->_axes->set_disable(false);
 


### PR DESCRIPTION
Fixes #259 

Here is what I think was happening.  With /stepping/idle_ms=250, issue a series of short jogs using e.g. "$J=G91 G21 F1000 Y-1" with very brief pauses between them.  Depending on the timing, it is possible that one of the jogs completes and the system sets the idle timer.  Before the timer expires, another jog command comes in and calls Stepper::wake_up().  That turns on the enable (it was already on) but does not cancel the timer.  The motion starts, but before it is complete the timer expires and turns off the enable, thus stopping the motion even though the stepping engine is still doing its thing.

The solution is to have Stepper::wake_up() always cancel the idle timer.  The timer will be restarted when the stepping engine has finished the motion.
