### PR TITLE
Using map of minimum speed in ramp increments' computations.

### DIFF
--- a/FluidNC/src/Spindles/PWMSpindle.cpp
+++ b/FluidNC/src/Spindles/PWMSpindle.cpp
@@ -57,10 +57,10 @@ namespace Spindles {
                 _use_pwm_ramping = false;
             } else {
                 // TODO: Do we want to deal with a min speed?
-                _ramp_up_dev_increment   = mapSpeed(maxSpeed()) / (_spinup_ms / _ramp_interval);
-                _ramp_down_dev_increment = mapSpeed(maxSpeed()) / (_spindown_ms / _ramp_interval);
-                //log_info("PWM Ramping Maxspeed:" << maxSpeed() << " spinup incr:" << _ramp_up_dev_increment
-                                                 //<< " spindown incr:" << _ramp_down_dev_increment);
+                _ramp_up_dev_increment   = (mapSpeed(maxSpeed()) - mapSpeed(minSpeed())) / (_spinup_ms / _ramp_interval);
+                _ramp_down_dev_increment = (mapSpeed(maxSpeed()) - mapSpeed(minSpeed())) / (_spindown_ms / _ramp_interval);
+                // log_info("PWM Ramping Maxspeed:" << maxSpeed() << " spinup incr:" << _ramp_up_dev_increment
+                //                                  << " spindown incr:" << _ramp_down_dev_increment);
             }
         }
 
@@ -194,7 +194,7 @@ namespace Spindles {
         uint32_t next_duty   = _current_duty;  // this is the value that increments in this function
         bool     spinup      = (target_duty > _current_duty);
 
-        //log_info("Ramp duty from:" << _current_duty << " to:" << target_duty);
+        // log_info("Ramp duty from:" << _current_duty << " to:" << target_duty);
 
         while ((spinup && next_duty < target_duty) || (!spinup && (next_duty > target_duty))) {
             if (spinup) {
@@ -210,7 +210,7 @@ namespace Spindles {
                     next_duty = target_duty;
                 }
             }
-
+            
             set_output(next_duty);
             _current_duty = next_duty;
             if (next_duty == target_duty) {

--- a/FluidNC/src/Spindles/Spindle.h
+++ b/FluidNC/src/Spindles/Spindle.h
@@ -30,6 +30,7 @@ namespace Spindles {
         bool     _defaultedSpeeds;
         uint32_t offSpeed() { return _speeds[0].offset; }
         uint32_t maxSpeed() { return _speeds[_speeds.size() - 1].speed; }
+        uint32_t minSpeed() { return _speeds[0].speed; }
         uint32_t mapSpeed(SpindleSpeed speed);
         void     setupSpeeds(uint32_t max_dev_speed);
         void     shelfSpeeds(SpindleSpeed min, SpindleSpeed max);


### PR DESCRIPTION
Hi!
Doing a bit of tests changing the configurations, we realized that the ramp intervals did not take in account the minimum speed.
When 'speed_map: 0' is not 0, the ramp intervals were larger then what we expected, so less intervals were needed to do a ramp and less time passed respect to the spinup_ms/spindown_ms.

Moreover, we noticed two additional things:

1) when the 'speed_map: 0' is not 0, during the initial connection the spin ramps up from zero to the minimum speed value
2) we tried to change "spinup_ms" and "spindown_ms" by terminal, and the value changed but were not really applied until when we re-uploaded the config file.