### PR TITLE
Add possibility to perform only combination of axis homing (ex : XY or XZ or XYZ or ...)

### DIFF
--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -334,8 +334,43 @@ static Error home(int cycle) {
     }
     return Error::Ok;
 }
-static Error home_all(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    return home(Machine::Homing::AllCycles);
+static Error home_axis(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    const char* AxisNames = "XYZABC";
+    int requestedAxis = 0;
+    
+    //check if request form user is valid (meaning that all requested axis are existing)
+    if ( value ) {
+        for (int i = 0; i < strlen ( value ); i ++ ) {
+            if ( strchr ( AxisNames, toupper ( value[i] ) ) == NULL ) {
+                out.print ( "Argument not valid. Axis " );
+                out << value[i];
+                out << " is not existing\n";
+                out << "Please use combination of ";
+                out << AxisNames;
+                out << "\n";
+
+                return Error::InvalidValue;
+            }
+        }
+    }
+
+    //if no particular axis given by user, requestedAxis will stay at 0 (which is the value for all axis - Machine::Homing::AllCycles - explicit affectation however)
+    //Otherwise, value is calculated assuming axis values defined in NutsBolts.h
+    if ( value ) {
+
+        for (int i = 0; i < strlen ( AxisNames ); i ++ ) {
+            if ( ( strchr ( value, AxisNames[i] ) ) || ( strchr ( value, tolower( AxisNames[i] ) ) ) ) requestedAxis += 1 << i;    
+        }
+    } else 
+        requestedAxis = Machine::Homing::AllCycles;
+
+    log_debug("Home feature\n");
+    log_debug("Request from user : ");
+    log_debug ( value );
+    log_debug("Value calculated : ");
+    log_debug ( requestedAxis );
+    
+    return home( requestedAxis );
 }
 static Error home_x(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     return home(bitnum_to_mask(X_AXIS));
@@ -670,7 +705,7 @@ void make_user_commands() {
     new UserCommand("NVX", "Settings/Erase", Setting::eraseNVS, notIdleOrAlarm, WA);
     new UserCommand("V", "Settings/Stats", Setting::report_nvs_stats, notIdleOrAlarm);
     new UserCommand("#", "GCode/Offsets", report_ngc, notIdleOrAlarm);
-    new UserCommand("H", "Home", home_all, notIdleOrAlarm);
+    new UserCommand("H", "Home", home_axis, notIdleOrAlarm);
     new UserCommand("MD", "Motor/Disable", motor_disable, notIdleOrAlarm);
     new UserCommand("MI", "Motors/Init", motors_init, notIdleOrAlarm);
 

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -343,6 +343,9 @@ static Error home_x(const char* value, WebUI::AuthenticationLevel auth_level, Ch
 static Error home_y(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     return home(bitnum_to_mask(Y_AXIS));
 }
+static Error home_xy(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    return home(bitnum_to_mask(X_AXIS) | bitnum_to_mask(Y_AXIS));
+}
 static Error home_z(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     return home(bitnum_to_mask(Z_AXIS));
 }
@@ -673,6 +676,7 @@ void make_user_commands() {
 
     new UserCommand("HX", "Home/X", home_x, notIdleOrAlarm);
     new UserCommand("HY", "Home/Y", home_y, notIdleOrAlarm);
+    new UserCommand("HXY", "Home/XY", home_xy, notIdleOrAlarm);
     new UserCommand("HZ", "Home/Z", home_z, notIdleOrAlarm);
     new UserCommand("HA", "Home/A", home_a, notIdleOrAlarm);
     new UserCommand("HB", "Home/B", home_b, notIdleOrAlarm);


### PR DESCRIPTION
Hello,

I have added a user command to execute only XY home.
This is very useful when I don't want to change my Z or to risk any small deviation on XY when Z is moving (I'm using a laser machine with motorized bed)

Command is : $HXY

Related to this discussion : https://discord.com/channels/780079161460916227/979771214815977594

Thanks