### PR TITLE
Typo in WiFi informational output

### DIFF
--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -342,7 +342,7 @@ namespace WebUI {
             if (WiFi.getMode() == WIFI_MODE_APSTA) {
                 result += "]\n[MSG:";
             }
-            result += "Mode=AP:SSDI=";
+            result += "Mode=AP:SSID=";
             wifi_config_t conf;
             esp_wifi_get_config(WIFI_IF_AP, &conf);
             result += (const char*)conf.ap.ssid;


### PR DESCRIPTION
The configuration for WiFi contained transposed characters in output
when calling `WiFiConfig::info()`.  This fixes that typo.