### PR TITLE
Fixed timing-dependent hang with M5

### DIFF
--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -235,9 +235,9 @@ void protocol_main_loop() {
 // Block until all buffered steps are executed or in a cycle state. Works with feed hold
 // during a synchronize call, if it should happen. Also, waits for clean cycle end.
 void protocol_buffer_synchronize() {
-    // If system is queued, ensure cycle resumes if the auto start flag is present.
-    protocol_auto_cycle_start();
     do {
+        // Restart motion if there are blocks in the planner queue
+        protocol_auto_cycle_start();
         pollChannels();
         protocol_execute_realtime();  // Check and execute run-time commands
         if (sys.abort) {


### PR DESCRIPTION
Under hard-to-predict conditions, M5 will hang the system.  Here is the analysis:

```c++
void protocol_auto_cycle_start() {
    if (plan_get_current_block() != NULL) {  // Check if there are any blocks in the buffer.
        rtCycleStart = true;                 // If so, execute them!
    }
}
void protocol_buffer_synchronize() {
    // If system is queued, ensure cycle resumes if the auto start flag is present.
    protocol_auto_cycle_start();
    do {
        pollChannels();
        protocol_execute_realtime();  // Check and execute run-time commands
        if (sys.abort) {
            return;  // Check for system abort
        }
    } while (plan_get_current_block() || (sys.state == State::Cycle));
}
```
Before the loop, protocol_auto_cycle_start() is called to make things run if there is anything in the planner.
Then the stepper runs and, if the segment is short, it might just finish with it by the time protocol_execute_realtime() is called, and if so, protocol_execute_realtime will see the rtCycleStop and set state to Idle.
The while will not exit the loop because plan_get_current_block() is still returning non-null, i.e. there are some planner blocks left.  But since we are in idle state, there is no way to run them.
If you move the protocol_auto_cycle_start() inside the loop, it works.