### PR TITLE
WIP

### DIFF
--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -1258,7 +1258,7 @@ Error gc_execute_line(char* line, Channel& channel) {
                     //   an error, it issues an alarm to prevent further motion to the probe. It's also done there to
                     //   allow the planner buffer to empty and move off the probe trigger before another probing cycle.
                     if (bitnum_is_true(value_words, GCodeWord::P)) {
-                        if (popcount(axis_words) > 1) {     // There should only be one axis word given
+                        if (multiple_bits_set(axis_words)) {  // There should only be one axis word given
                             FAIL(Error::GcodeUnusedWords);  // we have more axis words than allowed.
                         }
                     } else {

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -1257,6 +1257,15 @@ Error gc_execute_line(char* line, Channel& channel) {
                     //   is undefined. Probe is triggered. NOTE: Probe check moved to probe cycle. Instead of returning
                     //   an error, it issues an alarm to prevent further motion to the probe. It's also done there to
                     //   allow the planner buffer to empty and move off the probe trigger before another probing cycle.
+                    if (bitnum_is_true(value_words, GCodeWord::P)) {
+                        if (popcount(axis_words) > 1) {     // There should only be one axis word given
+                            FAIL(Error::GcodeUnusedWords);  // we have more axis words than allowed.
+                        }
+                    } else {
+                        gc_block.values.p = __FLT_MAX__;  // This is a hack to signal the probe cycle that not to auto offset.
+                    }
+                    clear_bitnum(value_words, GCodeWord::P);  // allow P to be used
+
                     if (!axis_words) {
                         FAIL(Error::GcodeNoAxisWords);  // [No axis words]
                     }
@@ -1575,7 +1584,7 @@ Error gc_execute_line(char* line, Channel& channel) {
                 if (!ALLOW_FEED_OVERRIDE_DURING_PROBE_CYCLES) {
                     pl_data->motion.noFeedOverride = 1;
                 }
-                gc_update_pos = mc_probe_cycle(gc_block.values.xyz, pl_data, gc_parser_flags);
+                gc_update_pos = mc_probe_cycle(gc_block.values.xyz, pl_data, gc_parser_flags, axis_words, gc_block.values.p);
             }
             // As far as the parser is concerned, the position is now == target. In reality the
             // motion control system might still be processing the action and the real tool position

--- a/FluidNC/src/MotionControl.h
+++ b/FluidNC/src/MotionControl.h
@@ -50,7 +50,7 @@ bool mc_dwell(int32_t milliseconds);
 void mc_homing_cycle(AxisMask cycle_mask);
 
 // Perform tool length probe cycle. Requires probe switch.
-GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, uint8_t parser_flags);
+GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, uint8_t parser_flags, uint8_t offsetAxis = 0, float offset = 0.0);
 
 // Handles updating the override control state.
 void mc_override_ctrl_update(Override override_state);

--- a/FluidNC/src/NutsBolts.cpp
+++ b/FluidNC/src/NutsBolts.cpp
@@ -197,6 +197,17 @@ char* trim(char* str) {
     return str;
 }
 
+// Count the number of bits that are on.
+uint8_t popcount(uint32_t val) {  // TODO Is there a built in function for this. Tried all the usual ones.
+    uint8_t count = 0;
+    for (int i = 0; i < 32; i++) {
+        if (bitnum_is_true(val, i)) {
+            count++;
+        }
+    }
+    return count;
+}
+
 String formatBytes(uint64_t bytes) {
     if (bytes < 1024) {
         return String((uint16_t)bytes) + " B";

--- a/FluidNC/src/NutsBolts.cpp
+++ b/FluidNC/src/NutsBolts.cpp
@@ -197,15 +197,12 @@ char* trim(char* str) {
     return str;
 }
 
-// Count the number of bits that are on.
-uint8_t popcount(uint32_t val) {  // TODO Is there a built in function for this. Tried all the usual ones.
-    uint8_t count = 0;
-    for (int i = 0; i < 32; i++) {
-        if (bitnum_is_true(val, i)) {
-            count++;
-        }
-    }
-    return count;
+bool multiple_bits_set(uint32_t val) {
+    // Takes advantage of a quirk of twos-complement math.  If a number has
+    // only one bit set, for example 0b1000, then subtracting 1 will clear that
+    // bit and set only other bits giving e.g. 0b0111, and anding the two gives 0.
+    // If multiple bits are set, subtracting 1 will not clear the high bit.
+    return val & (val - 1);
 }
 
 String formatBytes(uint64_t bytes) {

--- a/FluidNC/src/NutsBolts.h
+++ b/FluidNC/src/NutsBolts.h
@@ -168,6 +168,6 @@ bool constrain_with_message(T& value, T min, T max) {
     return true;
 }
 
-uint8_t popcount(uint32_t val);
+bool multiple_bits_set(uint32_t val);
 
 String formatBytes(uint64_t bytes);

--- a/FluidNC/src/NutsBolts.h
+++ b/FluidNC/src/NutsBolts.h
@@ -168,4 +168,6 @@ bool constrain_with_message(T& value, T min, T max) {
     return true;
 }
 
+uint8_t popcount(uint32_t val);
+
 String formatBytes(uint64_t bytes);

--- a/FluidNC/src/SDCard.cpp
+++ b/FluidNC/src/SDCard.cpp
@@ -94,7 +94,7 @@ void SDCard::init() {
                 _cardDetect.report("SD Card Detect");
                 init_message = false;
             }
-            log_info("SD Card cs_pin:" << _cs.name() << " dectect:" << _cardDetect.name());
+            log_info("SD Card cs_pin:" << _cs.name() << " detect:" << _cardDetect.name());
         }
     }
 


### PR DESCRIPTION
Add an optional "P" parameter that specifies the thickness (or offset from 0) of the probe device.

Upon successful probe the offset of the current system is zeroed with the P value applied. This will make it much easier for displays and senders to deal with probing. Most people trying to roll their own probe UI are doing a very bad job of it. This should not adversely affect any existing senders because the parameter is new and optional.

G38.2 G91 F80 Z-20 P8.00