### PR TITLE
Dual function reset and cycle_start pins

### DIFF
--- a/FluidNC/src/Control.cpp
+++ b/FluidNC/src/Control.cpp
@@ -22,6 +22,8 @@ void Control::init() {
 }
 
 void Control::group(Configuration::HandlerBase& handler) {
+    handler.item("enable_dual_mode_reset_pin", _dual_mode_reset); // reset button becomes a "feedhold button" if active state is "Cycle" or "Jog"
+    handler.item("enable_dual_mode_cycle_start_pin", _dual_mode_cycle_start); // cycle_start button becomes an "unlock button" if active state is "Alarm"
     handler.item("safety_door_pin", _safetyDoor._pin);
     handler.item("reset_pin", _reset._pin);
     handler.item("feed_hold_pin", _feedHold._pin);

--- a/FluidNC/src/Control.h
+++ b/FluidNC/src/Control.h
@@ -20,6 +20,10 @@ public:
     ControlPin _macro3;
 
 public:
+    // Configurable
+    bool _dual_mode_reset = false;
+    bool _dual_mode_cycle_start = false;
+    
     Control();
 
     // Initializes control pins.

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -761,8 +761,8 @@ void protocol_exec_rt_system() {
 #endif
     if (rtReset) {
         if (config->_control->_dual_mode_reset && (sys.state == State::Cycle || sys.state == State::Jog)) {
-            rtFeedHold = true;
             rtReset = false;
+            protocol_do_feedhold();
         } else {
             if (sys.state == State::Homing) {
                 rtAlarm = ExecAlarm::HomingFailReset;
@@ -798,6 +798,9 @@ void protocol_exec_rt_system() {
     if (rtCycleStart) {
         if(config->_control->_dual_mode_cycle_start && (sys.state == State::Alarm)) {
             rtCycleStart = false;
+            if (config->_control->stuck()) {
+                mc_reset();
+            } 
             report_feedback_message(Message::AlarmUnlock);
             sys.state = State::Idle;
         } else {


### PR DESCRIPTION

Allows dual functions for reset and cycle_start pins:

If "control/dual_mode_reset_pin" is true in config file, then reset_pin will act as feedhold when active state is "Cycle" or "Jog". Otherwise the original reset behaviour will be used). To completely kill a running cycle or jog, just press reset twice and state will change from Cycle/Jog->Hold->Idle. I think this is a good option because there will be a "soft stop" (feedhold) whenever possible, and a "hard stop" (reset) when required (for instance when homing or probing).

If "control/dual_mode_cycle_start_pin" is true in config file, then cycle_start_pin will act as an unlock pin when state is Alarm. Otherwise the original behaviour of cycle_start_pin will be used). This is very useful: no need to go to the UI to unlock and Alarm, and it does so without using a precious input pin / button.

https://github.com/bdring/FluidNC/issues/301#issue-1140223180