### PR TITLE
Fixed limits, jogging, and mpos setting

### DIFF
--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -263,19 +263,12 @@ namespace Machine {
 
         // Set machine positions for homed limit switches. Don't update non-homed axes.
         for (int axis = 0; axis < n_axis; axis++) {
-            Machine::Axis* axisConf = config->_axes->_axis[axis];
-            auto           homing   = axisConf->_homing;
-
             if (bitnum_is_true(axisMask, axis)) {
-                auto mpos    = homing->_mpos;
-                auto pulloff = axisConf->_motors[0]->_pulloff;
-
-                mpos += homing->_positiveDirection ? -pulloff : pulloff;
-                motor_steps[axis] = mpos_to_steps(mpos, axis);
+                motor_steps[axis] = mpos_to_steps(axes->_axis[axis]->_homing->_mpos, axis);
             }
         }
-        sys.step_control = {};                            // Return step control to normal operation.
-        config->_axes->set_homing_mode(axisMask, false);  // tell motors homing is done
+        sys.step_control = {};                   // Return step control to normal operation.
+        axes->set_homing_mode(axisMask, false);  // tell motors homing is done
     }
 
     void Homing::run_one_cycle(AxisMask axisMask) {

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -103,6 +103,7 @@ void mc_cancel_jog() {
 // unless invert_feed_rate is true. Then the feed_rate means that the motion should be completed in
 // (1 minute)/feed_rate time.
 bool mc_linear(float* target, plan_line_data_t* pl_data, float* position) {
+    limits_soft_check(target);
     return config->_kinematics->cartesian_to_motors(target, pl_data, position);
 }
 


### PR DESCRIPTION
This is a breaking change for machine configurations.

Previously, the homing pulloff value was considered to be inside the machine travel envelope, so with positive_direction:false, mpos_mm:0, max_travel_mm:200, after homing the position is 3 and the travel ranges from 3..200

Now. the pulloff is outside the envelope, so with those same settings, after homing the position is 0 and the travel ranges from 0..200

Doing it this way simplifies various calculations that were error-prone.  We think that this new way is easier to understand.

The down side is that you will might need to update your configuration.