### PR TITLE
Dynamixel msg fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: General Questions
-    url: https://github.com/bdring/FluidNC/wiki/General-Questions
-    about: Please read our documentation which answers many questions
+    url: http://wiki.fluidnc.com/
+    about: Please read our wiki which answers many questions
   - name: Discord server
     url: https://discord.com/invite/vGhne3QmFZ
     about: Please ask and answer questions on our Discord server.

--- a/FluidNC/src/Motors/Dynamixel2.cpp
+++ b/FluidNC/src/Motors/Dynamixel2.cpp
@@ -77,7 +77,7 @@ namespace MotorDrivers {
     }
 
     void Dynamixel2::config_message() {
-        log_info("    " << name() << " id::" << _id << " Count(" << _countMin << "," << _countMax << ")");
+        log_info("    " << name() << " id:" << _id << " Count(" << _countMin << "," << _countMax << ")");
     }
 
     bool Dynamixel2::test() {

--- a/FluidNC/src/Motors/Dynamixel2.cpp
+++ b/FluidNC/src/Motors/Dynamixel2.cpp
@@ -58,6 +58,10 @@ namespace MotorDrivers {
 
         config_message();  // print the config
 
+        startUpdateTask(_timer_ms);
+    }
+
+    void Dynamixel2::config_motor() {
         if (!test()) {  // ping the motor
             _has_errors = true;
             return;
@@ -70,11 +74,11 @@ namespace MotorDrivers {
         LED_on(true);
         vTaskDelay(100);
         LED_on(false);
-
-        startUpdateTask(_timer_ms);
     }
 
-    void Dynamixel2::config_message() { log_info("    " << name() << " id::" << _id << " Count(" << _countMin << "," << _countMax << ")"); }
+    void Dynamixel2::config_message() {
+        log_info("    " << name() << " id::" << _id << " Count(" << _countMin << "," << _countMax << ")");
+    }
 
     bool Dynamixel2::test() {
         uint16_t len = 3;
@@ -87,12 +91,12 @@ namespace MotorDrivers {
         if (len == PING_RSP_LEN) {
             uint16_t model_num = _dxl_rx_message[10] << 8 | _dxl_rx_message[9];
             if (model_num == 1060) {
-                log_info("    Model XL430-W250 F/W Rev " << String(_dxl_rx_message[11], HEX));
+                log_info("Axis ping reply " << axisName() << " Model XL430-W250 F/W Rev " << String(_dxl_rx_message[11], HEX));
             } else {
-                log_info("    M/N " << model_num << " F/W Rev " << String(_dxl_rx_message[11], HEX));
+                log_info("Axis ping reply " << axisName() << " M/N " << model_num << " F/W Rev " << String(_dxl_rx_message[11], HEX));
             }
         } else {
-            log_warn("    Ping failed");
+            log_warn(" Ping failed");
             return false;
         }
 
@@ -256,32 +260,32 @@ namespace MotorDrivers {
             uint8_t err = _dxl_rx_message[8];
             switch (err) {
                 case 1:
-                    log_info(name() << " ID " << _id << " Write fail error");
+                    log_error(name() << " ID " << _id << " Write fail error");
                     break;
                 case 2:
-                    log_info(name() << " ID " << _id << " Write instruction error");
+                    log_error(name() << " ID " << _id << " Write instruction error");
                     break;
                 case 3:
-                    log_info(name() << " ID " << _id << " Write access error");
+                    log_error(name() << " ID " << _id << " CRC Error");
                     break;
                 case 4:
-                    log_info(name() << " ID " << _id << " Write data range error");
+                    log_error(name() << " ID " << _id << " Write data range error");
                     break;
                 case 5:
-                    log_info(name() << " ID " << _id << " Write data length error");
+                    log_error(name() << " ID " << _id << " Write data length error");
                     break;
                 case 6:
-                    log_info(name() << " ID " << _id << " Write data limit error");
+                    log_error(name() << " ID " << _id << " Write data limit error");
                     break;
                 case 7:
-                    log_info(name() << " ID " << _id << " Write access error");
+                    log_error(name() << " ID " << _id << " Write access error addr:" << address);
                     break;
                 default:
                     break;
             }
         } else {
             // timeout
-            log_info(name() << " ID " << _id << " Timeout");
+            log_error(name() << " ID " << _id << " Timeout");
         }
     }
 
@@ -290,15 +294,16 @@ namespace MotorDrivers {
         uint32_t dxl_position;
 
         float* mpos = get_mpos();
+        float  motors[MAX_N_AXIS];
 
         dxl_count_min = float(_countMin);
         dxl_count_max = float(_countMax);
 
-        // map the mm range to the servo range
-        dxl_position = static_cast<uint32_t>(
-            mapConstrain(mpos[_axis_index], limitsMinPosition(_axis_index), limitsMaxPosition(_axis_index), dxl_count_min, dxl_count_max));
+        config->_kinematics->transform_cartesian_to_motors(motors, mpos);
 
-        log_debug("dxl:" << _id << " pos:" << dxl_position);
+        // map the mm range to the servo range
+        dxl_position = static_cast<uint32_t>(mapConstrain(
+            motors[_axis_index], limitsMinPosition(_axis_index), limitsMaxPosition(_axis_index), dxl_count_min, dxl_count_max));
 
         bulk_message[++bulk_message_index] = _id;                                // ID of the servo
         bulk_message[++bulk_message_index] = dxl_position & 0xFF;                // data
@@ -307,7 +312,12 @@ namespace MotorDrivers {
         bulk_message[++bulk_message_index] = (dxl_position & 0xFF000000) >> 24;  // data
     }
 
-    void Dynamixel2::send_bulk_message() { dxl_finish_message(DXL_BROADCAST_ID, bulk_message, bulk_message_index - DXL_MSG_INSTR + 1); }
+    void Dynamixel2::send_bulk_message() {
+        //static uint64_t ping = esp_timer_get_time() / 1000;
+        //log_debug("Ping:" << esp_timer_get_time() / 1000 - ping);
+        //ping = esp_timer_get_time() / 1000;
+        dxl_finish_message(DXL_BROADCAST_ID, bulk_message, bulk_message_index - DXL_MSG_INSTR + 3);
+    }
 
     /*
     Static
@@ -341,6 +351,8 @@ namespace MotorDrivers {
 
         _uart->flush();
         _uart->write(msg, msg_len + 7);
+
+        //hex_msg(msg, "0x", msg_len + 7);
     }
 
     // from http://emanual.robotis.com/docs/en/dxl/crc/

--- a/FluidNC/src/Motors/Dynamixel2.h
+++ b/FluidNC/src/Motors/Dynamixel2.h
@@ -70,6 +70,7 @@ namespace MotorDrivers {
 
         // protocol 2 instruction numbers
         static const int  DXL_INSTR_PING = 0x01;
+        static const char DXL_REBOOT     = char(0x08);
         static const int  PING_RSP_LEN   = 14;
         static const char DXL_READ       = char(0x02);
         static const char DXL_WRITE      = char(0x03);
@@ -100,6 +101,7 @@ namespace MotorDrivers {
         bool set_homing_mode(bool isHoming) override;
         void set_disable(bool disable) override;
         void update() override;
+        void config_motor() override;
 
         // Configuration handlers:
         void validate() const override {
@@ -113,6 +115,7 @@ namespace MotorDrivers {
 
             handler.item("count_min", _countMin);
             handler.item("count_max", _countMax);
+            handler.item("timer_ms", _timer_ms);
 
             if (_uart == nullptr) {
                 // If _uart is null this must be the parsing phase

--- a/FluidNC/src/Stepping.cpp
+++ b/FluidNC/src/Stepping.cpp
@@ -135,7 +135,7 @@ namespace Machine {
 
     void Stepping::group(Configuration::HandlerBase& handler) {
         handler.item("engine", _engine, stepTypes);
-        handler.item("idle_ms", _idleMsecs, 0, 255);  // full range
+        handler.item("idle_ms", _idleMsecs, 0, 10000000);  // full range
         handler.item("pulse_us", _pulseUsecs, 0, 10);
         handler.item("dir_delay_us", _directionDelayUsecs, 0, 10);
         handler.item("disable_delay_us", _disableDelayUsecs, 0, 10);

--- a/FluidNC/src/Stepping.h
+++ b/FluidNC/src/Stepping.h
@@ -40,7 +40,7 @@ namespace Machine {
 
         size_t _segments = 12;
 
-        uint8_t  _idleMsecs           = 255;
+        uint32_t _idleMsecs           = 255;
         uint32_t _pulseUsecs          = 4;
         uint32_t _directionDelayUsecs = 0;
         uint32_t _disableDelayUsecs   = 0;


### PR DESCRIPTION

- The bulk message was using the wrong message length which caused it not work right. Sometimes it got 2 out of 3 servos to move and sometimes none of them moved.
- Changed stepping idle ms to 32 bit so a longer delay could be used. This helps closed loop servos settle at the right location.
- Allow longer idle delays
