### PR TITLE
Spi index range constrain

### DIFF
--- a/FluidNC/src/Configuration/ParserHandler.h
+++ b/FluidNC/src/Configuration/ParserHandler.h
@@ -102,7 +102,7 @@ namespace Configuration {
         void item(const char* name, int32_t& value, int32_t minValue, int32_t maxValue) override {
             if (_parser.is(name)) {
                 value = _parser.intValue();
-                constrain_with_message(value, minValue, maxValue);
+                constrain_with_message(value, minValue, maxValue, name);
             }
         }
 
@@ -121,7 +121,7 @@ namespace Configuration {
         void item(const char* name, float& value, float minValue, float maxValue) override {
             if (_parser.is(name)) {
                 value = _parser.floatValue();
-                constrain_with_message(value, minValue, maxValue);
+                constrain_with_message(value, minValue, maxValue, name);
             }
         }
 

--- a/FluidNC/src/Motors/TrinamicSpiDriver.h
+++ b/FluidNC/src/Motors/TrinamicSpiDriver.h
@@ -89,7 +89,7 @@ namespace MotorDrivers {
 
         void group(Configuration::HandlerBase& handler) override {
             handler.item("cs_pin", _cs_pin);
-            handler.item("spi_index", _spi_index);
+            handler.item("spi_index", _spi_index, -1, 127);
             TrinamicBase::group(handler);
         }
 

--- a/FluidNC/src/NutsBolts.h
+++ b/FluidNC/src/NutsBolts.h
@@ -159,9 +159,9 @@ T mapConstrain(T x, T in_min, T in_max, T out_min, T out_max) {
 
 // constrain a value and issue a message. Returns true is the value was OK
 template <typename T>
-bool constrain_with_message(T& value, T min, T max) {
+bool constrain_with_message(T& value, T min, T max, const char* name = "") {
     if (value < min || value > max) {
-        log_warn("Value " << value << " constrained to range (" << min << "," << max << ")");
+        log_warn(name << " value " << value << " constrained to range (" << min << "," << max << ")");
         value = myConstrain(value, min, max);
         return false;
     }


### PR DESCRIPTION
Not having a defined range is causing it to use 0 to (big number). It actually should be -1 to 127.