### PR TITLE
Increased $/stepping/segments default from 6 to 12

### DIFF
--- a/FluidNC/src/Stepping.h
+++ b/FluidNC/src/Stepping.h
@@ -43,7 +43,7 @@ namespace Machine {
         // execution lead time there is for other processes to run.  The latency for a feedhold or other
         // override is roughly 10 ms times _segments.
 
-        size_t _segments = 6;
+        size_t _segments = 12;
 
         uint8_t  _idleMsecs           = 255;
         uint32_t _pulseUsecs          = 4;


### PR DESCRIPTION
The default value of 6 results in clunky motion with programs containing many short segments.  Increasing the number smooths out the motion, at the expense of increasing the latency after receipt of a realtime character.  The value 12 results in a latency of about 120 ms, which is short compared to human reaction times.