### PR TITLE
Added HBridge Spindle type

### DIFF
--- a/FluidNC/src/Spindles/HBridgeSpindle.cpp
+++ b/FluidNC/src/Spindles/HBridgeSpindle.cpp
@@ -1,22 +1,12 @@
 // Copyright (c) 2022 -	Santiago Palomino
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
 
-/*
-    This is a full featured TTL PWM spindle This does not include speed/power
-    compensation. Use the Laser class for that.
-*/
 #include "HBridgeSpindle.h"
 
 #include "../GCode.h"  // gc_state.modal
 #include "../Logging.h"
 #include "../Pins/LedcPin.h"
 #include <esp32-hal-ledc.h>  // ledcDetachPin
-
-// ======================= PWM ==============================
-/*
-    This gets called at startup or whenever a spindle setting changes
-    If the spindle is running it will stop and need to be restarted with M3Snnnn
-*/
 
 namespace Spindles {
     void HBridgeSpindle::init() {
@@ -95,9 +85,8 @@ namespace Spindles {
         if (state == SpindleState::Disable) {  // Halt or set spindle direction and speed.
             dev_speed = 0;
         } else {
-            // PWM: this could wreak havoc if the direction is changed without first
-            // spinning down. But it looks like the framework is stopping the motor
-            // before changing direction M4 is not accepted during M3 if M5 is not run first.
+            // The core is responsible for stopping the motor before changing
+            // direction
             if (state == SpindleState::Cw || state == SpindleState::Ccw) {}
         }
         _state = state;

--- a/FluidNC/src/Spindles/HBridgeSpindle.cpp
+++ b/FluidNC/src/Spindles/HBridgeSpindle.cpp
@@ -93,9 +93,7 @@ namespace Spindles {
         // sys.spindle_speed correctly.
         uint32_t dev_speed = mapSpeed(speed);
         if (state == SpindleState::Disable) {  // Halt or set spindle direction and speed.
-            if (_zero_speed_with_disable) {
-                dev_speed = offSpeed();
-            }
+            dev_speed = 0;
         } else {
             // PWM: this could wreak havoc if the direction is changed without first
             // spinning down. But it looks like the framework is stopping the motor
@@ -157,8 +155,8 @@ namespace Spindles {
             ledcSetDuty(_pwm_ccw_chan_num, 0);
             ledcSetDuty(_pwm_cw_chan_num, duty);
         } else {  // M5
-            ledcSetDuty(_pwm_cw_chan_num, duty);
-            ledcSetDuty(_pwm_ccw_chan_num, duty);
+            ledcSetDuty(_pwm_cw_chan_num, 0);
+            ledcSetDuty(_pwm_ccw_chan_num, 0);
         }
     }
 

--- a/FluidNC/src/Spindles/HBridgeSpindle.cpp
+++ b/FluidNC/src/Spindles/HBridgeSpindle.cpp
@@ -1,0 +1,196 @@
+// Copyright (c) 2022 -	Santiago Palomino
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+/*
+    This is a full featured TTL PWM spindle This does not include speed/power
+    compensation. Use the Laser class for that.
+*/
+#include "HBridgeSpindle.h"
+
+#include "../GCode.h"  // gc_state.modal
+#include "../Logging.h"
+#include "../Pins/LedcPin.h"
+#include <esp32-hal-ledc.h>  // ledcDetachPin
+
+// ======================= PWM ==============================
+/*
+    This gets called at startup or whenever a spindle setting changes
+    If the spindle is running it will stop and need to be restarted with M3Snnnn
+*/
+
+namespace Spindles {
+    void HBridgeSpindle::init() {
+        get_pins_and_settings();
+        setupSpeeds(_pwm_freq);
+
+        if (_output_a_pin.defined()) {
+            if (_output_a_pin.capabilities().has(Pin::Capabilities::PWM)) {
+                auto outputNative = _output_a_pin.getNative(Pin::Capabilities::PWM);
+                _pwm_a_chan_num     = ledcInit(_output_a_pin, -1, (double)_pwm_freq, _pwm_precision);
+            } else {
+                log_error(name() << " output A pin " << _output_a_pin.name().c_str() << " cannot do PWM");
+            }
+        } else {
+            log_error(name() << " output A pin not defined");
+        }
+
+        if (_output_b_pin.defined()) {
+            if (_output_b_pin.capabilities().has(Pin::Capabilities::PWM)) {
+                auto outputBNative = _output_b_pin.getNative(Pin::Capabilities::PWM);
+                _pwm_b_chan_num     = ledcInit(_output_b_pin, -1, (double)_pwm_freq, _pwm_precision);
+            } else {
+                log_error(name() << " output B pin " << _output_b_pin.name().c_str() << " cannot do PWM");
+            }
+        } else {
+            log_info(name() << " no output B pin defined (Only Clockwise support)");
+        }
+
+        _current_state    = SpindleState::Disable;
+        _current_pwm_duty = 0;
+        _enable_pin.setAttr(Pin::Attr::Output);
+
+        if (_speeds.size() == 0) {
+            // The default speed map for a PWM spindle is linear from 0=0% to 10000=100%
+            linearSpeeds(10000, 100.0f);
+        }
+        setupSpeeds(_pwm_period);
+        config_message();
+    }
+
+    // Get the GPIO from the machine definition
+    void HBridgeSpindle::get_pins_and_settings() {
+        // setup all the pins
+
+         is_reversable = _output_b_pin.defined();
+
+        _pwm_precision = calc_pwm_precision(_pwm_freq);  // determine the best precision
+        _pwm_period    = (1 << _pwm_precision);
+    }
+
+    void IRAM_ATTR HBridgeSpindle::set_enable(bool enable) {
+        if (_disable_with_zero_speed && sys.spindle_speed == 0) {
+            enable = false;
+        }
+
+        _enable_pin.synchronousWrite(enable);
+    }
+
+    void IRAM_ATTR HBridgeSpindle::setSpeedfromISR(uint32_t dev_speed) {
+        set_enable(gc_state.modal.spindle != SpindleState::Disable);
+        set_output(dev_speed);
+    }
+
+    void HBridgeSpindle::setState(SpindleState state, SpindleSpeed speed) {
+        if (sys.abort) {
+            return;  // Block during abort.
+        }
+
+        if (!_output_a_pin.defined()) {
+            log_warn(name() << " spindle output_pin not defined");
+        }
+
+        // We always use mapSpeed() with the unmodified input speed so it sets
+        // sys.spindle_speed correctly.
+        uint32_t dev_speed = mapSpeed(speed);
+        if (state == SpindleState::Disable) {  // Halt or set spindle direction and speed.
+            if (_zero_speed_with_disable) {
+                dev_speed = offSpeed();
+            }
+        } else {
+            // PWM: this could wreak havoc if the direction is changed without first
+            // spinning down. But it looks like the framework is stopping the motor
+            // before changing direction M4 is not accepted during M3 if M5 is not run first.
+            if (state == SpindleState::Cw || state == SpindleState::Ccw) {
+	    }
+        }
+	_state = state;
+
+        // rate adjusted spindles (laser) in M4 set power via the stepper engine, not here
+
+        // set_output must go first because of the way enable is used for level
+        // converters on some boards.
+
+        if (isRateAdjusted() && (state == SpindleState::Ccw)) {
+            dev_speed = offSpeed();
+            set_output(dev_speed);
+        } else {
+            set_output(dev_speed);
+        }
+
+        set_enable(state != SpindleState::Disable);
+        spindleDelay(state, speed);
+    }
+
+    // prints the startup message of the spindle config
+    void HBridgeSpindle::config_message() {
+        log_info(name() << " Spindle Ena:" << _enable_pin.name()
+            << " OutA:" << _output_a_pin.name() <<  " OutB:" << _output_b_pin.name()
+            << " Freq:" << _pwm_freq << "Hz Res:" << _pwm_precision << "bits"
+
+        );
+    }
+
+  void IRAM_ATTR HBridgeSpindle::set_output(uint32_t duty) {
+        if (_pwm_a_chan_num == -1) {
+            return;
+        }
+
+        // to prevent excessive calls to ledcSetDuty, make sure duty has changed
+        if (duty == _current_pwm_duty) {
+            return;
+        }
+
+        _current_pwm_duty = duty;
+	if (_output_b_pin.defined()) {
+	  if (_state == SpindleState::Cw) {
+	    ledcSetDuty(_pwm_a_chan_num, 0);
+	    ledcSetDuty(_pwm_b_chan_num, duty);
+	  }
+	  else if (_state == SpindleState::Ccw) {
+
+	    ledcSetDuty(_pwm_b_chan_num, 0);
+	    ledcSetDuty(_pwm_a_chan_num, duty);
+	  }
+	}
+	else {
+	  ledcSetDuty(_pwm_a_chan_num, duty);
+	}
+    }
+
+    // Calculate the highest PWM precision in bits for the desired frequency
+    // 80,000,000 (APB Clock) = freq * maxCount
+    // maxCount is a power of two between 2^1 and 2^20
+    // frequency is at most 80,000,000 / 2^1 = 40,000,000, limited elsewhere
+    // to 20,000,000 to give a period of at least 2^2 = 4 levels of control.
+    uint8_t HBridgeSpindle::calc_pwm_precision(uint32_t freq) {
+        if (freq == 0) {
+            freq = 1;  // Limited elsewhere but just to be safe...
+        }
+
+        // Increase the precision (bits) until it exceeds the frequency
+        // The hardware maximum precision is 20 bits
+        const uint8_t  ledcMaxBits = 20;
+        const uint32_t apbFreq     = 80000000;
+        const uint32_t maxCount    = apbFreq / freq;
+        for (uint8_t bits = 2; bits <= ledcMaxBits; ++bits) {
+            if ((1u << bits) > maxCount) {
+                return bits - 1;
+            }
+        }
+        return ledcMaxBits;
+    }
+
+    void HBridgeSpindle::deinit() {
+        stop();
+        ledcDetachPin(_output_a_pin.getNative(Pin::Capabilities::PWM));
+        ledcDetachPin(_output_b_pin.getNative(Pin::Capabilities::PWM));
+        _output_a_pin.setAttr(Pin::Attr::Input);
+        _output_b_pin.setAttr(Pin::Attr::Input);
+        _enable_pin.setAttr(Pin::Attr::Input);
+    }
+
+    // Configuration registration
+    namespace {
+        SpindleFactory::InstanceBuilder<HBridgeSpindle> registration("HBridgeSpindle");
+    }
+}

--- a/FluidNC/src/Spindles/HBridgeSpindle.cpp
+++ b/FluidNC/src/Spindles/HBridgeSpindle.cpp
@@ -9,7 +9,7 @@
 #include <esp32-hal-ledc.h>  // ledcDetachPin
 
 namespace Spindles {
-    void HBridgeSpindle::init() {
+    void HBridge::init() {
         get_pins_and_settings();
         setupSpeeds(_pwm_freq);
 
@@ -48,7 +48,7 @@ namespace Spindles {
     }
 
     // Get the GPIO from the machine definition
-    void HBridgeSpindle::get_pins_and_settings() {
+    void HBridge::get_pins_and_settings() {
         // setup all the pins
 
         is_reversable = _output_ccw_pin.defined();
@@ -57,7 +57,7 @@ namespace Spindles {
         _pwm_period    = (1 << _pwm_precision);
     }
 
-    void IRAM_ATTR HBridgeSpindle::set_enable(bool enable) {
+    void IRAM_ATTR HBridge::set_enable(bool enable) {
         if (_disable_with_zero_speed && sys.spindle_speed == 0) {
             enable = false;
         }
@@ -65,12 +65,12 @@ namespace Spindles {
         _enable_pin.synchronousWrite(enable);
     }
 
-    void IRAM_ATTR HBridgeSpindle::setSpeedfromISR(uint32_t dev_speed) {
+    void IRAM_ATTR HBridge::setSpeedfromISR(uint32_t dev_speed) {
         set_enable(gc_state.modal.spindle != SpindleState::Disable);
         set_output(dev_speed);
     }
 
-    void HBridgeSpindle::setState(SpindleState state, SpindleSpeed speed) {
+    void HBridge::setState(SpindleState state, SpindleSpeed speed) {
         if (sys.abort) {
             return;  // Block during abort.
         }
@@ -112,14 +112,14 @@ namespace Spindles {
     }
 
     // prints the startup message of the spindle config
-    void HBridgeSpindle::config_message() {
+    void HBridge::config_message() {
         log_info(name() << " Spindle Ena:" << _enable_pin.name() << " Out CW:" << _output_cw_pin.name()
                         << " Out CCW:" << _output_ccw_pin.name() << " Freq:" << _pwm_freq << "Hz Res:" << _pwm_precision << "bits"
 
         );
     }
 
-    void IRAM_ATTR HBridgeSpindle::set_output(uint32_t duty) {
+    void IRAM_ATTR HBridge::set_output(uint32_t duty) {
         if (_pwm_cw_chan_num == -1 || _pwm_cw_chan_num == -1) {
             return;
         }
@@ -150,7 +150,7 @@ namespace Spindles {
     // maxCount is a power of two between 2^1 and 2^20
     // frequency is at most 80,000,000 / 2^1 = 40,000,000, limited elsewhere
     // to 20,000,000 to give a period of at least 2^2 = 4 levels of control.
-    uint8_t HBridgeSpindle::calc_pwm_precision(uint32_t freq) {
+    uint8_t HBridge::calc_pwm_precision(uint32_t freq) {
         if (freq == 0) {
             freq = 1;  // Limited elsewhere but just to be safe...
         }
@@ -168,7 +168,7 @@ namespace Spindles {
         return ledcMaxBits;
     }
 
-    void HBridgeSpindle::deinit() {
+    void HBridge::deinit() {
         stop();
         ledcDetachPin(_output_cw_pin.getNative(Pin::Capabilities::PWM));
         ledcDetachPin(_output_ccw_pin.getNative(Pin::Capabilities::PWM));
@@ -179,6 +179,6 @@ namespace Spindles {
 
     // Configuration registration
     namespace {
-        SpindleFactory::InstanceBuilder<HBridgeSpindle> registration("HBridgeSpindle");
+        SpindleFactory::InstanceBuilder<HBridge> registration("HBridge");
     }
 }

--- a/FluidNC/src/Spindles/HBridgeSpindle.cpp
+++ b/FluidNC/src/Spindles/HBridgeSpindle.cpp
@@ -120,8 +120,6 @@ namespace Spindles {
 
         set_enable(state != SpindleState::Disable);
         spindleDelay(state, speed);
-
-        log_info("Dev speed:" << dev_speed);
     }
 
     // prints the startup message of the spindle config
@@ -141,8 +139,6 @@ namespace Spindles {
         if (duty == _current_pwm_duty && !_duty_update_needed) {
             return;
         }
-
-        log_info("Duty:" << duty);
 
         _duty_update_needed = false;
 

--- a/FluidNC/src/Spindles/HBridgeSpindle.h
+++ b/FluidNC/src/Spindles/HBridgeSpindle.h
@@ -4,15 +4,21 @@
 #pragma once
 
 /*
-	This is a full PWM spindle driver without speed compensation for an H Bridge controller
+	This is a PWM spindle driver without speed compensation for a full H-Bridge controller
    with support for two directions. The external HW has the following PINS:
      enable_pin : optional.
-     output_a_pin : Clockwise PWM signal
-     output_b_pin : Counter Clockwise PWM signal
-     When the output A is toggling, B is set LOW, and viceversa.
+     output_cw_pin : Clockwise PWM signal
+     output_ccw_pin : Counter Clockwise PWM signal
+     When the output CW is toggling, CCW is set LOW, and viceversa.
 
      Features which could be added afterwards:
-     # Soft start to prevent unnecessary current spikes on the spindle supply. The spindleDelay function seems to be a way to delay the application from using a spindle which has not accelerated yet. A similar feature could be added completing or replacing that functionality for this spindle type.
+
+     Soft start to prevent unnecessary current spikes on the spindle power
+     supply. The spindleDelay function seems to be a way to delay the
+     application from using a spindle which has not accelerated yet. A similar
+     feature could be added completing or replacing that functionality for
+     this spindle type, or for all spindles.
+
 
 */
 
@@ -82,10 +88,8 @@ namespace Spindles {
         // _disable_with_zero_speed forces a disable when speed is 0
         bool _disable_with_zero_speed = false;
 
-        // The parent class does not support a reverse pin
-        // Reverse pin is intended for HW in which two PWM outputs are needed
-        // Clock wise is achieved setting PWM on the output_pin and LOW reverse_pin.
-        // CClock wise is achieved setting PWM on the reverse pin and LOW on output_pin
+        // Clockwise is achieved setting PWM on the output_pin and LOW reverse_pin.
+        // Counter Clockwise is achieved setting PWM on the reverse pin and LOW on output_pin
         Pin _enable_pin;
         Pin _output_cw_pin;
         Pin _output_ccw_pin;

--- a/FluidNC/src/Spindles/HBridgeSpindle.h
+++ b/FluidNC/src/Spindles/HBridgeSpindle.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2022 -	Santiago Palomino
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#pragma once
+
+/*
+	This is a full PWM spindle driver without speed compensation for an H Bridge controller
+   with support for two directions. The external HW has the following PINS:
+     enable_pin : optional.
+     output_a_pin : Clockwise PWM signal
+     output_b_pin : Counter Clockwise PWM signal
+     When the output A is toggling, B is set LOW, and viceversa.
+
+     Features which could be added afterwards:
+     # Soft start to prevent unnecessary current spikes on the spindle supply. The spindleDelay function seems to be a way to delay the application from using a spindle which has not accelerated yet. A similar feature could be added completing or replacing that functionality for this spindle type.
+
+*/
+
+#include "Spindle.h"
+
+#include <cstdint>
+
+namespace Spindles {
+    // This adds support for PWM H-Bridge Spindles
+    class HBridgeSpindle : public Spindle {
+    public:
+        HBridgeSpindle() = default;
+
+        // PWM(Pin&& output, Pin&& enable, Pin&& direction, uint32_t minRpm, uint32_t maxRpm) :
+        //     _min_rpm(minRpm), _max_rpm(maxRpm), _output_pin(std::move(output)), _enable_pin(std::move(enable)),
+        //     _direction_pin(std::move(direction)) {}
+
+        HBridgeSpindle(const HBridgeSpindle&) = delete;
+        HBridgeSpindle(HBridgeSpindle&&)      = delete;
+        HBridgeSpindle& operator=(const HBridgeSpindle&) = delete;
+        HBridgeSpindle& operator=(HBridgeSpindle&&) = delete;
+
+        void init() override;
+        void setSpeedfromISR(uint32_t dev_speed) override;
+        void setState(SpindleState state, SpindleSpeed speed) override;
+        void config_message() override;
+        // Configuration handlers:
+        void validate() const override { Spindle::validate(); }
+
+        void group(Configuration::HandlerBase& handler) override {
+            // The APB clock frequency is 80MHz and the maximum divisor
+            // is 2^10.  The maximum precision is 2^20. 80MHz/2^(20+10)
+            // is 0.075 Hz, or one cycle in 13.4 seconds.  We cannot
+            // represent that in an integer so we set the minimum
+            // frequency to 1 Hz.  Frequencies of 76 Hz or less use
+            // the full 20 bit resolution, 77 to 152 Hz uses 19 bits,
+            // 153 to 305 uses 18 bits, ...
+            // At the other end, the minimum useful precision is 2^2
+            // or 4 levels of control, so the max is 80MHz/2^2 = 20MHz.
+            // Those might not be practical for many CNC applications,
+            // but the ESP32 hardware can handle them, so we let the
+            // user choose.
+            handler.item("pwm_hz", _pwm_freq, 1, 20000000);
+	    handler.item("output_a_pin", _output_a_pin);
+	    handler.item("output_b_pin", _output_b_pin);
+            handler.item("enable_pin", _enable_pin);
+            handler.item("disable_with_s0", _disable_with_zero_speed);
+            handler.item("s0_with_disable", _zero_speed_with_disable);
+
+            Spindle::group(handler);
+        }
+
+        // Name of the configurable. Must match the name registered in the cpp file.
+        const char* name() const override { return "HBridgeSpindle"; }
+
+        virtual ~HBridgeSpindle() {}
+
+    protected:
+      // TODO: A/B rename
+        int32_t  _current_pwm_duty;
+        int      _pwm_a_chan_num = -1;
+        int      _pwm_b_chan_num = -1;
+        uint32_t _pwm_period;     // how many counts in 1 period
+        uint8_t  _pwm_precision;  // auto calculated
+
+        // _disable_with_zero_speed forces a disable when speed is 0
+        bool _disable_with_zero_speed = false;
+        // _zero_speed_with_disable forces speed to 0 when disabled
+        bool _zero_speed_with_disable = true;
+
+        // The parent class does not support a reverse pin
+        // Reverse pin is intended for HW in which two PWM outputs are needed
+        // Clock wise is achieved setting PWM on the output_pin and LOW reverse_pin.
+        // CClock wise is achieved setting PWM on the reverse pin and LOW on output_pin
+        Pin _enable_pin;
+        Pin _output_a_pin;
+        Pin _output_b_pin;
+
+        // Configurable
+        uint32_t _pwm_freq = 5000;
+        SpindleState _state;
+        void set_enable(bool enable);
+
+        void         set_output(uint32_t duty);
+        virtual void deinit();
+
+        virtual void get_pins_and_settings();
+        uint8_t      calc_pwm_precision(uint32_t freq);
+    };
+}

--- a/FluidNC/src/Spindles/HBridgeSpindle.h
+++ b/FluidNC/src/Spindles/HBridgeSpindle.h
@@ -60,7 +60,6 @@ namespace Spindles {
             handler.item("output_ccw_pin", _output_ccw_pin);
             handler.item("enable_pin", _enable_pin);
             handler.item("disable_with_s0", _disable_with_zero_speed);
-            handler.item("s0_with_disable", _zero_speed_with_disable);
 
             Spindle::group(handler);
         }
@@ -82,8 +81,6 @@ namespace Spindles {
 
         // _disable_with_zero_speed forces a disable when speed is 0
         bool _disable_with_zero_speed = false;
-        // _zero_speed_with_disable forces speed to 0 when disabled
-        bool _zero_speed_with_disable = true;
 
         // The parent class does not support a reverse pin
         // Reverse pin is intended for HW in which two PWM outputs are needed

--- a/FluidNC/src/Spindles/HBridgeSpindle.h
+++ b/FluidNC/src/Spindles/HBridgeSpindle.h
@@ -56,8 +56,8 @@ namespace Spindles {
             // but the ESP32 hardware can handle them, so we let the
             // user choose.
             handler.item("pwm_hz", _pwm_freq, 1, 20000000);
-	    handler.item("output_a_pin", _output_a_pin);
-	    handler.item("output_b_pin", _output_b_pin);
+            handler.item("output_cw_pin", _output_cw_pin);
+            handler.item("output_ccw_pin", _output_ccw_pin);
             handler.item("enable_pin", _enable_pin);
             handler.item("disable_with_s0", _disable_with_zero_speed);
             handler.item("s0_with_disable", _zero_speed_with_disable);
@@ -71,12 +71,14 @@ namespace Spindles {
         virtual ~HBridgeSpindle() {}
 
     protected:
-      // TODO: A/B rename
-        int32_t  _current_pwm_duty;
-        int      _pwm_a_chan_num = -1;
-        int      _pwm_b_chan_num = -1;
-        uint32_t _pwm_period;     // how many counts in 1 period
-        uint8_t  _pwm_precision;  // auto calculated
+        // TODO: A/B rename
+        int32_t      _current_pwm_duty;
+        SpindleState _current_state    = SpindleState::Unknown;
+        int          _pwm_cw_chan_num  = -1;
+        int          _pwm_ccw_chan_num = -1;
+        uint32_t     _pwm_period;     // how many counts in 1 period
+        uint8_t      _pwm_precision;  // auto calculated
+        bool         _duty_update_needed = false;
 
         // _disable_with_zero_speed forces a disable when speed is 0
         bool _disable_with_zero_speed = false;
@@ -88,13 +90,13 @@ namespace Spindles {
         // Clock wise is achieved setting PWM on the output_pin and LOW reverse_pin.
         // CClock wise is achieved setting PWM on the reverse pin and LOW on output_pin
         Pin _enable_pin;
-        Pin _output_a_pin;
-        Pin _output_b_pin;
+        Pin _output_cw_pin;
+        Pin _output_ccw_pin;
 
         // Configurable
-        uint32_t _pwm_freq = 5000;
+        uint32_t     _pwm_freq = 5000;
         SpindleState _state;
-        void set_enable(bool enable);
+        void         set_enable(bool enable);
 
         void         set_output(uint32_t duty);
         virtual void deinit();

--- a/FluidNC/src/Spindles/HBridgeSpindle.h
+++ b/FluidNC/src/Spindles/HBridgeSpindle.h
@@ -28,18 +28,18 @@
 
 namespace Spindles {
     // This adds support for PWM H-Bridge Spindles
-    class HBridgeSpindle : public Spindle {
+    class HBridge : public Spindle {
     public:
-        HBridgeSpindle() = default;
+        HBridge() = default;
 
         // PWM(Pin&& output, Pin&& enable, Pin&& direction, uint32_t minRpm, uint32_t maxRpm) :
         //     _min_rpm(minRpm), _max_rpm(maxRpm), _output_pin(std::move(output)), _enable_pin(std::move(enable)),
         //     _direction_pin(std::move(direction)) {}
 
-        HBridgeSpindle(const HBridgeSpindle&) = delete;
-        HBridgeSpindle(HBridgeSpindle&&)      = delete;
-        HBridgeSpindle& operator=(const HBridgeSpindle&) = delete;
-        HBridgeSpindle& operator=(HBridgeSpindle&&) = delete;
+        HBridge(const HBridge&) = delete;
+        HBridge(HBridge&&)      = delete;
+        HBridge& operator=(const HBridge&) = delete;
+        HBridge& operator=(HBridge&&) = delete;
 
         void init() override;
         void setSpeedfromISR(uint32_t dev_speed) override;
@@ -71,9 +71,9 @@ namespace Spindles {
         }
 
         // Name of the configurable. Must match the name registered in the cpp file.
-        const char* name() const override { return "HBridgeSpindle"; }
+        const char* name() const override { return "HBridge"; }
 
-        virtual ~HBridgeSpindle() {}
+        virtual ~HBridge() {}
 
     protected:
         // TODO: A/B rename

--- a/example_configs/6P_extn_XYZ_HBridge.yaml
+++ b/example_configs/6P_extn_XYZ_HBridge.yaml
@@ -1,0 +1,121 @@
+board: 6 Pack
+name: 6 Pack External XYZ HBridgeSpindle
+meta:
+
+stepping:
+  engine: I2S_STREAM
+  idle_ms: 250
+  pulse_us: 4
+  dir_delay_us: 1
+  disable_delay_us: 0
+
+axes:
+  shared_stepper_disable_pin: NO_PIN
+  x:
+    steps_per_mm: 100.000
+    max_rate_mm_per_min: 5000.000
+    acceleration_mm_per_sec2: 50.000
+    max_travel_mm: 300.000
+    soft_limits: false
+    homing:
+      cycle: 2
+      positive_direction: false
+      mpos_mm: 0.000
+      feed_mm_per_min: 100.000
+      seek_mm_per_min: 200.000
+      settle_ms: 500
+      seek_scaler: 1.100
+      feed_scaler: 1.100
+
+    motor0:
+      limit_neg_pin: NO_PIN
+      limit_pos_pin: NO_PIN
+      limit_all_pin: NO_PIN
+      hard_limits: false
+      pulloff_mm:1.000
+      stepstick:
+        ms3_pin: i2so.3
+        step_pin: I2SO.2
+        direction_pin: I2SO.1
+        disable_pin: I2SO.0
+
+  y:
+    steps_per_mm: 100.000
+    max_rate_mm_per_min: 5000.000
+    acceleration_mm_per_sec2: 50.000
+    max_travel_mm: 300.000
+    soft_limits: false
+    homing:
+      cycle: 2
+      positive_direction: true
+      mpos_mm: 0.000
+      feed_mm_per_min: 100.000
+      seek_mm_per_min: 200.000
+      settle_ms: 500
+      seek_scaler: 1.100
+      feed_scaler: 1.100
+
+    motor0:
+      limit_neg_pin: NO_PIN
+      limit_pos_pin: NO_PIN
+      limit_all_pin: NO_PIN
+      hard_limits: false
+      pulloff_mm:1.000
+      stepstick:
+        ms3_pin: i2so.6
+        step_pin: I2SO.5
+        direction_pin: I2SO.4
+        disable_pin: I2SO.7
+        
+  z:
+    steps_per_mm: 100.000
+    max_rate_mm_per_min: 5000.000
+    acceleration_mm_per_sec2: 50.000
+    max_travel_mm: 300.000
+    soft_limits: false
+    homing:
+      cycle: 2
+      positive_direction: true
+      mpos_mm: 0.000
+      feed_mm_per_min: 100.000
+      seek_mm_per_min: 200.000
+      settle_ms: 500
+      seek_scaler: 1.100
+      feed_scaler: 1.100
+        
+    motor0:
+      limit_neg_pin: NO_PIN
+      limit_pos_pin: NO_PIN
+      limit_all_pin: NO_PIN
+      hard_limits: false
+      pulloff_mm:1.000
+      standard_stepper:
+        step_pin: I2SO.10
+        direction_pin: I2SO.9
+        disable_pin: I2SO.8
+
+i2so:
+  bck_pin: gpio.22
+  data_pin: gpio.21
+  ws_pin: gpio.17
+
+spi:
+  miso_pin: gpio.19
+  mosi_pin: gpio.23
+  sck_pin: gpio.18
+
+sdcard:
+  card_detect_pin: NO_PIN
+  cs_pin: gpio.5
+
+HBridgeSpindle:
+  pwm_hz: 5000
+  output_cw_pin: gpio.4
+  output_ccw_pin: gpio.16
+  enable_pin: gpio.26
+  disable_with_s0: false
+  spinup_ms: 0
+  spindown_ms: 0
+  tool_num: 100
+  speed_map: 0=0.000% 10000=100.000%
+  


### PR DESCRIPTION
Implementation of HBridge Spindle as discussed in  https://github.com/bdring/FluidNC/issues/364

Please bear with me, as I am not completely familiar with github PR workflow.

The implementation is very similar to the PWMSpindle implementation. The reason I did not derive from there is that PWMSpindle already has a _direction_pin which the HBridge does not use and would be confusing.

I am willing to suggest a wiki entry, but I am afraid I would need permissions for that.

