### PR TITLE
Update platformio platform to 4.3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -48,7 +48,7 @@ wifi_deps =
 	arduinoWebSockets=https://github.com/Links2004/arduinoWebSockets
 
 [common_esp32]
-platform = espressif32@4.2.0
+platform = espressif32@4.3.0
 
 ; See FluidNC/ld/esp32/README.md
 extra_scripts =	FluidNC/ld/esp32/vtable_in_dram.py


### PR DESCRIPTION
Bump platform version to 4.3, pulling in latest arduino ver (2.0.3), fixes for SD card mounting issue.

https://github.com/platformio/platform-espressif32/releases/tag/v4.3.0