### PR TITLE
c2c7ce5 broke WebUI because of a JSON escaping problem

### DIFF
--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -890,7 +890,7 @@ Error settings_execute_line(char* line, Channel& out, WebUI::AuthenticationLevel
 
     char* value;
     if (*line++ == '[') {  // [ESPxxx] form
-        value = strrchr(line, ']');
+        value = strchr(line, ']');
         if (!value) {
             // Missing ] is an error in this form
             return Error::InvalidStatement;

--- a/FluidNC/src/WebUI/JSONEncoder.cpp
+++ b/FluidNC/src/WebUI/JSONEncoder.cpp
@@ -43,7 +43,36 @@ namespace WebUI {
     // Private function to add a name enclosed with quotes.
     void JSONencoder::quoted(const char* s) {
         add('"');
-        stream << s;
+        char c;
+        while ((c = *s++) != '\0') {
+            // Escape JSON special characters
+            switch (c) {
+                case '\b':
+                    stream << "\\b";
+                    break;
+                case '\n':
+                    stream << "\\n";
+                    break;
+                case '\f':
+                    stream << "\\f";
+                    break;
+                case '\r':
+                    stream << "\\r";
+                    break;
+                case '\t':
+                    stream << "\\t";
+                    break;
+                case '"':
+                    stream << "\\\"";
+                    break;
+                case '\\':
+                    stream << "\\\\";
+                    break;
+                default:
+                    stream << c;
+                    break;
+            }
+        }
         add('"');
     }
 


### PR DESCRIPTION
In addition to escaping the JSON special characters, there was a related bug in the way that incoming [ESPxxx] commands were being parsed.  If the value string contained ']', the command would be misparsed and rejected.