### PR TITLE
Revamp and fix parking.  It is now configurable.

### DIFF
--- a/FluidNC/src/Config.h
+++ b/FluidNC/src/Config.h
@@ -197,14 +197,6 @@ const bool FORCE_BUFFER_SYNC_DURING_WCO_CHANGE = true;  // Default enabled. Comm
 // repeatable. If needed, you can disable this behavior by uncommenting the define below.
 const bool ALLOW_FEED_OVERRIDE_DURING_PROBE_CYCLES = false;
 
-// Configure options for the parking motion, if enabled.
-#define PARKING_AXIS Z_AXIS                      // Define which axis that performs the parking motion
-const double PARKING_TARGET            = -5.0;   // Parking axis target. In mm, as machine coordinate.
-const double PARKING_RATE              = 800.0;  // Parking fast rate after pull-out in mm/min.
-const double PARKING_PULLOUT_RATE      = 250.0;  // Pull-out/plunge slow feed rate in mm/min.
-const double PARKING_PULLOUT_INCREMENT = 5.0;    // Spindle pull-out and plunge distance in mm. Incremental distance.
-// Must be positive value or equal to zero.
-
 // INCLUDE_OLED_IO enables access to a basic OLED library.  To use it you must uncomment the
 //  "thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays" line in platformio.ini
 // You must uncomment it if you use either INCLUDE_OLED_TINY or INCLUDE_OLED_BASIC

--- a/FluidNC/src/Machine/Axes.cpp
+++ b/FluidNC/src/Machine/Axes.cpp
@@ -8,9 +8,7 @@
 #include "MachineConfig.h"  // config->
 #include "../Limits.h"
 
