### PR TITLE
Disable CR-adding when transferring files via XModem

### DIFF
--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -644,10 +644,10 @@ static Error xmodem_send(const char* value, WebUI::AuthenticationLevel auth_leve
         log_info("Cannot open " << value);
         return Error::DownloadFailed;
     }
-    bool prevAddCr = out.setCr(false);
+    bool oldCr = out.setCr(false);
     log_info("Sending " << value << " via XModem");
     int size = xmodemTransmit(&out, infile);
-    out.setCr(prevAddCr);
+    out.setCr(oldCr);
     delete infile;
     if (size >= 0) {
         log_info("Sent " << size << " bytes");

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -644,8 +644,10 @@ static Error xmodem_send(const char* value, WebUI::AuthenticationLevel auth_leve
         log_info("Cannot open " << value);
         return Error::DownloadFailed;
     }
+    bool prevAddCr = out.setCr(false);
     log_info("Sending " << value << " via XModem");
     int size = xmodemTransmit(&out, infile);
+    out.setCr(prevAddCr);
     delete infile;
     if (size >= 0) {
         log_info("Sent " << size << " bytes");


### PR DESCRIPTION
The UART channel have a feature for adding extra CR on line feeds enabled, which will break the XModem protocol. This fix will disable the extra CR adding and restore the setting after the file is sent.

It would be more sensible to toggle this in xmodem.cpp if this would be used in other places. But that function has multiple returns which makes it really hard and would require a bit of refactoring:
https://github.com/bdring/FluidNC/blob/main/FluidNC/src/xmodem.cpp#L243

