### PR TITLE
Fast limits

### DIFF
--- a/FluidNC/src/Config.h
+++ b/FluidNC/src/Config.h
@@ -57,11 +57,6 @@ const char* const DEFAULT_ADMIN_LOGIN = "admin";
 const char* const DEFAULT_USER_LOGIN  = "user";
 #endif
 
-// Number of homing cycles performed after when the machine initially jogs to limit switches.
-// This help in preventing overshoot and should improve repeatability. This value should be one or
-// greater.
-static const uint8_t NHomingLocateCycle = 1;  // Integer (1-128)
-
 // Upon a successful probe cycle, this option provides immediately feedback of the probe coordinates
 // through an automatically generated message. If disabled, users can still access the last probe
 // coordinates through the '$#' print parameters command.

--- a/FluidNC/src/Config.h
+++ b/FluidNC/src/Config.h
@@ -215,5 +215,3 @@ const double PARKING_PULLOUT_INCREMENT = 5.0;    // Spindle pull-out and plunge 
 
 // INCLUDE_OLED_BASIC includes a driver for a modest sized OLED display
 // #define INCLUDE_OLED_BASIC
-
-// #define DEBUG_STEPPING

--- a/FluidNC/src/Configuration/RuntimeSetting.cpp
+++ b/FluidNC/src/Configuration/RuntimeSetting.cpp
@@ -57,7 +57,6 @@ namespace Configuration {
                 out_ << "$/" << setting_ << "=" << (value ? "true" : "false") << '\n';
             } else {
                 value = (!strcasecmp(newValue_, "true") || !strcasecmp(newValue_, "yes") || !strcasecmp(newValue_, "1"));
-                log_info("Bool value:" << value);
             }
         }
     }

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -52,7 +52,7 @@ void gc_init() {
 // Sets g-code parser position in mm. Input in steps. Called by the system abort and hard
 // limit pull-off routines.
 void gc_sync_position() {
-    motor_steps_to_mpos(gc_state.position, motor_steps);
+    motor_steps_to_mpos(gc_state.position, get_motor_steps());
 }
 
 static void gcode_comment_msg(char* comment) {

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -906,7 +906,7 @@ Error gc_execute_line(char* line, Channel& channel) {
     // future versions on processors with enough memory, all coordinate data should be stored
     // in memory and written to non-volatile storage only when there is not a cycle active.
     float block_coord_system[MAX_N_AXIS];
-    memcpy(block_coord_system, gc_state.coord_system, sizeof(gc_state.coord_system));
+    copyAxes(block_coord_system, gc_state.coord_system);
     if (bitnum_is_true(command_words, ModalGroup::MG12)) {  // Check if called in block
         // This error probably cannot happen because preceding code sets
         // gc_block.modal.coord_select only to specific supported values
@@ -1324,7 +1324,7 @@ Error gc_execute_line(char* line, Channel& channel) {
         bool  cancelledInflight = false;
         Error status            = jog_execute(pl_data, &gc_block, &cancelledInflight);
         if (status == Error::Ok && !cancelledInflight) {
-            memcpy(gc_state.position, gc_block.values.xyz, sizeof(gc_block.values.xyz));
+            copyAxes(gc_state.position, gc_block.values.xyz);
         }
         // JogCancelled is not reported as a GCode error
         return status == Error::JogCancelled ? Error::Ok : status;
@@ -1510,7 +1510,7 @@ Error gc_execute_line(char* line, Channel& channel) {
     // [15. Coordinate system selection ]:
     if (gc_state.modal.coord_select != gc_block.modal.coord_select) {
         gc_state.modal.coord_select = gc_block.modal.coord_select;
-        memcpy(gc_state.coord_system, block_coord_system, sizeof(gc_state.coord_system));
+        copyAxes(gc_state.coord_system, block_coord_system);
         gc_wco_changed();
     }
     // [16. Set path control mode ]: G61.1/G64 NOT SUPPORTED
@@ -1524,7 +1524,7 @@ Error gc_execute_line(char* line, Channel& channel) {
             coords[coord_select]->set(coord_data);
             // Update system coordinate system if currently active.
             if (gc_state.modal.coord_select == coord_select) {
-                memcpy(gc_state.coord_system, coord_data, sizeof(gc_state.coord_system));
+                copyAxes(gc_state.coord_system, coord_data);
                 gc_wco_changed();
             }
             break;
@@ -1537,7 +1537,7 @@ Error gc_execute_line(char* line, Channel& channel) {
                 mc_linear(gc_block.values.xyz, pl_data, gc_state.position);
             }
             mc_linear(coord_data, pl_data, gc_state.position);
-            memcpy(gc_state.position, coord_data, sizeof(gc_state.position));
+            copyAxes(gc_state.position, coord_data);
             break;
         case NonModal::SetHome0:
             coords[CoordIndex::G28]->set(gc_state.position);
@@ -1546,7 +1546,7 @@ Error gc_execute_line(char* line, Channel& channel) {
             coords[CoordIndex::G30]->set(gc_state.position);
             break;
         case NonModal::SetCoordinateOffset:
-            memcpy(gc_state.coord_offset, gc_block.values.xyz, sizeof(gc_block.values.xyz));
+            copyAxes(gc_state.coord_offset, gc_block.values.xyz);
             gc_wco_changed();
             break;
         case NonModal::ResetCoordinateOffset:
@@ -1590,7 +1590,7 @@ Error gc_execute_line(char* line, Channel& channel) {
             // motion control system might still be processing the action and the real tool position
             // in any intermediate location.
             if (gc_update_pos == GCUpdatePos::Target) {
-                memcpy(gc_state.position, gc_block.values.xyz, sizeof(gc_block.values.xyz));  // gc_state.position[] = gc_block.values.xyz[]
+                copyAxes(gc_state.position, gc_block.values.xyz);
             } else if (gc_update_pos == GCUpdatePos::System) {
                 gc_sync_position();
             }  // == GCUpdatePos::None

--- a/FluidNC/src/Kinematics/Cartesian.cpp
+++ b/FluidNC/src/Kinematics/Cartesian.cpp
@@ -21,7 +21,7 @@ namespace Kinematics {
 
     void Cartesian::motors_to_cartesian(float* cartesian, float* motors, int n_axis) {
         // Motor space is cartesian space, so we do no transform.
-        memcpy(cartesian, motors, n_axis * sizeof(motors[0]));
+        copyAxes(cartesian, motors);
     }
 
     // Configuration registration

--- a/FluidNC/src/Kinematics/CoreXY.cpp
+++ b/FluidNC/src/Kinematics/CoreXY.cpp
@@ -68,8 +68,8 @@ namespace Kinematics {
         // leave other axes unchanged
         for (int axis = X_AXIS; axis <= config->_axes->_numberAxis; axis++) {
             if (axis < Z_AXIS) {
-                motor_steps[axis] = 0.0;
-                target[axis]      = 0.0;
+                set_motor_steps(axis, 0);
+                target[axis] = 0.0;
             } else {
                 move_to[axis] = target[axis];
             }
@@ -235,13 +235,13 @@ namespace Kinematics {
             for (int axis = Z_AXIS; axis < n_axis; axis++) {
                 if (bitnum_is_true(cycle_mask, axis)) {
                     // set the Z motor position
-                    motor_steps[axis] = mpos_to_steps(motors_mm[axis], axis);
+                    set_motor_steps(axis, mpos_to_steps(motors_mm[axis], axis));
                 }
             }
         } else {
             // set all of them
             for (int axis = X_AXIS; axis < n_axis; axis++) {
-                motor_steps[axis] = mpos_to_steps(motors_mm[axis], axis);
+                set_motor_steps(axis, mpos_to_steps(motors_mm[axis], axis));
             }
         }
 

--- a/FluidNC/src/Kinematics/CoreXY.cpp
+++ b/FluidNC/src/Kinematics/CoreXY.cpp
@@ -171,8 +171,8 @@ namespace Kinematics {
             AxisMask axisMask = Machine::Homing::axis_mask_from_cycle(cycle);
             uint8_t  count    = 0;
 
-            for (int i = 0; i < 16; i++) {
-                if (bitnum_is_true(axisMask, i)) {
+            for (int axis = 0; axis < MAX_N_AXIS; axis++) {
+                if (bitnum_is_true(axisMask, axis)) {
                     if (++count > 1) {  // Error with any axis with more than one axis per cycle
                         log_error("CoreXY cannot multi-axis home. Check homing cycle:" << cycle);
                         // TODO: Set some Kinematics error or alarm

--- a/FluidNC/src/Kinematics/CoreXY.cpp
+++ b/FluidNC/src/Kinematics/CoreXY.cpp
@@ -29,7 +29,13 @@ TODO: If touching back off
 namespace Kinematics {
     void CoreXY::group(Configuration::HandlerBase& handler) {}
 
-    void CoreXY::init() { log_info("Kinematic system: " << name()); }
+    void CoreXY::init() {
+        log_info("Kinematic system: " << name());
+
+        // A limit switch on either axis stops both motors
+        config->_axes->_axis[X_AXIS]->_motors[0]->limitOtherAxis(Y_AXIS);
+        config->_axes->_axis[Y_AXIS]->_motors[0]->limitOtherAxis(X_AXIS);
+    }
 
     // plan a homing mve in motor space for the homing sequence
     void CoreXY::plan_homing_move(AxisMask axisMask, bool approach, bool seek) {

--- a/FluidNC/src/Machine/Axes.cpp
+++ b/FluidNC/src/Machine/Axes.cpp
@@ -109,26 +109,16 @@ namespace Machine {
             config->_stepping->waitDirection();
         }
 
-        auto limitedMotors    = posLimitMask | negLimitMask;
-        bool isHomingApproach = Homing::_approach;
-
         // Turn on step pulses for motors that are supposed to step now
         for (size_t axis = X_AXIS; axis < n_axis; axis++) {
             if (bitnum_is_true(step_mask, axis)) {
-                int stepIncrement = bitnum_is_true(dir_mask, axis) ? 1 : -1;
+                bool dir = bitnum_is_true(dir_mask, axis);
 
                 auto a = _axis[axis];
-
-                // Skip steps based on limit pins if:
-                // (Homing approach or axis hard limits) & limit pin is true
-
                 for (size_t motor = 0; motor < Axis::MAX_MOTORS_PER_AXIS; motor++) {
-                    auto m = a->_motors[0];
+                    auto m = a->_motors[motor];
                     if (m) {
-                        if (!((isHomingApproach || m->_hardLimits) && bitnum_is_true(limitedMotors, motor_bit(axis, motor)))) {
-                            m->_driver->step();
-                            m->_steps += stepIncrement;
-                        }
+                        m->step(dir);
                     }
                 }
             }

--- a/FluidNC/src/Machine/Axes.cpp
+++ b/FluidNC/src/Machine/Axes.cpp
@@ -79,7 +79,7 @@ namespace Machine {
                     for (size_t motor = 0; motor < Axis::MAX_MOTORS_PER_AXIS; motor++) {
                         auto m = _axis[axis]->_motors[motor];
                         if (m && m->_driver->set_homing_mode(isHoming)) {
-                            set_bitnum(motorsCanHome, motor * 16 + axis);
+                            set_bitnum(motorsCanHome, motor_bit(axis, motor));
                         }
                     }
                 }

--- a/FluidNC/src/Machine/Axes.h
+++ b/FluidNC/src/Machine/Axes.h
@@ -15,10 +15,6 @@ namespace Machine {
     class Axes : public Configuration::Configurable {
         bool _switchedStepper = false;
 
-        // During homing, this is used to stop stepping on motors that have
-        // reached their limit switches, by clearing bits in the mask.
-        MotorMask _motorLockoutMask = 0;
-
     public:
         static constexpr const char* _names = "XYZABC";
 
@@ -67,9 +63,6 @@ namespace Machine {
         // These are used during homing cycles.
         // The return value is a bitmask of axes that can home
         MotorMask set_homing_mode(AxisMask homing_mask, bool isHoming);
-        void      unlock_all_motors();
-        void      lock_motors(MotorMask motor_mask);
-        void      unlock_motors(MotorMask motor_mask);
 
         void set_disable(int axis, bool disable);
         void set_disable(bool disable);

--- a/FluidNC/src/Machine/Axes.h
+++ b/FluidNC/src/Machine/Axes.h
@@ -33,6 +33,10 @@ namespace Machine {
 
         inline char axisName(int index) { return index < MAX_N_AXIS ? _names[index] : '?'; }  // returns axis letter
 
+        static inline size_t    motor_bit(size_t axis, size_t motor) { return motor ? axis + 16 : axis; }
+        static inline AxisMask  motors_to_axes(MotorMask motors) { return (motors & 0xffff) | (motors >> 16); }
+        static inline MotorMask axes_to_motors(AxisMask axes) { return axes | (axes << 16); }
+
         Pin _sharedStepperDisable;
         Pin _sharedStepperReset;
 

--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -51,7 +51,7 @@ namespace Machine {
         AxisMask axesMask = 0;
         // Find the axis that will take the longest
         for (int axis = 0; axis < n_axis; axis++) {
-            if (bitnum_is_false(motors, axis) && bitnum_is_false(motors, axis + 16)) {
+            if (bitnum_is_false(motors, Machine::Axes::motor_bit(axis, 0)) && bitnum_is_false(motors, Machine::Axes::motor_bit(axis, 1))) {
                 continue;
             }
 
@@ -77,13 +77,15 @@ namespace Machine {
                 travel = axisConfig->_maxTravel;
             } else {  // see if which pull off we use
                 // If both motors are running use the first pull off
-                if (bitnum_is_true(motors, axis) && bitnum_is_true(motors, axis + 16)) {
+                if (bitnum_is_true(motors, Axes::motor_bit(axis, 0)) && bitnum_is_true(motors, Axes::motor_bit(axis, 1))) {
                     travel = axisConfig->_motors[0]->_pulloff;
                 } else {
                     if (customPulloff != 0) {
                         travel = customPulloff;
                     } else {
-                        bitnum_is_true(motors, axis) ? travel = axisConfig->_motors[0]->_pulloff : travel = axisConfig->_motors[1]->_pulloff;
+                        // If motor 0 is not running, use the pulloff for motor 1
+                        int motor = bitnum_is_false(motors, Axes::motor_bit(axis, 0));
+                        travel    = axisConfig->_motors[motor]->_pulloff;
                     }
                 }
             }

--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -34,7 +34,7 @@ namespace Machine {
     // Then we scale the travel distances for the other axes so they would complete
     // at the same time.
 
-    bool Homing::_approach = false;
+    volatile bool Homing::_approach = false;
 
     const uint32_t MOTOR0 = 0xffff;
     const uint32_t MOTOR1 = 0xffff0000;
@@ -61,7 +61,7 @@ namespace Machine {
             set_bitnum(axesMask, axis);
 
             // Set target location for active axes and setup computation for homing rate.
-            motor_steps[axis] = 0;
+            set_motor_steps(axis, 0);
 
             auto axisConfig = axes->_axis[axis];
             auto homing     = axisConfig->_homing;
@@ -241,7 +241,7 @@ namespace Machine {
         // Set machine positions for homed limit switches. Don't update non-homed axes.
         for (int axis = 0; axis < n_axis; axis++) {
             if (bitnum_is_true(axisMask, axis)) {
-                motor_steps[axis] = mpos_to_steps(axes->_axis[axis]->_homing->_mpos, axis);
+                set_motor_steps(axis, mpos_to_steps(axes->_axis[axis]->_homing->_mpos, axis));
             }
         }
         sys.step_control = {};                   // Return step control to normal operation.

--- a/FluidNC/src/Machine/Homing.h
+++ b/FluidNC/src/Machine/Homing.h
@@ -23,7 +23,7 @@ namespace Machine {
 
         static const int AllCycles = 0;  // Must be zero.
 
-        static bool _approach;
+        static volatile bool _approach;
 
         static void run_cycles(AxisMask axisMask);
         static void run_one_cycle(AxisMask axisMask);

--- a/FluidNC/src/Machine/Homing.h
+++ b/FluidNC/src/Machine/Homing.h
@@ -23,6 +23,8 @@ namespace Machine {
 
         static const int AllCycles = 0;  // Must be zero.
 
+        static bool _approach;
+
         static void run_cycles(AxisMask axisMask);
         static void run_one_cycle(AxisMask axisMask);
 

--- a/FluidNC/src/Machine/LimitPin.cpp
+++ b/FluidNC/src/Machine/LimitPin.cpp
@@ -67,6 +67,9 @@ namespace Machine {
     void IRAM_ATTR LimitPin::read() {
         _value    = _pin.read();
         _pLimited = _value;
+        if (_pExtraLimited != nullptr) {
+            *_pExtraLimited = _value;
+        }
         if (_value) {
             if (_posLimits != nullptr) {
                 set_bits(*_posLimits, _bitmask);
@@ -104,6 +107,8 @@ namespace Machine {
     // This should be called from a higher level object, that has the logic to figure out
     // if this belongs to a dual motor, single switch axis
     void LimitPin::makeDualMask() { _bitmask = Axes::axes_to_motors(Axes::motors_to_axes(_bitmask)); }
+
+    void LimitPin::setExtraMotorLimit(int axis, int motorNum) { _pExtraLimited = &config->_axes->_axis[axis]->_motors[motorNum]->_limited; }
 
     LimitPin::~LimitPin() { _pin.detachInterrupt(); }
 }

--- a/FluidNC/src/Machine/LimitPin.cpp
+++ b/FluidNC/src/Machine/LimitPin.cpp
@@ -10,8 +10,8 @@
 #include <esp32-hal-gpio.h>  // CHANGE
 
 namespace Machine {
-    LimitPin::LimitPin(Pin& pin, int axis, int motor, int direction, bool& pHardLimits) :
-        _axis(axis), _motorNum(motor), _value(false), _pHardLimits(pHardLimits), _pin(pin) {
+    LimitPin::LimitPin(Pin& pin, int axis, int motor, int direction, bool& pHardLimits, bool& pLimited) :
+        _axis(axis), _motorNum(motor), _value(false), _pHardLimits(pHardLimits), _pLimited(pLimited), _pin(pin) {
         String sDir;
         // Select one or two bitmask variables to receive the switch data
         switch (direction) {
@@ -65,7 +65,8 @@ namespace Machine {
     }
 
     void IRAM_ATTR LimitPin::read() {
-        _value = _pin.read();
+        _value    = _pin.read();
+        _pLimited = _value;
         if (_value) {
             if (_posLimits != nullptr) {
                 set_bits(*_posLimits, _bitmask);

--- a/FluidNC/src/Machine/LimitPin.cpp
+++ b/FluidNC/src/Machine/LimitPin.cpp
@@ -38,10 +38,9 @@ namespace Machine {
         }
 
         // Set a bitmap with bits to represent the axis and which motors are affected
-        // The bitmap looks like CBAZYXcbazyx where motor0 motors are in the lower bits
-        motor == 0 ? _bitmask = 1 : _bitmask = 1 << 16;
-        _bitmask <<= axis;  // Shift the bits into position
-        _legend = String("    " + sDir + " Limit");
+        // The bitmap looks like CBAZYX..cbazyx where motor0 motors are in the lower bits
+        _bitmask = 1 << Axes::motor_bit(axis, motor);
+        _legend  = String("    " + sDir + " Limit");
     }
 
     void IRAM_ATTR LimitPin::handleISR() {
@@ -103,10 +102,7 @@ namespace Machine {
     // Make this switch act like an axis level switch. Both motors will report the same
     // This should be called from a higher level object, that has the logic to figure out
     // if this belongs to a dual motor, single switch axis
-    void LimitPin::makeDualMask() {
-        uint32_t both = ((_bitmask >> 16) | (_bitmask & 0xffff));
-        _bitmask      = (both << 16) | both;
-    }
+    void LimitPin::makeDualMask() { _bitmask = Axes::axes_to_motors(Axes::motors_to_axes(_bitmask)); }
 
     LimitPin::~LimitPin() { _pin.detachInterrupt(); }
 }

--- a/FluidNC/src/Machine/LimitPin.h
+++ b/FluidNC/src/Machine/LimitPin.h
@@ -16,7 +16,14 @@ namespace Machine {
         // _pHardLimits is a reference so the shared variable at the
         // Endstops level can be changed at runtime to control the
         // limit behavior dynamically.
-        bool&              _pHardLimits;
+        bool& _pHardLimits;
+
+        // _pHardLimits is a reference to the _limited member of
+        // the Motor class.  Setting it when the Limit ISR fires
+        // lets the motor driver respond rapidly to a limit switch
+        // touch, increasing the accuracy of homing
+        volatile bool& _pLimited;
+
         volatile uint32_t* _posLimits = nullptr;
         volatile uint32_t* _negLimits = nullptr;
 
@@ -27,7 +34,7 @@ namespace Machine {
         void read();
 
     public:
-        LimitPin(Pin& pin, int axis, int motorNum, int direction, bool& phardLimits);
+        LimitPin(Pin& pin, int axis, int motorNum, int direction, bool& phardLimits, bool& pLimited);
 
         Pin& _pin;
 

--- a/FluidNC/src/Machine/LimitPin.h
+++ b/FluidNC/src/Machine/LimitPin.h
@@ -23,6 +23,7 @@ namespace Machine {
         // lets the motor driver respond rapidly to a limit switch
         // touch, increasing the accuracy of homing
         volatile bool& _pLimited;
+        volatile bool* _pExtraLimited = nullptr;
 
         volatile uint32_t* _posLimits = nullptr;
         volatile uint32_t* _negLimits = nullptr;
@@ -43,6 +44,7 @@ namespace Machine {
         void init();
         bool get() { return _value; }
         void makeDualMask();  // makes this a mask for motor0 and motor1
+        void setExtraMotorLimit(int axis, int motorNum);
 
         ~LimitPin();
     };

--- a/FluidNC/src/Machine/MachineConfig.h
+++ b/FluidNC/src/Machine/MachineConfig.h
@@ -107,3 +107,11 @@ namespace Machine {
 }
 
 extern Machine::MachineConfig* config;
+
+template <typename T>
+void copyAxes(T* dest, T* src) {
+    auto n_axis = config->_axes->_numberAxis;
+    for (size_t axis = 0; axis < n_axis; axis++) {
+        dest[axis] = src[axis];
+    }
+}

--- a/FluidNC/src/Machine/Motor.cpp
+++ b/FluidNC/src/Machine/Motor.cpp
@@ -27,7 +27,7 @@ namespace Machine {
 
     void Motor::init() {
         if (strcmp(_driver->name(), "null_motor") != 0) {
-            set_bitnum(Machine::Axes::motorMask, _axis + 16 * _motorNum);
+            set_bitnum(Machine::Axes::motorMask, Machine::Axes::motor_bit(_axis, _motorNum));
         }
         _driver->init();
 

--- a/FluidNC/src/Machine/Motor.cpp
+++ b/FluidNC/src/Machine/Motor.cpp
@@ -31,9 +31,9 @@ namespace Machine {
         }
         _driver->init();
 
-        _negLimitPin = new LimitPin(_negPin, _axis, _motorNum, -1, _hardLimits);
-        _posLimitPin = new LimitPin(_posPin, _axis, _motorNum, 1, _hardLimits);
-        _allLimitPin = new LimitPin(_allPin, _axis, _motorNum, 0, _hardLimits);
+        _negLimitPin = new LimitPin(_negPin, _axis, _motorNum, -1, _hardLimits, _limited);
+        _posLimitPin = new LimitPin(_posPin, _axis, _motorNum, 1, _hardLimits, _limited);
+        _allLimitPin = new LimitPin(_allPin, _axis, _motorNum, 0, _hardLimits, _limited);
 
         _negLimitPin->init();
         _posLimitPin->init();
@@ -57,6 +57,17 @@ namespace Machine {
     }
 
     bool Motor::isReal() { return _driver->isReal(); }
+
+    void Motor::step(bool reverse) {
+        // Skip steps based on limit pins
+        if (_limited && (Homing::_approach || (sys.state != State::Homing && _hardLimits))) {
+            return;
+        }
+        _driver->step();
+        _steps += reverse ? -1 : 1;
+    }
+
+    void Motor::unstep() { _driver->unstep(); }
 
     Motor::~Motor() { delete _driver; }
 }

--- a/FluidNC/src/Machine/Motor.cpp
+++ b/FluidNC/src/Machine/Motor.cpp
@@ -56,6 +56,13 @@ namespace Machine {
         _allLimitPin->makeDualMask();
     }
 
+    // Used for CoreXY when one limit switch should stop multiple motors
+    void Motor::limitOtherAxis(int axis) {
+        _negLimitPin->setExtraMotorLimit(axis, _motorNum);
+        _posLimitPin->setExtraMotorLimit(axis, _motorNum);
+        _allLimitPin->setExtraMotorLimit(axis, _motorNum);
+    }
+
     bool Motor::isReal() { return _driver->isReal(); }
 
     void Motor::step(bool reverse) {

--- a/FluidNC/src/Machine/Motor.h
+++ b/FluidNC/src/Machine/Motor.h
@@ -35,6 +35,8 @@ namespace Machine {
         Pin  _allPin;
         bool _hardLimits = false;
 
+        int32_t _steps = 0;
+
         // Configuration system helpers:
         void group(Configuration::HandlerBase& handler) override;
         void afterParse() override;

--- a/FluidNC/src/Machine/Motor.h
+++ b/FluidNC/src/Machine/Motor.h
@@ -35,7 +35,8 @@ namespace Machine {
         Pin  _allPin;
         bool _hardLimits = false;
 
-        int32_t _steps = 0;
+        int32_t _steps   = 0;
+        bool    _limited = false;  // _limited is set by the LimitPin ISR
 
         // Configuration system helpers:
         void group(Configuration::HandlerBase& handler) override;
@@ -45,6 +46,8 @@ namespace Machine {
         void makeDualSwitches();
         void init();
         void config_motor();
+        void step(bool reverse);
+        void unstep();
         ~Motor();
     };
 }

--- a/FluidNC/src/Machine/Motor.h
+++ b/FluidNC/src/Machine/Motor.h
@@ -44,6 +44,7 @@ namespace Machine {
         bool hasSwitches();
         bool isReal();
         void makeDualSwitches();
+        void limitOtherAxis(int axis);
         void init();
         void config_motor();
         void step(bool reverse);

--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -82,7 +82,10 @@ void setup() {
 
             config->_kinematics->init();
 
-            memset(motor_steps, 0, sizeof(motor_steps));  // Clear machine position.
+            auto n_axis = config->_axes->_numberAxis;
+            for (size_t axis = 0; axis < n_axis; axis++) {
+                set_motor_steps(axis, 0);  // Clear machine position.
+            }
 
             machine_init();  // user supplied function for special initialization
         }
@@ -132,16 +135,6 @@ void setup() {
 }
 
 static void reset_variables() {
-#    ifdef DEBUG_STEPPING
-    rtTestPl    = false;
-    rtTestSt    = false;
-    st_seq      = 0;
-    st_seq0     = 0;
-    pl_seq0     = 0;
-    seg_seq0    = 0;
-    seg_seq1    = 0;
-    planner_seq = 0;
-#    endif
     // Reset primary systems.
     system_reset();
     protocol_reset();

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -342,8 +342,7 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, uint8_t par
     // Set state variables and error out, if the probe failed and cycle with error is enabled.
     if (probeState == ProbeState::Active) {
         if (is_no_error) {
-            auto n_axis = config->_axes->_numberAxis;
-            memcpy(probe_steps, get_motor_steps(), n_axis * sizeof(probe_steps[0]));
+            copyAxes(probe_steps, get_motor_steps());
         } else {
             rtAlarm = ExecAlarm::ProbeFailContact;
         }
@@ -376,7 +375,7 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, uint8_t par
             }
             log_info("Probe offset applied:");
             coords[gc_state.modal.coord_select]->set(coord_data);  // save it
-            memcpy(gc_state.coord_system, coord_data, sizeof(gc_state.coord_system));
+            copyAxes(gc_state.coord_system, coord_data);
             report_wco_counter = 0;
         }
 

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -342,7 +342,8 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, uint8_t par
     // Set state variables and error out, if the probe failed and cycle with error is enabled.
     if (probeState == ProbeState::Active) {
         if (is_no_error) {
-            memcpy(probe_steps, motor_steps, sizeof(motor_steps));
+            auto n_axis = config->_axes->_numberAxis;
+            memcpy(probe_steps, get_motor_steps(), n_axis * sizeof(probe_steps[0]));
         } else {
             rtAlarm = ExecAlarm::ProbeFailContact;
         }

--- a/FluidNC/src/Motors/Dynamixel2.cpp
+++ b/FluidNC/src/Motors/Dynamixel2.cpp
@@ -155,8 +155,8 @@ namespace MotorDrivers {
             return false;
         }
 
-        auto axis                = config->_axes->_axis[_axis_index];
-        motor_steps[_axis_index] = mpos_to_steps(axis->_homing->_mpos, _axis_index);
+        auto axis = config->_axes->_axis[_axis_index];
+        set_motor_steps(_axis_index, mpos_to_steps(axis->_homing->_mpos, _axis_index));
 
         set_disable(false);
         set_location();  // force the PWM to update now
@@ -192,7 +192,7 @@ namespace MotorDrivers {
 
             uint32_t temp = myMap(dxl_position, _countMin, _countMax, pos_min_steps, pos_max_steps);
 
-            motor_steps[_axis_index] = temp;
+            set_motor_steps(_axis_index, temp);
 
             plan_sync_position();
 

--- a/FluidNC/src/Motors/RcServo.cpp
+++ b/FluidNC/src/Motors/RcServo.cpp
@@ -84,8 +84,8 @@ namespace MotorDrivers {
             return false;
 
         if (isHoming) {
-            auto axis                = config->_axes->_axis[_axis_index];
-            motor_steps[_axis_index] = mpos_to_steps(axis->_homing->_mpos, _axis_index);
+            auto axis = config->_axes->_axis[_axis_index];
+            set_motor_steps(_axis_index, mpos_to_steps(axis->_homing->_mpos, _axis_index));
 
             float home_time_sec = (axis->_maxTravel / axis->_maxRate * 60 * 1.1);  // 1.1 fudge factor for accell time.
 
@@ -108,8 +108,8 @@ namespace MotorDrivers {
 
         read_settings();
 
-        float mpos = steps_to_mpos(motor_steps[_axis_index], _axis_index);  // get the axis machine position in mm
-        servo_pos  = mpos;                                                  // determine the current work position
+        float mpos = steps_to_mpos(get_axis_motor_steps(_axis_index), _axis_index);  // get the axis machine position in mm
+        servo_pos  = mpos;                                                           // determine the current work position
 
         // determine the pulse length
         servo_pulse_len = static_cast<uint32_t>(mapConstrain(

--- a/FluidNC/src/Motors/Solenoid.cpp
+++ b/FluidNC/src/Motors/Solenoid.cpp
@@ -82,7 +82,7 @@ namespace MotorDrivers {
             return;
         }
 
-        float mpos = steps_to_mpos(motor_steps[_axis_index], _axis_index);  // get the axis machine position in mm
+        float mpos = steps_to_mpos(get_axis_motor_steps(_axis_index), _axis_index);  // get the axis machine position in mm
 
         _dir_invert ? is_solenoid_on = (mpos < 0.0) : is_solenoid_on = (mpos > 0.0);
 

--- a/FluidNC/src/Planner.h
+++ b/FluidNC/src/Planner.h
@@ -25,18 +25,9 @@ struct PlMotion {
 
 // This struct stores a linear movement of a g-code block motion with its critical "nominal" values
 // are as specified in the source g-code.
-#ifdef DEBUG_STEPPING
-extern uint32_t planner_seq;
-#endif
 struct plan_block_t {
     // Fields used by the bresenham algorithm for tracing the line
     // NOTE: Used by stepper algorithm to execute the block correctly. Do not alter these values.
-
-#ifdef DEBUG_STEPPING
-    uint32_t entry_pos[MAX_N_AXIS];  // Expected mpos when this block starts execution
-    uint32_t exit_pos[MAX_N_AXIS];   // Expected mpos when this block finishes execution
-    uint32_t seq;                    // Sequence number
-#endif
 
     uint32_t steps[MAX_N_AXIS];  // Step count along each axis
     uint32_t step_event_count;   // The maximum step axis count and number of steps required to complete this block.

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -357,12 +357,12 @@ static Error home_c(const char* value, WebUI::AuthenticationLevel auth_level, Ch
 }
 static void write_limit_set(uint32_t mask, Channel& out) {
     const char* motor0AxisName = "xyzabc";
-    for (int i = 0; i < MAX_N_AXIS; i++) {
-        out << (bitnum_is_true(mask, i) ? char(motor0AxisName[i]) : ' ');
+    for (int axis = 0; axis < MAX_N_AXIS; axis++) {
+        out << (bitnum_is_true(mask, Machine::Axes::motor_bit(axis, 0)) ? char(motor0AxisName[axis]) : ' ');
     }
     const char* motor1AxisName = "XYZABC";
-    for (int i = 0; i < MAX_N_AXIS; i++) {
-        out << (bitnum_is_true(mask, i + 16) ? char(motor1AxisName[i]) : ' ');
+    for (int axis = 0; axis < MAX_N_AXIS; axis++) {
+        out << (bitnum_is_true(mask, Machine::Axes::motor_bit(axis, 1)) ? char(motor1AxisName[axis]) : ' ');
     }
 }
 static Error show_limits(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -866,7 +866,7 @@ static void protocol_exec_rt_suspend() {
 
                     // Get current position and store restore location and spindle retract waypoint.
                     if (!sys.suspend.bit.restartRetract) {
-                        memcpy(restore_target, parking_target, sizeof(restore_target[0]) * config->_axes->_numberAxis);
+                        copyAxes(restore_target, parking_target);
                         retract_waypoint += restore_target[PARKING_AXIS];
                         retract_waypoint = MIN(retract_waypoint, PARKING_TARGET);
                     }

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -17,15 +17,6 @@
 #include "Settings.h"       // settings_execute_startup
 #include "InputFile.h"      // infile
 
-#ifdef DEBUG_STEPPING
-volatile bool rtCrash;
-volatile bool rtSeq;
-volatile bool rtSegSeq;
-volatile bool rtTestPl;
-volatile bool rtTestSt;
-uint32_t      expected_steps[MAX_N_AXIS];
-#endif
-
 #ifdef DEBUG_REPORT_REALTIME
 volatile bool rtExecDebug;
 #endif
@@ -736,34 +727,6 @@ void protocol_do_macro(int macro_num) {
 void protocol_exec_rt_system() {
     protocol_do_alarm();  // If there is a hard or soft limit, this will block until rtReset is set
 
-#ifdef DEBUG_STEPPING
-    if (rtSegSeq) {
-        rtSegSeq = false;
-        log_error("segment exp " << seg_seq_exp << " actual " << seg_seq_act);
-        rtReset = true;
-    }
-    if (rtSeq) {
-        rtSeq = false;
-        log_error("planner " << pl_seq0 << " stepper " << st_seq0);
-        rtReset = true;
-    }
-    if (rtCrash) {
-        rtCrash = false;
-        log_error("Stepper exp,actual " << expected_steps[0] << "," << motor_steps[0] << " " << expected_steps[1] << "," << motor_steps[1]
-                                        << " " << expected_steps[2] << "," << motor_steps[2]);
-        rtReset = true;
-    }
-    if (rtTestPl) {
-        rtTestPl = false;
-        log_info("Poisoned planner_seq");
-        planner_seq += 20;
-    }
-    if (rtTestSt) {
-        rtTestSt = false;
-        log_info("Poisoned stepper");
-        --motor_steps[0];
-    }
-#endif
     if (rtReset) {
         if (sys.state == State::Homing) {
             rtAlarm = ExecAlarm::HomingFailReset;

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -51,15 +51,6 @@ extern volatile bool rtButtonMacro1;
 extern volatile bool rtButtonMacro2;
 extern volatile bool rtButtonMacro3;
 
-#ifdef DEBUG_STEPPING
-extern volatile bool rtCrash;
-extern volatile bool rtSeq;
-extern volatile bool rtSegSeq;
-extern volatile bool rtTestPl;
-extern volatile bool rtTestSt;
-extern uint32_t      expected_steps[MAX_N_AXIS];
-#endif
-
 #ifdef DEBUG_REPORT_REALTIME
 extern volatile bool rtExecDebug;
 #endif

--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -504,13 +504,14 @@ static void pinString(Print& channel) {
     MotorMask lim_pin_state = limits_get_state();
     if (lim_pin_state) {
         auto n_axis = config->_axes->_numberAxis;
-        for (int i = 0; i < n_axis; i++) {
-            if (bitnum_is_true(lim_pin_state, i) || bitnum_is_true(lim_pin_state, i + 16)) {
+        for (size_t axis = 0; axis < n_axis; axis++) {
+            if (bitnum_is_true(lim_pin_state, Machine::Axes::motor_bit(axis, 0)) ||
+                bitnum_is_true(lim_pin_state, Machine::Axes::motor_bit(axis, 1))) {
                 if (prefixNeeded) {
                     prefixNeeded = false;
                     channel << "|Pn:";
                 }
-                channel << config->_axes->axisName(i);
+                channel << config->_axes->axisName(axis);
             }
         }
     }

--- a/FluidNC/src/Serial.cpp
+++ b/FluidNC/src/Serial.cpp
@@ -184,14 +184,6 @@ void execute_realtime_command(Cmd command, Channel& channel) {
         case Cmd::CoolantMistOvrToggle:
             rtAccessoryOverride.bit.coolantMistOvrToggle = 1;
             break;
-#ifdef DEBUG_STEPPING
-        case Cmd::TestPl:
-            rtTestPl = true;
-            break;
-        case Cmd::TestSt:
-            rtTestSt = true;
-            break;
-#endif
     }
 }
 
@@ -201,11 +193,7 @@ bool is_realtime_command(uint8_t data) {
         return true;
     }
     auto cmd = static_cast<Cmd>(data);
-    return cmd == Cmd::Reset || cmd == Cmd::StatusReport || cmd == Cmd::CycleStart || cmd == Cmd::FeedHold
-#ifdef DEBUG_STEPPING
-           || cmd == Cmd::TestPl || cmd == Cmd::TestSt
-#endif
-        ;
+    return cmd == Cmd::Reset || cmd == Cmd::StatusReport || cmd == Cmd::CycleStart || cmd == Cmd::FeedHold;
 }
 
 void AllChannels::init() {

--- a/FluidNC/src/Serial.h
+++ b/FluidNC/src/Serial.h
@@ -55,10 +55,6 @@ enum class Cmd : uint8_t {
     SpindleOvrStop        = 0x9E,
     CoolantFloodOvrToggle = 0xA0,
     CoolantMistOvrToggle  = 0xA1,
-#ifdef DEBUG_STEPPING
-    TestPl = '^',
-    TestSt = '%',
-#endif
 };
 
 bool is_realtime_command(uint8_t data);

--- a/FluidNC/src/Stepper.cpp
+++ b/FluidNC/src/Stepper.cpp
@@ -237,8 +237,7 @@ void IRAM_ATTR Stepper::pulse_func() {
     // Check probing state.
     if (probeState == ProbeState::Active && config->_probe->tripped()) {
         probeState = ProbeState::Off;
-        // Memcpy is not IRAM_ATTR, but: most compilers optimize memcpy away.
-        auto axes = config->_axes;
+        auto axes  = config->_axes;
         for (int axis = 0; axis < n_axis; axis++) {
             auto m            = axes->_axis[axis]->_motors[0];
             probe_steps[axis] = m ? m->_steps : 0;

--- a/FluidNC/src/Stepper.h
+++ b/FluidNC/src/Stepper.h
@@ -47,13 +47,3 @@ namespace Stepper {
 
     extern uint32_t isr_count;  // for debugging only
 }
-#ifdef DEBUG_STEPPING
-extern uint32_t st_seq;
-extern uint32_t st_seq0;
-extern uint32_t pl_seq0;
-extern uint32_t seg_seq0;
-extern uint32_t seg_seq1;
-extern uint32_t seg_seq_act;
-extern uint32_t seg_seq_exp;
-
-#endif

--- a/FluidNC/src/System.cpp
+++ b/FluidNC/src/System.cpp
@@ -15,7 +15,6 @@
 
 // Declare system global variable structure
 system_t sys;
-int32_t  motor_steps[MAX_N_AXIS];  // Real-time position in steps.
 int32_t  probe_steps[MAX_N_AXIS];  // Last probe position in steps.
 
 void system_reset() {
@@ -48,9 +47,37 @@ void motor_steps_to_mpos(float* position, int32_t* steps) {
     config->_kinematics->motors_to_cartesian(position, motor_mpos, n_axis);
 }
 
+void set_motor_steps(size_t axis, int32_t steps) {
+    auto a = config->_axes->_axis[axis];
+    for (size_t motor = 0; motor < Machine::Axis::MAX_MOTORS_PER_AXIS; motor++) {
+        auto m = a->_motors[motor];
+        if (m) {
+            m->_steps = steps;
+        }
+    }
+}
+
+int32_t get_axis_motor_steps(size_t axis) {
+    auto m = config->_axes->_axis[axis]->_motors[0];
+    return m ? m->_steps : 0;
+}
+
+int32_t* get_motor_steps() {
+    static int32_t motor_steps[MAX_N_AXIS];
+
+    auto axes   = config->_axes;
+    auto n_axis = axes->_numberAxis;
+    for (size_t axis = 0; axis < n_axis; axis++) {
+        auto m            = axes->_axis[axis]->_motors[0];
+        motor_steps[axis] = m ? m->_steps : 0;
+    }
+    return motor_steps;
+}
+
 float* get_mpos() {
     static float position[MAX_N_AXIS];
-    motor_steps_to_mpos(position, motor_steps);
+
+    motor_steps_to_mpos(position, get_motor_steps());
     return position;
 };
 

--- a/FluidNC/src/System.h
+++ b/FluidNC/src/System.h
@@ -81,6 +81,10 @@ void system_reset();
 float   steps_to_mpos(int32_t steps, size_t axis);
 int32_t mpos_to_steps(float mpos, size_t axis);
 
+int32_t  get_axis_motor_steps(size_t axis);
+void     set_motor_steps(size_t axis, int32_t steps);
+int32_t* get_motor_steps();
+
 // Updates a machine position array from a steps array
 void   motor_steps_to_mpos(float* position, int32_t* steps);
 float* get_mpos();

--- a/example_configs/fysetc_corexy.yaml
+++ b/example_configs/fysetc_corexy.yaml
@@ -7,6 +7,9 @@ stepping:
   dir_delay_us: 1
   pulse_us: 2
   disable_delay_us: 0
+  
+kinematics:
+  corexy:
 
 axes:
   shared_stepper_disable_pin: gpio.25:high
@@ -21,15 +24,15 @@ axes:
       cycle: 1
       positive_direction: true
       mpos_mm: 150.000
-      feed_mm_per_min: 100.000
-      seek_mm_per_min: 200.000
+      feed_mm_per_min: 200.000
+      seek_mm_per_min: 400.000
       settle_ms: 500
       seek_scaler: 1.100
       feed_scaler: 1.100
 
     motor0:
       limit_all_pin: gpio.34:low
-      hard_limits: false
+      hard_limits: true
       pulloff_mm: 1.000
       tmc_2209:
         uart:
@@ -39,7 +42,7 @@ axes:
           mode: 8N1
         addr: 1
         r_sense_ohms: 0.110
-        run_amps: 1.200
+        run_amps: 1.500
         hold_amps: 0.500
         microsteps: 16
         stallguard: 0
@@ -47,8 +50,8 @@ axes:
         toff_disable: 0
         toff_stealthchop: 5
         toff_coolstep: 3
-        run_mode: StallGuard
-        homing_mode: StallGuard
+        run_mode: CoolStep
+        homing_mode: CoolStep
         use_enable: false
         step_pin: gpio.27
         direction_pin: gpio.26
@@ -64,8 +67,8 @@ axes:
       cycle: 2
       positive_direction: true
       mpos_mm: 150.000
-      feed_mm_per_min: 100.000
-      seek_mm_per_min: 200.000
+      feed_mm_per_min: 200.000
+      seek_mm_per_min: 400.000
       settle_ms: 500
       seek_scaler: 1.100
       feed_scaler: 1.100
@@ -77,7 +80,7 @@ axes:
       tmc_2209:
         addr: 3
         r_sense_ohms: 0.110
-        run_amps: 1.200
+        run_amps: 1.5200
         hold_amps: 0.500
         microsteps: 16
         stallguard: 0
@@ -85,8 +88,8 @@ axes:
         toff_disable: 0
         toff_stealthchop: 5
         toff_coolstep: 3
-        run_mode: StallGuard
-        homing_mode: StallGuard
+        run_mode: CoolStep
+        homing_mode: CoolStep
         use_enable: false
         step_pin: gpio.33
         direction_pin: gpio.32:low


### PR DESCRIPTION
Instead of handling limit lockout at the protocol level, the LimitPin ISR sets a variable in the Motor class so stepping can stop instantly.  That simplifies the homing code and makes the system respond faster to limits.