-EnumItem axisType[] = {
-    { 0, "X" }, { 1, "Y" }, { 2, "Z" }, { 3, "A" }, { 4, "B" }, { 5, "C" },
-};
+EnumItem axisType[] = { { 0, "X" }, { 1, "Y" }, { 2, "Z" }, { 3, "A" }, { 4, "B" }, { 5, "C" }, EnumItem(0) };
 
 namespace Machine {
     MotorMask Axes::posLimitMask = 0;

--- a/FluidNC/src/Machine/Axes.cpp
+++ b/FluidNC/src/Machine/Axes.cpp
@@ -8,6 +8,10 @@
 #include "MachineConfig.h"  // config->
 #include "../Limits.h"
 
+EnumItem axisType[] = {
+    { 0, "X" }, { 1, "Y" }, { 2, "Z" }, { 3, "A" }, { 4, "B" }, { 5, "C" },
+};
+
 namespace Machine {
     MotorMask Axes::posLimitMask = 0;
     MotorMask Axes::negLimitMask = 0;

--- a/FluidNC/src/Machine/Axes.h
+++ b/FluidNC/src/Machine/Axes.h
@@ -6,6 +6,7 @@
 
 #include "../Configuration/Configurable.h"
 #include "Axis.h"
+#include "../EnumItem.h"
 
 namespace MotorDrivers {
     class MotorDriver;
@@ -80,3 +81,4 @@ namespace Machine {
         ~Axes();
     };
 }
+extern EnumItem axisType[];

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -47,6 +47,7 @@ namespace Machine {
         handler.section("probe", _probe);
         handler.section("macros", _macros);
         handler.section("start", _start);
+        handler.section("parking", _parking);
 
         handler.section("user_outputs", _userOutputs);
         // TODO: Consider putting these under a gcode: hierarchy level? Or motion control?
@@ -104,6 +105,10 @@ namespace Machine {
 
         if (_start == nullptr) {
             _start = new Start();
+        }
+
+        if (_parking == nullptr) {
+            _parking = new Parking();
         }
 
         if (_spindles.size() == 0) {

--- a/FluidNC/src/Machine/MachineConfig.h
+++ b/FluidNC/src/Machine/MachineConfig.h
@@ -13,6 +13,7 @@
 #include "../WebUI/BTConfig.h"
 #include "../Control.h"
 #include "../Probe.h"
+#include "src/Parking.h"
 #include "../SDCard.h"
 #include "../Spindles/Spindle.h"
 #include "../Stepping.h"
@@ -67,6 +68,7 @@ namespace Machine {
         SDCard*               _sdCard      = nullptr;
         Macros*               _macros      = nullptr;
         Start*                _start       = nullptr;
+        Parking*              _parking     = nullptr;
         Spindles::SpindleList _spindles;
 
         float _arcTolerance      = 0.002f;

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -350,31 +350,6 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, bool away, 
     }
 }
 
-// Plans and executes the single special motion case for parking. Independent of main planner buffer.
-// NOTE: Uses the always free planner ring buffer head to store motion parameters for execution.
-void mc_parking_motion(float* parking_target, plan_line_data_t* pl_data) {
-    if (sys.abort) {
-        return;  // Block during abort.
-    }
-    if (plan_buffer_line(parking_target, pl_data)) {
-        sys.step_control.executeSysMotion = true;
-        sys.step_control.endMotion        = false;  // Allow parking motion to execute, if feed hold is active.
-        Stepper::parking_setup_buffer();            // Setup step segment buffer for special parking motion case
-        Stepper::prep_buffer();
-        Stepper::wake_up();
-        do {
-            protocol_exec_rt_system();
-            if (sys.abort) {
-                return;
-            }
-        } while (sys.step_control.executeSysMotion);
-        Stepper::parking_restore_buffer();  // Restore step segment buffer to normal run state.
-    } else {
-        sys.step_control.executeSysMotion = false;
-        protocol_exec_rt_system();
-    }
-}
-
 void mc_override_ctrl_update(Override override_state) {
     // Finish all queued commands before altering override control state
     protocol_buffer_synchronize();

--- a/FluidNC/src/MotionControl.h
+++ b/FluidNC/src/MotionControl.h
@@ -46,17 +46,11 @@ void mc_arc(float*            target,
 // Dwell for a specific number of seconds
 bool mc_dwell(int32_t milliseconds);
 
-// Perform homing cycle to locate machine zero. Requires limit switches.
-void mc_homing_cycle(AxisMask cycle_mask);
-
 // Perform tool length probe cycle. Requires probe switch.
 GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, bool away, bool no_error, uint8_t offsetAxis, float offset);
 
 // Handles updating the override control state.
 void mc_override_ctrl_update(Override override_state);
-
-// Plans and executes the single special motion case for parking. Independent of main planner buffer.
-void mc_parking_motion(float* parking_target, plan_line_data_t* pl_data);
 
 // Performs system reset. If in motion state, kills all motion and sets system alarm.
 void mc_reset();

--- a/FluidNC/src/Parking.cpp
+++ b/FluidNC/src/Parking.cpp
@@ -193,9 +193,9 @@ void Parking::restore_coolant() {
 
 void Parking::group(Configuration::HandlerBase& handler) {
     handler.item("enable", _enable);
-    handler.item("target_mpos_mm", _target_mpos);
-    handler.item("pullout_distance_mm", _pullout, 0, 3e38);
-    handler.item("rate_mm_per_min", _rate);
-    handler.item("pullout_rate_mm_per_min", _pullout_rate);
     handler.item("axis", _axis, axisType);
+    handler.item("target_mpos_mm", _target_mpos);
+    handler.item("rate_mm_per_min", _rate);
+    handler.item("pullout_distance_mm", _pullout, 0, 3e38);
+    handler.item("pullout_rate_mm_per_min", _pullout_rate);
 }

--- a/FluidNC/src/Parking.cpp
+++ b/FluidNC/src/Parking.cpp
@@ -1,0 +1,201 @@
+// Copyright (c) 2022 - Mitch Bradley
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#include "Parking.h"
+#include "Logging.h"
+#include "System.h"                 // sys
+#include "Stepper.h"                // Stepper::
+#include "Machine/MachineConfig.h"  // config
+#include "Spindles/Spindle.h"       // spindle
+
+// Plans and executes the single special motion case for parking. Independent of main planner buffer.
+// NOTE: Uses the always free planner ring buffer head to store motion parameters for execution.
+void Parking::moveto(float* target) {
+    if (sys.abort) {
+        return;  // Block during abort.
+    }
+    if (plan_buffer_line(target, &plan_data)) {
+        sys.step_control.executeSysMotion = true;
+        sys.step_control.endMotion        = false;  // Allow parking motion to execute, if feed hold is active.
+        Stepper::parking_setup_buffer();            // Setup step segment buffer for special parking motion case
+        Stepper::prep_buffer();
+        Stepper::wake_up();
+        do {
+            pollChannels();  // Handle realtime commands like status report, cycle start and reset
+            protocol_exec_rt_system();
+            if (sys.abort) {
+                return;
+            }
+        } while (sys.step_control.executeSysMotion);
+        Stepper::parking_restore_buffer();  // Restore step segment buffer to normal run state.
+    } else {
+        sys.step_control.executeSysMotion = false;
+        protocol_exec_rt_system();
+    }
+}
+
+bool Parking::can_park() {
+    if (!_enable) {
+        return false;
+    }
+    if (spindle->isRateAdjusted()) {
+        // No parking in Laser mode
+        return false;
+    }
+    if (!Machine::Axes::homingMask) {
+        // No parking without homing
+        return false;
+    }
+    if (!config->_enableParkingOverrideControl) {
+        // _enableParkingOverrideControl adds M56 whereby you can
+        // disable parking via GCode.  If that feature is not present,
+        // parking is enabled subject to the preceding tests.
+        return true;
+    }
+    // If the M56 feature is present, M56 controls the value
+    // of sys.override_ctrl, thus letting you disable parking
+    // by saying M56 P0
+    return sys.override_ctrl == Override::ParkingMotion;
+}
+
+void Parking::setup() {
+    // Initialize parking local variables
+    retract_waypoint = _pullout;
+    memset(&plan_data, 0, sizeof(plan_line_data_t));
+    plan_data.motion                = {};
+    plan_data.motion.systemMotion   = 1;
+    plan_data.motion.noFeedOverride = 1;
+    plan_data.line_number           = PARKING_MOTION_LINE_NUMBER;
+    block                           = plan_get_current_block();
+
+    if (block) {
+        saved_coolant       = block->coolant;
+        saved_spindle       = block->spindle;
+        saved_spindle_speed = block->spindle_speed;
+    } else {
+        saved_coolant       = gc_state.modal.coolant;
+        saved_spindle       = gc_state.modal.spindle;
+        saved_spindle_speed = gc_state.spindle_speed;
+    }
+}
+
+void Parking::set_target() {
+    copyAxes(parking_target, get_mpos());
+}
+
+void Parking::park(bool restart) {
+    if (!restart) {
+        // Get current position and store restore location and spindle retract waypoint.
+        copyAxes(restore_target, parking_target);
+        retract_waypoint += restore_target[_axis];
+        retract_waypoint = MIN(retract_waypoint, _target_mpos);
+    }
+
+    if (can_park() && parking_target[_axis] < _target_mpos) {
+        // Retract spindle by pullout distance. Ensure retraction motion moves away from
+        // the workpiece and waypoint motion doesn't exceed the parking target location.
+        if (parking_target[_axis] < retract_waypoint) {
+            log_debug("Parking pullout");
+            parking_target[_axis]   = retract_waypoint;
+            plan_data.feed_rate     = _pullout_rate;
+            plan_data.coolant       = saved_coolant;
+            plan_data.spindle       = saved_spindle;
+            plan_data.spindle_speed = saved_spindle_speed;
+            moveto(parking_target);
+        }
+
+        // NOTE: Clear accessory state after retract and after an aborted restore motion.
+        plan_data.spindle               = SpindleState::Disable;
+        plan_data.coolant               = {};
+        plan_data.motion                = {};
+        plan_data.motion.systemMotion   = 1;
+        plan_data.motion.noFeedOverride = 1;
+        plan_data.spindle_speed         = 0.0;
+
+        log_debug("Spin down");
+        spindle->spinDown();
+        report_ovr_counter = 0;  // Set to report change immediately
+
+        // Execute fast parking retract motion to parking target location.
+        if (parking_target[_axis] < _target_mpos) {
+            log_debug("Parking motion");
+            parking_target[_axis] = _target_mpos;
+            plan_data.feed_rate   = _rate;
+            moveto(parking_target);
+        }
+    } else {
+        log_debug("Spin down only");
+        // Parking motion not possible. Just disable the spindle and coolant.
+        // NOTE: Laser mode does not start a parking motion to ensure the laser stops immediately.
+        spindle->spinDown();
+        config->_coolant->off();
+        report_ovr_counter = 0;  // Set to report changes immediately
+    }
+}
+void Parking::unpark(bool restart) {
+    // Execute fast restore motion to the pull-out position. Parking requires homing enabled.
+    // NOTE: State is will remain DOOR, until the de-energizing and retract is complete.
+    if (can_park()) {
+        // Check to ensure the motion doesn't move below pull-out position.
+        if (parking_target[_axis] <= _target_mpos) {
+            log_debug("Parking return to pullout position");
+            parking_target[_axis] = retract_waypoint;
+            plan_data.feed_rate   = _rate;
+            moveto(parking_target);
+        }
+    }
+
+    // Delayed Tasks: Restart spindle and coolant, delay to power-up, then resume cycle.
+    if (gc_state.modal.spindle != SpindleState::Disable) {
+        // Block if safety door re-opened during prior restore actions.
+        if (!restart) {
+            if (spindle->isRateAdjusted()) {
+                // When in laser mode, defer turn on until cycle starts
+                sys.step_control.updateSpindleSpeed = true;
+            } else {
+                log_debug("Spin up");
+                restore_spindle();
+                report_ovr_counter = 0;  // Set to report change immediately
+            }
+        }
+    }
+    if (gc_state.modal.coolant.Flood || gc_state.modal.coolant.Mist) {
+        // Block if safety door re-opened during prior restore actions.
+        if (!restart) {
+            restore_coolant();
+            report_ovr_counter = 0;  // Set to report change immediately
+        }
+    }
+
+    // Execute slow plunge motion from pull-out position to resume position.
+    if (can_park()) {
+        // Block if safety door re-opened during prior restore actions.
+        if (!restart) {
+            log_debug("Parking restore original state");
+            // Whether or not a retraction happened, returning to the original
+            // position should be valid, whether it moves or not.
+            plan_data.feed_rate     = _pullout_rate;
+            plan_data.spindle       = saved_spindle;
+            plan_data.coolant       = saved_coolant;
+            plan_data.spindle_speed = saved_spindle_speed;
+            moveto(restore_target);
+        }
+    }
+}
+
+void Parking::restore_spindle() {
+    spindle->setState(saved_spindle, saved_spindle_speed);
+}
+
+void Parking::restore_coolant() {
+    config->_coolant->set_state(saved_coolant);
+}
+
+void Parking::group(Configuration::HandlerBase& handler) {
+    handler.item("enable", _enable);
+    handler.item("target_mpos_mm", _target_mpos);
+    handler.item("pullout_distance_mm", _pullout, 0, 3e38);
+    handler.item("rate_mm_per_min", _rate);
+    handler.item("pullout_rate_mm_per_min", _pullout_rate);
+    handler.item("axis", _axis, axisType);
+}

--- a/FluidNC/src/Parking.cpp
+++ b/FluidNC/src/Parking.cpp
@@ -42,7 +42,7 @@ bool Parking::can_park() {
         // No parking in Laser mode
         return false;
     }
-    if (!Machine::Axes::homingMask) {
+    if (bitnum_is_false(Machine::Axes::homingMask, _axis)) {
         // No parking without homing
         return false;
     }

--- a/FluidNC/src/Parking.h
+++ b/FluidNC/src/Parking.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 -	Mitch Bradley
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "Configuration/HandlerBase.h"
+#include "Configuration/Configurable.h"
+
+#include "GCode.h"         // CoolantState etc
+#include "Planner.h"       // plan_line_data_t
+#include "Machine/Axes.h"  // axisType
+
+#include <cstdint>
+
+class Parking : public Configuration::Configurable {
+private:
+    // Configuration
+    bool  _enable       = false;
+    float _target_mpos  = -5.0;
+    float _pullout      = 5.0;
+    float _rate         = 800.0;
+    float _pullout_rate = 250.0;
+    int   _axis         = 2;  // Default to Z
+
+    // local variables
+    float parking_target[MAX_N_AXIS];
+    float restore_target[MAX_N_AXIS];
+    float retract_waypoint;
+
+    CoolantState saved_coolant;
+    SpindleState saved_spindle;
+    SpindleSpeed saved_spindle_speed;
+
+    plan_line_data_t plan_data;
+
+    plan_block_t* block;
+
+    void moveto(float* target);
+
+    bool can_park();
+
+public:
+    Parking() {}
+
+    void setup();       // Called when suspend start
+    void set_target();  // Called when motion has stopped after suspend
+
+    void restore_spindle();  // Restores spindle state upon resume
+    void restore_coolant();  // Restores coolant state upon resume
+
+    void park(bool restart);
+    void unpark(bool restart);
+
+    // Configuration handlers.
+    void group(Configuration::HandlerBase& handler) override;
+
+    ~Parking() = default;
+};

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -67,27 +67,6 @@ union SpindleStop {
 
 static SpindleStop spindle_stop_ovr;
 
-bool can_park() {
-    if (spindle->isRateAdjusted()) {
-        // No parking in Laser mode
-        return false;
-    }
-    if (!Machine::Axes::homingMask) {
-        // No parking without homing
-        return false;
-    }
-    if (!config->_enableParkingOverrideControl) {
-        // _enableParkingOverrideControl adds M56 whereby you can
-        // disable parking via GCode.  If that feature is not present,
-        // parking is enabled subject to the preceding tests.
-        return true;
-    }
-    // If the M56 feature is present, M56 controls the value
-    // of sys.override_ctrl, thus letting you disable parking
-    // by saying M56 P0
-    return sys.override_ctrl == Override::ParkingMotion;
-}
-
 void protocol_reset() {
     probeState             = ProbeState::Off;
     soft_limit             = false;
@@ -426,7 +405,6 @@ static void protocol_do_safety_door() {
 
                 sys.suspend.bit.retractComplete = false;
                 sys.suspend.bit.initiateRestore = false;
-                sys.suspend.bit.restoreComplete = false;
                 sys.suspend.bit.restartRetract  = true;
             }
             break;
@@ -516,21 +494,6 @@ static void protocol_do_cycle_start() {
     // Resume door state when parking motion has retracted and door has been closed.
     switch (sys.state) {
         case State::SafetyDoor:
-            if (!sys.suspend.bit.safetyDoorAjar) {
-                // If the safety door is still open, do not restart yet
-                if (sys.suspend.bit.restoreComplete) {
-                    // Restore is complete.  Set the state to IDLE and resume normal motion
-                    sys.state = State::Idle;
-                    protocol_do_initiate_cycle();
-                } else if (sys.suspend.bit.retractComplete) {
-                    // retractComplete means that all of the retraction operations that were
-                    // initiated by the safety door opening, such as spindle stop and parking,
-                    // are done.  Thus we can respond to this cycle start by "restoring",
-                    // i.e. undoing those retraction operations.  Afterwards, restoreComplete
-                    // will be set and another cycle start event will be issued automatically.
-                    sys.suspend.bit.initiateRestore = true;
-                }
-            }
             break;
         case State::Idle:
             protocol_do_initiate_cycle();
@@ -711,36 +674,53 @@ void protocol_exec_rt_system() {
     }
 }
 
+static void protocol_manage_spindle() {
+    // Feed hold manager. Controls spindle stop override states.
+    // NOTE: Hold ensured as completed by condition check at the beginning of suspend routine.
+    if (spindle_stop_ovr.value) {
+        // Handles beginning of spindle stop
+        if (spindle_stop_ovr.bit.initiate) {
+            if (gc_state.modal.spindle != SpindleState::Disable) {
+                spindle->spinDown();
+                report_ovr_counter           = 0;  // Set to report change immediately
+                spindle_stop_ovr.value       = 0;
+                spindle_stop_ovr.bit.enabled = true;  // Set stop override state to enabled, if de-energized.
+            } else {
+                spindle_stop_ovr.value = 0;  // Clear stop override state
+            }
+            // Handles restoring of spindle state
+        } else if (spindle_stop_ovr.bit.restore || spindle_stop_ovr.bit.restoreCycle) {
+            if (gc_state.modal.spindle != SpindleState::Disable) {
+                report_feedback_message(Message::SpindleRestore);
+                if (spindle->isRateAdjusted()) {
+                    // When in laser mode, defer turn on until cycle starts
+                    sys.step_control.updateSpindleSpeed = true;
+                } else {
+                    config->_parking->restore_spindle();
+                    report_ovr_counter = 0;  // Set to report change immediately
+                }
+            }
+            if (spindle_stop_ovr.bit.restoreCycle) {
+                protocol_send_event(&cycleStartEvent);  // Resume program.
+            }
+            spindle_stop_ovr.value = 0;  // Clear stop override state
+        }
+    } else {
+        // Handles spindle state during hold. NOTE: Spindle speed overrides may be altered during hold state.
+        // NOTE: sys.step_control.updateSpindleSpeed is automatically reset upon resume in step generator.
+        if (sys.step_control.updateSpindleSpeed) {
+            config->_parking->restore_spindle();
+            sys.step_control.updateSpindleSpeed = false;
+        }
+    }
+}
+
 // Handles system suspend procedures, such as feed hold, safety door, and parking motion.
 // The system will enter this loop, create local variables for suspend tasks, and return to
 // whatever function that invoked the suspend, resuming normal operation.
-// This function is written in a way to promote custom parking motions. Simply use this as a
-// template
 static void protocol_exec_rt_suspend() {
-    // Declare and initialize parking local variables
-    float             restore_target[MAX_N_AXIS];
-    float             retract_waypoint = PARKING_PULLOUT_INCREMENT;
-    plan_line_data_t  plan_data;
-    plan_line_data_t* pl_data = &plan_data;
-    memset(pl_data, 0, sizeof(plan_line_data_t));
-    pl_data->motion                = {};
-    pl_data->motion.systemMotion   = 1;
-    pl_data->motion.noFeedOverride = 1;
-    pl_data->line_number           = PARKING_MOTION_LINE_NUMBER;
+    config->_parking->setup();
 
-    plan_block_t* block = plan_get_current_block();
-    CoolantState  restore_coolant;
-    SpindleState  restore_spindle;
-    SpindleSpeed  restore_spindle_speed;
-    if (block == NULL) {
-        restore_coolant       = gc_state.modal.coolant;
-        restore_spindle       = gc_state.modal.spindle;
-        restore_spindle_speed = gc_state.spindle_speed;
-    } else {
-        restore_coolant       = block->coolant;
-        restore_spindle       = block->spindle;
-        restore_spindle_speed = block->spindle_speed;
-    }
     if (spindle->isRateAdjusted()) {
         protocol_send_event(&accessoryOverrideEvent, (void*)AccessoryOverride::SpindleStopOvr);
     }
@@ -761,56 +741,18 @@ static void protocol_exec_rt_suspend() {
             // the safety door and sleep states.
             if (sys.state == State::SafetyDoor || sys.state == State::Sleep) {
                 // Handles retraction motions and de-energizing.
-                float* parking_target = get_mpos();
+                config->_parking->set_target();
                 if (!sys.suspend.bit.retractComplete) {
                     // Ensure any prior spindle stop override is disabled at start of safety door routine.
                     spindle_stop_ovr.value = 0;  // Disable override
 
-                    // Get current position and store restore location and spindle retract waypoint.
-                    if (!sys.suspend.bit.restartRetract) {
-                        copyAxes(restore_target, parking_target);
-                        retract_waypoint += restore_target[PARKING_AXIS];
-                        retract_waypoint = MIN(retract_waypoint, PARKING_TARGET);
-                    }
                     // Execute slow pull-out parking retract motion. Parking requires homing enabled, the
                     // current location not exceeding the parking target location, and laser mode disabled.
                     // NOTE: State will remain DOOR, until the de-energizing and retract is complete.
-                    if (can_park() && parking_target[PARKING_AXIS] < PARKING_TARGET) {
-                        // Retract spindle by pullout distance. Ensure retraction motion moves away from
-                        // the workpiece and waypoint motion doesn't exceed the parking target location.
-                        if (parking_target[PARKING_AXIS] < retract_waypoint) {
-                            parking_target[PARKING_AXIS] = retract_waypoint;
-                            pl_data->feed_rate           = PARKING_PULLOUT_RATE;
-                            pl_data->coolant             = restore_coolant;
-                            pl_data->spindle             = restore_spindle;
-                            pl_data->spindle_speed       = restore_spindle_speed;
-                            mc_parking_motion(parking_target, pl_data);
-                        }
-                        // NOTE: Clear accessory state after retract and after an aborted restore motion.
-                        pl_data->spindle               = SpindleState::Disable;
-                        pl_data->coolant               = {};
-                        pl_data->motion                = {};
-                        pl_data->motion.systemMotion   = 1;
-                        pl_data->motion.noFeedOverride = 1;
-                        pl_data->spindle_speed         = 0.0;
-                        spindle->spinDown();
-                        report_ovr_counter = 0;  // Set to report change immediately
-                        // Execute fast parking retract motion to parking target location.
-                        if (parking_target[PARKING_AXIS] < PARKING_TARGET) {
-                            parking_target[PARKING_AXIS] = PARKING_TARGET;
-                            pl_data->feed_rate           = PARKING_RATE;
-                            mc_parking_motion(parking_target, pl_data);
-                        }
-                    } else {
-                        // Parking motion not possible. Just disable the spindle and coolant.
-                        // NOTE: Laser mode does not start a parking motion to ensure the laser stops immediately.
-                        spindle->spinDown();
-                        config->_coolant->off();
-                        report_ovr_counter = 0;  // Set to report changes immediately
-                    }
+                    config->_parking->park(sys.suspend.bit.restartRetract);
 
-                    sys.suspend.bit.restartRetract  = false;
                     sys.suspend.bit.retractComplete = true;
+                    sys.suspend.bit.restartRetract  = false;
                 } else {
                     if (sys.state == State::Sleep) {
                         report_feedback_message(Message::SleepMode);
@@ -824,104 +766,31 @@ static void protocol_exec_rt_suspend() {
                         }
                         return;  // Abort received. Return to re-initialize.
                     }
-                    // Allows resuming from parking/safety door. Actively checks if safety door is closed and ready to resume.
+                    // Allows resuming from parking/safety door. Polls to see if safety door is closed and ready to resume.
                     if (sys.state == State::SafetyDoor) {
                         if (!config->_control->safety_door_ajar()) {
                             sys.suspend.bit.safetyDoorAjar = false;  // Reset door ajar flag to denote ready to resume.
-                        }
-                    }
-                    // Handles parking restore and safety door resume.
-                    if (sys.suspend.bit.initiateRestore) {
-                        // Execute fast restore motion to the pull-out position. Parking requires homing enabled.
-                        // NOTE: State is will remain DOOR, until the de-energizing and retract is complete.
-                        if (can_park()) {
-                            // Check to ensure the motion doesn't move below pull-out position.
-                            if (parking_target[PARKING_AXIS] <= PARKING_TARGET) {
-                                parking_target[PARKING_AXIS] = retract_waypoint;
-                                pl_data->feed_rate           = PARKING_RATE;
-                                mc_parking_motion(parking_target, pl_data);
-                            }
-                        }
-                        // Delayed Tasks: Restart spindle and coolant, delay to power-up, then resume cycle.
-                        if (gc_state.modal.spindle != SpindleState::Disable) {
-                            // Block if safety door re-opened during prior restore actions.
-                            if (!sys.suspend.bit.restartRetract) {
-                                if (spindle->isRateAdjusted()) {
-                                    // When in laser mode, defer turn on until cycle starts
-                                    sys.step_control.updateSpindleSpeed = true;
-                                } else {
-                                    spindle->setState(restore_spindle, restore_spindle_speed);
-                                    report_ovr_counter = 0;  // Set to report change immediately
+                            if (sys.suspend.bit.retractComplete) {
+                                // retractComplete means that all of the retraction operations that were
+                                // initiated by the safety door opening, such as spindle stop and parking,
+                                // are done.  Thus we can respond to this cycle start by "restoring",
+                                // i.e. undoing those retraction operations.  When that is complete,
+                                // a cycle start event will be issued automatically.
+                                sys.suspend.bit.initiateRestore = true;
+                                log_info("Safety door closed");
+
+                                config->_parking->unpark(sys.suspend.bit.restartRetract);
+
+                                if (!sys.suspend.bit.restartRetract && sys.state == State::SafetyDoor && !sys.suspend.bit.safetyDoorAjar) {
+                                    sys.state = State::Idle;
+                                    protocol_send_event(&cycleStartEvent);  // Resume program.
                                 }
                             }
-                        }
-                        if (gc_state.modal.coolant.Flood || gc_state.modal.coolant.Mist) {
-                            // Block if safety door re-opened during prior restore actions.
-                            if (!sys.suspend.bit.restartRetract) {
-                                config->_coolant->set_state(restore_coolant);
-                                report_ovr_counter = 0;  // Set to report change immediately
-                            }
-                        }
-
-                        // Execute slow plunge motion from pull-out position to resume position.
-                        if (can_park()) {
-                            // Block if safety door re-opened during prior restore actions.
-                            if (!sys.suspend.bit.restartRetract) {
-                                // Regardless if the retract parking motion was a valid/safe motion or not, the
-                                // restore parking motion should logically be valid, either by returning to the
-                                // original position through valid machine space or by not moving at all.
-                                pl_data->feed_rate     = PARKING_PULLOUT_RATE;
-                                pl_data->spindle       = restore_spindle;
-                                pl_data->coolant       = restore_coolant;
-                                pl_data->spindle_speed = restore_spindle_speed;
-                                mc_parking_motion(restore_target, pl_data);
-                            }
-                        }
-                        if (!sys.suspend.bit.restartRetract) {
-                            sys.suspend.bit.restoreComplete = true;
-                            protocol_send_event(&cycleStartEvent);  // Resume program.
                         }
                     }
                 }
             } else {
-                // Feed hold manager. Controls spindle stop override states.
-                // NOTE: Hold ensured as completed by condition check at the beginning of suspend routine.
-                if (spindle_stop_ovr.value) {
-                    // Handles beginning of spindle stop
-                    if (spindle_stop_ovr.bit.initiate) {
-                        if (gc_state.modal.spindle != SpindleState::Disable) {
-                            spindle->spinDown();
-                            report_ovr_counter           = 0;  // Set to report change immediately
-                            spindle_stop_ovr.value       = 0;
-                            spindle_stop_ovr.bit.enabled = true;  // Set stop override state to enabled, if de-energized.
-                        } else {
-                            spindle_stop_ovr.value = 0;  // Clear stop override state
-                        }
-                        // Handles restoring of spindle state
-                    } else if (spindle_stop_ovr.bit.restore || spindle_stop_ovr.bit.restoreCycle) {
-                        if (gc_state.modal.spindle != SpindleState::Disable) {
-                            report_feedback_message(Message::SpindleRestore);
-                            if (spindle->isRateAdjusted()) {
-                                // When in laser mode, defer turn on until cycle starts
-                                sys.step_control.updateSpindleSpeed = true;
-                            } else {
-                                spindle->setState(restore_spindle, restore_spindle_speed);
-                                report_ovr_counter = 0;  // Set to report change immediately
-                            }
-                        }
-                        if (spindle_stop_ovr.bit.restoreCycle) {
-                            protocol_send_event(&cycleStartEvent);  // Resume program.
-                        }
-                        spindle_stop_ovr.value = 0;  // Clear stop override state
-                    }
-                } else {
-                    // Handles spindle state during hold. NOTE: Spindle speed overrides may be altered during hold state.
-                    // NOTE: sys.step_control.updateSpindleSpeed is automatically reset upon resume in step generator.
-                    if (sys.step_control.updateSpindleSpeed) {
-                        spindle->setState(restore_spindle, restore_spindle_speed);
-                        sys.step_control.updateSpindleSpeed = false;
-                    }
-                }
+                protocol_manage_spindle();
             }
         }
         pollChannels();  // Handle realtime commands like status report, cycle start and reset

--- a/FluidNC/src/System.h
+++ b/FluidNC/src/System.h
@@ -43,7 +43,6 @@ struct SuspendBits {
     uint8_t restartRetract : 1;   // Flag to indicate a retract from a restore parking motion.
     uint8_t retractComplete : 1;  // (Safety door only) Indicates retraction and de-energizing is complete.
     uint8_t initiateRestore : 1;  // (Safety door only) Flag to initiate resume procedures from a cycle start.
-    uint8_t restoreComplete : 1;  // (Safety door only) Indicates ready to resume normal operation.
     uint8_t safetyDoorAjar : 1;   // Tracks safety door state for resuming.
     uint8_t motionCancel : 1;     // Indicates a canceled resume motion. Currently used by probing routine.
     uint8_t jogCancel : 1;        // Indicates a jog cancel in process and to reset buffers when complete.


### PR DESCRIPTION
Moved the parking code out of Protocol.cpp into Parking.cpp .  Parking is now its own class, configurable via the new parking: section (defaults shown):

```
parking:
  enable: false
  target_mpos_mm: -5.000
  pullout_distance_mm: 5.000
  rate_mm_per_min: 800.000
  pullout_rate_mm_per_min: 250.000
  axis: Z
```
With this change, the state variables and bitfields that control the sequencing are in Protocol.cpp, while the actions for the parking and unparking motions, with the associated spindle and coolant actions, are in Parking.cpp .

This change also fixes a bug that was introduced recently, whereby safety door closing was ignored.
