### PR TITLE
Issue #371 Range for TMC2209 was incorrect.

### DIFF
--- a/FluidNC/src/Motors/TMC2209Driver.cpp
+++ b/FluidNC/src/Motors/TMC2209Driver.cpp
@@ -68,7 +68,7 @@ namespace MotorDrivers {
                 tmc2209->en_spreadCycle(false);
                 tmc2209->pwm_autoscale(false);
                 tmc2209->TCOOLTHRS(calc_tstep(homingFeedRate, 150.0));
-                tmc2209->SGTHRS(constrain(_stallguard, 0, 255));
+                tmc2209->SGTHRS(_stallguard);
                 break;
             }
         }
@@ -89,7 +89,7 @@ namespace MotorDrivers {
         // TMC2208 does not have StallGuard
         if (tmc2209) {
             log_info(axisName() << " SG_Val: " << tmc2209->SG_RESULT() << "   Rate: " << feedrate
-                                << " mm/min SG_Setting:" << constrain(_stallguard, -64, 63));
+                                << " mm/min SG_Setting:" << _stallguard);
         }
     }
 

--- a/FluidNC/src/Motors/TMC2209Driver.h
+++ b/FluidNC/src/Motors/TMC2209Driver.h
@@ -25,7 +25,7 @@ namespace MotorDrivers {
         void group(Configuration::HandlerBase& handler) override {
             handler.item("run_mode", _run_mode, trinamicModes);
             handler.item("homing_mode", _homing_mode, trinamicModes);
-            handler.item("stallguard", _stallguard, -64, 63);
+            handler.item("stallguard", _stallguard, 0, 255);
             handler.item("stallguard_debug", _stallguardDebugMode);
             handler.item("toff_coolstep", _toff_coolstep, 2, 15);
 


### PR DESCRIPTION
It was assumed to be the same as SPI types.
It no longer needs to be constrained if handler.item has a range.