### PR TITLE
Rebase of #575 onto Devt, Thanks to grittershub

### DIFF
--- a/FluidNC/src/Motors/TMC2208Driver.cpp
+++ b/FluidNC/src/Motors/TMC2208Driver.cpp
@@ -64,7 +64,17 @@ namespace MotorDrivers {
         }
     }
 
-    bool TMC2208Driver::test() { return TrinamicBase::reportTest(tmc2208->test_connection()); }
+    bool TMC2208Driver::test() {
+        uint8_t ifcnt_before = tmc2208->IFCNT();
+        tmc2208->GSTAT(0);  // clear GSTAT to increase ifcnt
+        uint8_t ifcnt_after = tmc2208->IFCNT();
+        bool    okay        = ((ifcnt_before + 1) & 0xff) == ifcnt_after;
+        if (!okay) {
+            TrinamicBase::reportCommsFailure();
+            return false;
+        }
+        return true;
+    }
 
     // Configuration registration
     namespace {

--- a/FluidNC/src/Motors/TMC2209Driver.cpp
+++ b/FluidNC/src/Motors/TMC2209Driver.cpp
@@ -48,11 +48,11 @@ namespace MotorDrivers {
         // The TMCStepper library uses the value 0 to mean 1x microstepping
         int usteps = _microsteps == 1 ? 0 : _microsteps;
         tmc2209->microsteps(usteps);
-        tmc2209->pdn_disable(true); // powerdown pin is disabled. uses ihold.
+        tmc2209->pdn_disable(true);  // powerdown pin is disabled. uses ihold.
 
         switch (_mode) {
             case TrinamicMode ::StealthChop:
-                log_debug(axisName() <<  " StealthChop");
+                log_debug(axisName() << " StealthChop");
                 tmc2209->en_spreadCycle(false);
                 tmc2209->pwm_autoscale(true);
                 break;
@@ -65,7 +65,7 @@ namespace MotorDrivers {
             {
                 auto axisConfig     = config->_axes->_axis[this->axis_index()];
                 auto homingFeedRate = (axisConfig->_homing != nullptr) ? axisConfig->_homing->_feedRate : 200;
-                log_debug(axisName() <<  " Stallguard");
+                log_debug(axisName() << " Stallguard");
                 tmc2209->en_spreadCycle(false);
                 tmc2209->pwm_autoscale(false);
                 tmc2209->TCOOLTHRS(calc_tstep(homingFeedRate, 150.0));
@@ -87,10 +87,8 @@ namespace MotorDrivers {
         }
         float feedrate = Stepper::get_realtime_rate();  //* settings.microsteps[axis_index] / 60.0 ; // convert mm/min to Hz
 
-        // TMC2208 does not have StallGuard
         if (tmc2209) {
-            log_info(axisName() << " SG_Val: " << tmc2209->SG_RESULT() << "   Rate: " << feedrate
-                                << " mm/min SG_Setting:" << _stallguard);
+            log_info(axisName() << " SG_Val: " << tmc2209->SG_RESULT() << "   Rate: " << feedrate << " mm/min SG_Setting:" << _stallguard);
         }
     }
 
@@ -102,7 +100,17 @@ namespace MotorDrivers {
         }
     }
 
-    bool TMC2209Driver::test() { return TrinamicBase::reportTest(tmc2209->test_connection()); }
+    bool TMC2209Driver::test() {
+        uint8_t ifcnt_before = tmc2209->IFCNT();
+        tmc2209->GSTAT(0);  // clear GSTAT to increase ifcnt
+        uint8_t ifcnt_after = tmc2209->IFCNT();
+        bool    okay        = ((ifcnt_before + 1) & 0xff) == ifcnt_after;
+        if (!okay) {
+            TrinamicBase::reportCommsFailure();
+            return false;
+        }
+        return true;
+    }
 
     // Configuration registration
     namespace {

--- a/FluidNC/src/Motors/TrinamicBase.cpp
+++ b/FluidNC/src/Motors/TrinamicBase.cpp
@@ -120,6 +120,8 @@ namespace MotorDrivers {
         }
     }
 
+    void TrinamicBase::reportCommsFailure(void) { log_info(axisName() << " communications check failed"); }
+
     bool TrinamicBase::startDisable(bool disable) {
         if (_has_errors) {
             return false;

--- a/FluidNC/src/Motors/TrinamicBase.h
+++ b/FluidNC/src/Motors/TrinamicBase.h
@@ -60,6 +60,7 @@ namespace MotorDrivers {
         bool         set_homing_mode(bool isHoming);
         virtual void set_registers(bool isHoming) {}
         bool         reportTest(uint8_t result);
+        void         reportCommsFailure(void);
         bool         startDisable(bool disable);
         virtual void config_motor();
 


### PR DESCRIPTION
This fixes a problem with accurately determining whether it is possible to test UART communication to TMC2208 and TMC2209 chips.  The original PR for the fix is #575 but that one was PR'ed against main and attempts to rebase it automatically caused some glitches.  So I moved the changes on top of Devt manually.