### PR TITLE
Update Homing.cpp

### DIFF
--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -285,12 +285,10 @@ namespace Machine {
         try {
             if (squaredOneSwitch(motors)) {
                 //log_info("POG Squaring");
-                run(motors, true, true);             // Approach slowly
-                run(motors, false, false);           // Pulloff
-                run(motors & MOTOR0, true, false);   // Approach slowly
-                run(motors & MOTOR0, false, false);  // Pulloff
-                run(motors & MOTOR1, true, false);   // Approach slowly
-                run(motors & MOTOR1, false, false);  // Pulloff
+                run(motors, true, true);    // Approach slowly
+                run(motors, false, false);  // Pulloff
+                run(motors, true, false);   // Approach slowly
+                run(motors, false, false);  // Pulloff
             } else if (squaredStressfree(motors)) {
                 //log_info("Stress Free Squaring 0x" << String(motors, 16));
                 run(motors, true, true);    // Approach fast


### PR DESCRIPTION
This fixes single switch, dual motor homing.

 - 2 inputs = stress free homing
 - 1 input = homes like a single motor axis.


[Discord fluidnc_help](https://discord.com/channels/780079161460916227/882732763126583326/939719418131386379)
[Discord fluidnc_dev](https://discord.com/channels/780079161460916227/805613138916802570/940277086227136552)