### PR TITLE
$start/message NVS variable

### DIFF
--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -172,24 +172,72 @@ void report_feedback_message(Message message) {  // ok to send to all channels
 }
 
 #include "Uart.h"
+
+const char* radio =
+#if defined(ENABLE_WIFI) || defined(ENABLE_BLUETOOTH)
+#    ifdef ENABLE_WIFI
+    "wifi";
+#    endif
+#    ifdef ENABLE_BLUETOOTH
+"bt";
+#    endif
+#else
+    "noradio";
+#endif
+
 // Welcome message
+void report_init_message(Print& channel) {
+    channel << '\n';
+    const char* p = start_message->get();
+    char        c;
+    while ((c = *p++) != '\0') {
+        if (c == '\\') {
+            switch ((c = *p++)) {
+                case '\0':
+                    --p;  // Unconsume the null character
+                    break;
+                case 'H':
+                    channel << "'$' for help";
+                    break;
+                case 'B':
+                    channel << git_info;
+                    break;
+                case 'V':
+                    channel << grbl_version;
+                    break;
+                case 'R':
+                    channel << radio;
+                    break;
+                default:
+                    channel << c;
+                    break;
+            }
+        } else {
+            channel << c;
+        }
+    }
+    channel << '\n';
+}
+
+#if 0
 void report_init_message(Print& channel) {
     channel << "\r\nGrbl " << grbl_version << " [FluidNC " << git_info << " (";
 
-#if defined(ENABLE_WIFI) || defined(ENABLE_BLUETOOTH)
-#    ifdef ENABLE_WIFI
+#    if defined(ENABLE_WIFI) || defined(ENABLE_BLUETOOTH)
+#        ifdef ENABLE_WIFI
     channel << "wifi";
-#    endif
+#        endif
 
-#    ifdef ENABLE_BLUETOOTH
+#        ifdef ENABLE_BLUETOOTH
     channel << "bt";
-#    endif
-#else
+#        endif
+#    else
     channel << "noradio";
-#endif
+#    endif
 
     channel << ") '$' for help]\n";
 }
+#endif
 
 // Prints current probe parameters. Upon a probe command, these parameters are updated upon a
 // successful probe or upon a failed probe with the G38.3 without errors command (if supported).

--- a/FluidNC/src/SettingsDefinitions.cpp
+++ b/FluidNC/src/SettingsDefinitions.cpp
@@ -5,6 +5,8 @@ StringSetting* config_filename;
 
 StringSetting* build_info;
 
+StringSetting* start_message;
+
 IntSetting* status_mask;
 
 EnumSetting* message_level;
@@ -53,4 +55,7 @@ void make_settings() {
     status_mask = new IntSetting("What to include in status report", GRBL, WG, "10", "Report/Status", 1, 0, 3, NULL);
 
     build_info = new StringSetting("OEM build info for $I command", EXTENDED, WG, NULL, "Firmware/Build", "", 0, 20, NULL);
+
+    start_message =
+        new StringSetting("Message issued at startup", EXTENDED, WG, NULL, "Start/Message", "Grbl \\V [FluidNC \\B (\\R) \\H]", 0, 40, NULL);
 }

--- a/FluidNC/src/SettingsDefinitions.h
+++ b/FluidNC/src/SettingsDefinitions.h
@@ -6,6 +6,8 @@ extern StringSetting* config_filename;
 
 extern StringSetting* build_info;
 
+extern StringSetting* start_message;
+
 extern IntSetting* status_mask;
 
 extern EnumSetting* message_level;


### PR DESCRIPTION
Accepts these substitution sequences:

\V - expands to version info like: 3.4
\B - expands to build info like: v3.4.6 (Devt-827770e-dirty)
\R - expands to radio info like: wifi
\H - expands to: '$' for help

The default value is: Grbl \V [FluidNC \B (\R) \H]