### PR TITLE
bug: Logic error: state cannot be both Cycle & Hold

### DIFF
--- a/FluidNC/src/Settings.cpp
+++ b/FluidNC/src/Settings.cpp
@@ -21,7 +21,7 @@ bool notIdleOrAlarm() {
     return sys.state != State::Idle && sys.state != State::Alarm && sys.state != State::ConfigAlarm;
 }
 bool cycleOrHold() {
-    return sys.state == State::Cycle && sys.state == State::Hold;
+    return sys.state == State::Cycle || sys.state == State::Hold;
 }
 
 Word::Word(type_t type, permissions_t permissions, const char* description, const char* grblName, const char* fullName) :


### PR DESCRIPTION
The logical conjunction introduced in the `cycleOrHold` function will
always evaluate to false.