### PR TITLE
Allow to query the build info even if the controller is in an alarm state

### DIFF
--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -736,7 +736,7 @@ void make_user_commands() {
     new UserCommand("HC", "Home/C", home_c, notIdleOrAlarm);
 
     new UserCommand("SLP", "System/Sleep", go_to_sleep, notIdleOrAlarm);
-    new UserCommand("I", "Build/Info", get_report_build_info, notIdleOrAlarm);
+    new UserCommand("I", "Build/Info", get_report_build_info, anyState);
     new UserCommand("N", "GCode/StartupLines", report_startup_lines, notIdleOrAlarm);
     new UserCommand("RST", "Settings/Restore", restore_settings, notIdleOrAlarm, WA);
 


### PR DESCRIPTION
When connecting to a controller we need to know that it is a FluidNC machine and which version, and the best way is (as far as I know) to query the build info. 

If the controller is in an alarm state this information can't be queried, making it impossible to know what controller we have connected to. I propose to make this command available in any state.