### PR TITLE
Fixed Feedhold after Soft Limit

### DIFF
--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -101,6 +101,7 @@ bool can_park() {
 
 void protocol_reset() {
     probeState                = ProbeState::Off;
+    soft_limit                = false;
     rtStatusReport            = false;
     rtCycleStart              = false;
     rtFeedHold                = false;


### PR DESCRIPTION
If you trigger a soft limit, then issue a feedhold while running
a program, the system goes into Hold state but does not stop moving.

Reported on Discord by Jürgen H.

To repro:
1. Soft limits must be enabled in the config
2. Home the machine
3. Issue a movement command that would trigger a soft limit
4. Unblock the system with ^X then $X
5. Run a program
6. Issue ! to pause the program
7. Issue ? ? ? to observe that motion continues

The problem was caused by not clearing the soft_limits variable in reset_variables().  POG clears the variable, but in one of our code rearrangements that was inadvertently omitted.