### PR TITLE
Fixed mist cooling status

### DIFF
--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -433,7 +433,7 @@ void report_build_info(const char* line, Print& channel) {
     channel << "[VER:" << grbl_version << " FluidNC " << git_info << ":" << line << "]\n";
     channel << "[OPT:";
     if (config->_coolant->hasMist()) {
-        channel << "M";  // TODO Need to deal with M8...it could be disabled
+        channel << "M";
     }
     channel << "PH";
     if (ALLOW_FEED_OVERRIDE_DURING_PROBE_CYCLES) {
@@ -676,11 +676,10 @@ void report_realtime_status(Channel& channel) {
             }
 
             auto coolant = coolant_state;
-            // XXX WMB why .Flood in one case and ->hasMist() in the other? also see above
             if (coolant.Flood) {
                 channel << "F";
             }
-            if (config->_coolant->hasMist()) {
+            if (coolant.Mist) {
                 channel << "M";
             }
         }


### PR DESCRIPTION
As the title suggests this is a small fix for the status of mist cooling.

Config:
Mist pin is defined in config

Behavior before this fix:
M7 would report correctly
M9 would report correctly
M3 SXXX and M4 SXXX would report mist cooling being enabled even when it isnt

Behavior after this fix:
M7 would report correctly
M9 would report correctly
M3 SXXX and M4 SXXX no longer report mist cooling being enabled

What was happening is that the existence of a mist cooling pin was reported instead of the actual status.
