### PR TITLE
Fix isr templates

### DIFF
--- a/FluidNC/src/ControlPin.cpp
+++ b/FluidNC/src/ControlPin.cpp
@@ -23,9 +23,9 @@ void ControlPin::init() {
         attr = attr | Pin::Attr::PullUp;
     }
     _pin.setAttr(attr);
-    _pin.attachInterrupt<ControlPin, &ControlPin::handleISR>(this, CHANGE);
+    _pin.attachInterrupt(ISRHandler, CHANGE, this);
     _rtVariable = false;
-    _value      = _pin.read();
+    _value                            = _pin.read();
     // Control pins must start in inactive state
     if (_value) {
         log_error(_legend << " pin is active at startup");

--- a/FluidNC/src/ControlPin.h
+++ b/FluidNC/src/ControlPin.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Pin.h"
+#include <esp_attr.h>  // IRAM_ATTR
 
 class ControlPin {
 private:
@@ -9,7 +10,8 @@ private:
     volatile bool& _rtVariable;
     const char*    _legend;
 
-    void handleISR();
+    void IRAM_ATTR handleISR();
+    CreateISRHandlerFor(ControlPin, handleISR);
 
 public:
     ControlPin(volatile bool& rtVariable, const char* legend, char letter) :

--- a/FluidNC/src/Machine/LimitPin.cpp
+++ b/FluidNC/src/Machine/LimitPin.cpp
@@ -95,7 +95,7 @@ namespace Machine {
             attr = attr | Pin::Attr::PullUp;
         }
         _pin.setAttr(attr);
-        _pin.attachInterrupt<LimitPin, &LimitPin::handleISR>(this, CHANGE);
+        _pin.attachInterrupt(ISRHandler, CHANGE, this);
 
         read();
     }

--- a/FluidNC/src/Machine/LimitPin.h
+++ b/FluidNC/src/Machine/LimitPin.h
@@ -22,6 +22,8 @@ namespace Machine {
 
         void IRAM_ATTR handleISR();
 
+        CreateISRHandlerFor(LimitPin, handleISR);
+
         void read();
 
     public:
@@ -33,7 +35,7 @@ namespace Machine {
 
         void init();
         bool get() { return _value; }
-        void makeDualMask(); // makes this a mask for motor0 and motor1
+        void makeDualMask();  // makes this a mask for motor0 and motor1
 
         ~LimitPin();
     };


### PR DESCRIPTION
Apparently templates are not compiled in IRAM, even though they are marked as such. After more investigation this seems to be an issue in GCC, which totally ignores the section attributes when they are in a template.

That leaves us with not many options left... I basically got rid of the template by using a `#define` until we can somehow device a better solution.