### PR TITLE
Fix typo in HOWTO-COMPILE (command line)

### DIFF
--- a/fluidterm/HOWTO-COMPILE.md
+++ b/fluidterm/HOWTO-COMPILE.md
@@ -4,7 +4,7 @@ You have to do this on the host system on which you wish to run
 the executable.
 
   python3 -m pip install pyinstaller
-  python3 -m PyInstaller --oneline fluidterm.py
+  python3 -m PyInstaller --onefile fluidterm.py
 
 The output is in dist\fluidterm.exe (Windows) or dist\fluidterm
 (Linux and MacOS).  On Linux and Mac, the executable may depend


### PR DESCRIPTION
Fix typo in HOWTO-COMPILE
Fix the command line to generate executable file (--oneline changed to --onefile)