### PR TITLE
Load exception decoder filter only once

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,6 @@ board_build.partitions = min_spiffs.csv ; For 4M ESP32
 monitor_speed = 115200
 monitor_flags = 
 	--eol=LF
-	--filter=esp32_exception_decoder
 monitor_filters=esp32_exception_decoder
 board_build.f_flash = 80000000L
 build_flags = ${common.build_flags}


### PR DESCRIPTION
platformio.ini was inadvertently asking for the esp32 exception
decoder filter to be loaded twice into the pio monitor program,
causing problems with exception decoding.  This patch makes it
load only once, which helps with, but does not by itself solve,
exception decoding problems.  For the other necessary fixes,
see https://github.com/espressif/esp-idf/pull/9138
and https://github.com/platformio/platform-espressif32/pull/831

The first one is the correct fix to the root problem, while
the second one is a pragmatic short-term workaround.