### PR TITLE
Wallplotter feedrate logic

### DIFF
--- a/FluidNC/src/Spindles/BESCSpindle.h
+++ b/FluidNC/src/Spindles/BESCSpindle.h
@@ -34,8 +34,8 @@ namespace Spindles {
         const uint32_t besc_pwm_max_freq = 2000;  // 50 Hz
 
         // Calculated
-        uint16_t _pulse_span_counts;  // In counts of a 16-bit counter
-        uint16_t _min_pulse_counts;   // In counts of a 16-bit counter
+        uint32_t _pulse_span_counts;  // In counts of a 32-bit counter. ESP32 uses up to 20bits
+        uint32_t _min_pulse_counts;   // In counts of a 32-bit counter  ESP32 uses up to 20bits
 
     protected:
         // Configurable

--- a/FluidNC/src/Spindles/PWMSpindle.h
+++ b/FluidNC/src/Spindles/PWMSpindle.h
@@ -59,7 +59,7 @@ namespace Spindles {
         virtual ~PWM() {}
 
     protected:
-        int32_t _current_pwm_duty = 0;
+        uint32_t _current_pwm_duty = 0;
         PwmPin* _pwm              = nullptr;
 
         // Configurable

--- a/example_configs/WallPlotter.yaml
+++ b/example_configs/WallPlotter.yaml
@@ -104,7 +104,7 @@ besc:
   spindown_ms: 2000
   tool_num: 100
   speed_map: 0=0.000% 255=100.000%
-  min_pulse_us: 600
-  max_pulse_us: 2300
+  min_pulse_us: 700
+  max_pulse_us: 2200
 
 


### PR DESCRIPTION
Finally got around to fixing feed rate logic in wallplotter kinematics so that feedrates in cartesian space are segmented and translated into kinematic space. Also fixed segmentation bug where only one axis was being used for determining segmentation amount. 
Also uncovered problem with the way PWM/Servo pulses were being generated under ESP32. This involved changes to convert logic to 32bit for the speedmap in the BESC code. I have tried two different methods for the speedmap. One involves doing 64 bit math on the entire PWM period speedmap. The other involves using the speed map logic on just the portion of the pulse that is changing in the servo pulse which is less intuitive, but more efficient as it only involves 32 bit math.  Both work. I have run the wallplotter successfully with both methods and verified waveforms on oscilloscope for both. Sticking with 64 bit version for now as it is clearer????