### PR TITLE
Fixed spindle override motion pause problem

### DIFF
--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -432,8 +432,7 @@ void mc_reset() {
         // NOTE: If steppers are kept enabled via the step idle delay setting, this also keeps
         // the steppers enabled by avoiding the go_idle call altogether, unless the motion state is
         // violated, by which, all bets are off.
-        if ((sys.state == State::Cycle || sys.state == State::Homing || sys.state == State::Jog) ||
-            (sys.step_control.executeHold || sys.step_control.executeSysMotion)) {
+        if (inMotionState() || sys.step_control.executeHold || sys.step_control.executeSysMotion) {
             if (sys.state == State::Homing) {
                 if (rtAlarm == ExecAlarm::None) {
                     rtAlarm = ExecAlarm::HomingFailReset;

--- a/FluidNC/src/Motors/TrinamicBase.cpp
+++ b/FluidNC/src/Motors/TrinamicBase.cpp
@@ -25,7 +25,7 @@ namespace MotorDrivers {
         xLastWakeTime = xTaskGetTickCount();  // Initialise the xLastWakeTime variable with the current time.
         while (true) {                        // don't ever return from this or the task dies
             std::atomic_thread_fence(std::memory_order::memory_order_seq_cst);  // read fence for settings
-            if (sys.state == State::Cycle || sys.state == State::Homing || sys.state == State::Jog) {
+            if (inMotionState()) {
                 for (TrinamicBase* p = List; p; p = p->link) {
                     if (p->_stallguardDebugMode) {
                         //log_info("SG:" << p->_stallguardDebugMode);

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -649,9 +649,9 @@ static void protocol_execute_overrides() {
         sys.spindle_speed_ovr               = rtSOverride;
         report_ovr_counter                  = 0;  // Set to report change immediately
 
-        // XXX this might not be necessary if the override is processed at the right level
         // If spindle is on, tell it the RPM has been overridden
-        if (gc_state.modal.spindle != SpindleState::Disable) {
+        // When moving, the override is handled by the stepping code
+        if (gc_state.modal.spindle != SpindleState::Disable && !inMotionState()) {
             spindle->setState(gc_state.modal.spindle, gc_state.spindle_speed);
             report_ovr_counter = 0;  // Set to report change immediately
         }

--- a/FluidNC/src/System.cpp
+++ b/FluidNC/src/System.cpp
@@ -94,3 +94,7 @@ std::map<State, const char*> StateName = {
     { State::Sleep, "Sleep" },
     { State::ConfigAlarm, "ConfigAlarm" },
 };
+
+bool inMotionState() {
+    return sys.state == State::Cycle || sys.state == State::Homing || sys.state == State::Jog;
+}

--- a/FluidNC/src/System.h
+++ b/FluidNC/src/System.h
@@ -88,3 +88,5 @@ int32_t* get_motor_steps();
 // Updates a machine position array from a steps array
 void   motor_steps_to_mpos(float* position, int32_t* steps);
 float* get_mpos();
+
+bool inMotionState();  // True if moving, i.e. the stepping engine is active

--- a/FluidNC/src/WebUI/WebServer.cpp
+++ b/FluidNC/src/WebUI/WebServer.cpp
@@ -240,7 +240,7 @@ namespace WebUI {
         // This can make it hard to debug ISR IRAM problems, because the easiest
         // way to trigger such problems is to refresh WebUI during motion.
         // If you need to do such debugging, comment out this check temporarily.
-        if (sys.state == State::Cycle || sys.state == State::Jog || sys.state == State::Homing) {
+        if (inMotionState()) {
             //           _webserver->send(503, "text/plain", "FluidNC is busy running GCode.  Try again later.");
             //            _webserver->sendHeader("Cache-Control", "no-cache");
             _webserver->send(200,


### PR DESCRIPTION
Motion would pause when a spindle override realtime character was received and the spindle was on.