### PR TITLE
Fix #445 by add a flushRx() method to the Channel class

### DIFF
--- a/FluidNC/src/Channel.cpp
+++ b/FluidNC/src/Channel.cpp
@@ -5,6 +5,11 @@
 #include "Machine/MachineConfig.h"  // config
 #include "Serial.h"                 // execute_realtime_command
 
+void Channel::flushRx() {
+    _linelen   = 0;
+    _lastWasCR = false;
+}
+
 Channel* Channel::pollLine(char* line) {
     handle();
     while (1) {

--- a/FluidNC/src/Channel.h
+++ b/FluidNC/src/Channel.h
@@ -39,4 +39,5 @@ public:
     virtual void     ack(Error status);
     const char*      name() { return _name; }
     virtual int      rx_buffer_available() = 0;
+    virtual void     flushRx();
 };

--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -159,6 +159,7 @@ static void reset_variables() {
     // Sync cleared gcode and planner positions to current system position.
     plan_sync_position();
     gc_sync_position();
+    allChannels.flushRx();
     report_init_message(allChannels);
     mc_init();
 }

--- a/FluidNC/src/Serial.cpp
+++ b/FluidNC/src/Serial.cpp
@@ -218,6 +218,12 @@ String AllChannels::info() {
     return retval;
 }
 
+void AllChannels::flushRx() {
+    for (auto channel : _channelq) {
+        channel->flushRx();
+    }
+}
+
 size_t AllChannels::write(uint8_t data) {
     for (auto channel : _channelq) {
         channel->write(data);

--- a/FluidNC/src/Serial.h
+++ b/FluidNC/src/Serial.h
@@ -79,7 +79,7 @@ public:
     int  available() override { return 0; }
     int  read() { return -1; }
     int  peek() { return -1; }
-    void flush() {}
+    void flushRx();
 
     // All channels cannot be a direct command source so
     // its rx_buffer_available() method should not be called.

--- a/FluidNC/src/StartupLog.h
+++ b/FluidNC/src/StartupLog.h
@@ -21,7 +21,6 @@ public:
     size_t readBytes(char* buffer, size_t length) override { return 0; };
     int    peek(void) override { return -1; }
     size_t write(uint8_t data) override;
-    void   flush() override {}
 
     Channel* pollLine(char* line) override { return nullptr; }
 

--- a/FluidNC/src/Uart.cpp
+++ b/FluidNC/src/Uart.cpp
@@ -211,3 +211,12 @@ void uartInit() {
 void Uart::config_message(const char* prefix, const char* usage) {
     log_info(prefix << usage << "Uart Tx:" << _txd_pin.name() << " Rx:" << _rxd_pin.name() << " RTS:" << _rts_pin.name() << " Baud:" << baud);
 }
+
+void Uart::flushRx() {
+    uart_flush_input(_uart_num);
+    _pushback = -1;
+    while (_queue.size()) {
+        _queue.pop();
+    }
+    Channel::flushRx();
+}

--- a/FluidNC/src/Uart.h
+++ b/FluidNC/src/Uart.h
@@ -55,7 +55,7 @@ public:
     size_t write(const uint8_t* buffer, size_t length) override;
     // inline size_t write(const char* buffer, size_t size) { return write(reinterpret_cast<const uint8_t*>(buffer), size); }
     // size_t        write(const char* text) override;
-    void flush() { uart_flush(_uart_num); }
+    void flushRx() override;
     bool flushTxTimed(TickType_t ticks);
 
     bool setCr(bool on) {

--- a/FluidNC/src/WebUI/BTConfig.h
+++ b/FluidNC/src/WebUI/BTConfig.h
@@ -42,7 +42,7 @@ namespace WebUI {
         int    available() override { return SerialBT.available(); }
         int    read() override { return SerialBT.read(); }
         int    peek() override { return SerialBT.peek(); }
-        void   flush() override { return SerialBT.flush(); }
+        void   flush() override { SerialBT.flush(); }
         size_t write(uint8_t data) override;
         // 512 is RX_QUEUE_SIZE which is defined in BluetoothSerial.cpp but not in its .h
         int rx_buffer_available() override { return 512 - available(); }

--- a/FluidNC/src/WebUI/InputBuffer.cpp
+++ b/FluidNC/src/WebUI/InputBuffer.cpp
@@ -14,10 +14,12 @@ namespace WebUI {
         _RXbufferpos  = 0;
     }
 
-    void InputBuffer::end() {
-        _RXbufferSize = 0;
-        _RXbufferpos  = 0;
+    void InputBuffer::flushRx() {
+        begin();
+        Channel::flushRx();
     }
+
+    void InputBuffer::end() { begin(); }
 
     InputBuffer::operator bool() const { return true; }
 
@@ -70,13 +72,5 @@ namespace WebUI {
         }
     }
 
-    void InputBuffer::flush(void) {
-        //No need currently
-        //keep for compatibility
-    }
-
-    InputBuffer::~InputBuffer() {
-        _RXbufferSize = 0;
-        _RXbufferpos  = 0;
-    }
+    InputBuffer::~InputBuffer() { begin(); }
 }

--- a/FluidNC/src/WebUI/InputBuffer.h
+++ b/FluidNC/src/WebUI/InputBuffer.h
@@ -19,7 +19,7 @@ namespace WebUI {
         int    read(void);
         bool   push(const char* data);
         bool   push(char data);
-        void   flush(void);
+        void   flushRx(void) override;
 
         int rx_buffer_available() { return RXBUFFERSIZE - available(); }
 

--- a/FluidNC/src/WebUI/Serial2Socket.cpp
+++ b/FluidNC/src/WebUI/Serial2Socket.cpp
@@ -148,6 +148,12 @@ namespace WebUI {
         }
     }
 
+    void Serial_2_Socket::flushRx() {
+        _RXbufferSize = 0;
+        _RXbufferpos  = 0;
+        Channel::flush();
+    }
+
     Serial_2_Socket::~Serial_2_Socket() {
         if (_web_socket) {
             detachWS();

--- a/FluidNC/src/WebUI/Serial2Socket.h
+++ b/FluidNC/src/WebUI/Serial2Socket.h
@@ -52,6 +52,7 @@ namespace WebUI {
         bool push(const uint8_t* data, size_t length);
         bool push(const char* data);
         void flush(void);
+        void flushRx(void) override;
         void handle_flush();
         bool attachWS(WebSocketsServer* web_socket);
         bool detachWS();

--- a/FluidNC/src/WebUI/TelnetServer.cpp
+++ b/FluidNC/src/WebUI/TelnetServer.cpp
@@ -59,6 +59,12 @@ namespace WebUI {
         return no_error;
     }
 
+    void Telnet_Server::flushRx() {
+        _RXbufferSize = 0;
+        _RXbufferpos  = 0;
+        Channel::flushRx();
+    }
+
     void Telnet_Server::end() {
         _setupdone    = false;
         _RXbufferSize = 0;

--- a/FluidNC/src/WebUI/TelnetServer.h
+++ b/FluidNC/src/WebUI/TelnetServer.h
@@ -41,6 +41,7 @@ namespace WebUI {
         bool   push(uint8_t data);
         bool   push(const uint8_t* data, int datasize);
         void   flush() override {}
+        void   flushRx() override;
 
         int rx_buffer_available() override;
 

--- a/FluidNC/src/WebUI/WebClient.cpp
+++ b/FluidNC/src/WebUI/WebClient.cpp
@@ -44,6 +44,7 @@ namespace WebUI {
             _buflen = 0;
         }
     }
+    void WebClient::flushRx() { Channel::flushRx(); }
 
     WebClient::~WebClient() {
         flush();

--- a/FluidNC/src/WebUI/WebClient.h
+++ b/FluidNC/src/WebUI/WebClient.h
@@ -26,6 +26,8 @@ namespace WebUI {
         int read() { return -1; }
         int peek() { return -1; }
 
+        void flushRx() override;
+
         int rx_buffer_available() { return BUFLEN - available(); }
 
     private:


### PR DESCRIPTION
The Uart class, derived from Channel, has a queue to
capture data bytes while looking for a realtime characters.
That queue was holding data that had been sent ahead.