### PR TITLE
Handle reserved GPIOs without crashing - #630

### DIFF
--- a/FluidNC/src/Configuration/Tokenizer.cpp
+++ b/FluidNC/src/Configuration/Tokenizer.cpp
@@ -93,7 +93,10 @@ namespace Configuration {
                 }
 
                 if (Current() != ':') {
-                    ParseError("Keys must be followed by ':'");
+                    String err = "Key ";
+                    err += StringRange(token_.keyStart_, token_.keyEnd_).str();
+                    err += "must be followed by ':'";
+                    ParseError(err.c_str());
                 }
                 Inc();
 

--- a/FluidNC/src/Pin.cpp
+++ b/FluidNC/src/Pin.cpp
@@ -127,12 +127,12 @@ Pin Pin::create(const StringRange& str) {
     } catch (const AssertionFailed& ex) {  // We shouldn't get here under normal circumstances.
 
         char buf[255];
-        snprintf(buf, 255, "ERR: Setting up pin [%s] failed. Details: %s", str.str().c_str(), ex.what());
+        snprintf(buf, 255, "ERR: %s - %s", str.str().c_str(), ex.what());
 
         Assert(false, buf);
 
         /*
-          log_error("ERR: Setting up pin ["<<str.str()<<"] failed. Details:"<< ex.what());
+          log_error("ERR: " << str.str() << " - " << ex.what());
 
         return Pin(new Pins::ErrorPinDetail(str.str()));
         */

--- a/FluidNC/src/Pins/GPIOPinDetail.cpp
+++ b/FluidNC/src/Pins/GPIOPinDetail.cpp
@@ -68,8 +68,7 @@ namespace Pins {
             case 9:
             case 10:
             case 11:
-                return PinCapabilities::Native | PinCapabilities::Input | PinCapabilities::Output | PinCapabilities::PWM |
-                       PinCapabilities::ISR | PinCapabilities::UART;
+                return PinCapabilities::Reserved;
 
             case 34:  // Input only pins
             case 35:
@@ -92,6 +91,7 @@ namespace Pins {
         // WILL get into trouble.
 
         Assert(index < nGPIOPins, "Pin number is greater than max %d", nGPIOPins - 1);
+        Assert(_capabilities != PinCapabilities::Reserved, "Reserved GPIO");
         Assert(_capabilities != PinCapabilities::None, "Unavailable GPIO");
         Assert(!_claimed[index], "Pin is already used.");
 

--- a/FluidNC/src/Pins/GPIOPinDetail.cpp
+++ b/FluidNC/src/Pins/GPIOPinDetail.cpp
@@ -91,7 +91,7 @@ namespace Pins {
         // WILL get into trouble.
 
         Assert(index < nGPIOPins, "Pin number is greater than max %d", nGPIOPins - 1);
-        Assert(_capabilities != PinCapabilities::Reserved, "Reserved GPIO");
+        Assert(_capabilities != PinCapabilities::Reserved, "Unusable GPIO");
         Assert(_capabilities != PinCapabilities::None, "Unavailable GPIO");
         Assert(!_claimed[index], "Pin is already used.");
 

--- a/FluidNC/src/Pins/PinAttributes.cpp
+++ b/FluidNC/src/Pins/PinAttributes.cpp
@@ -7,6 +7,7 @@
 namespace Pins {
     PinAttributes PinAttributes::Undefined(0);
     PinAttributes PinAttributes::None(0);
+    PinAttributes PinAttributes::Reserved(1);
 
     // The attributes that have a mapped capability have to be at
     // the top of the list. Note that this list must match the list

--- a/FluidNC/src/Pins/PinAttributes.h
+++ b/FluidNC/src/Pins/PinAttributes.h
@@ -29,6 +29,7 @@ namespace Pins {
         // All the capabilities we use and test:
         static PinAttributes Undefined;
         static PinAttributes None;
+        static PinAttributes Reserved;
 
         static PinAttributes Input;
         static PinAttributes Output;

--- a/FluidNC/src/Pins/PinCapabilities.cpp
+++ b/FluidNC/src/Pins/PinCapabilities.cpp
@@ -5,6 +5,7 @@
 
 namespace Pins {
     PinCapabilities PinCapabilities::None(0);
+    PinCapabilities PinCapabilities::Reserved(1);
 
     // Use a little trick here to ensure we don't make mistakes...
     // Do NOT add empty lines here, or have more than 32 items!!!

--- a/FluidNC/src/Pins/PinCapabilities.h
+++ b/FluidNC/src/Pins/PinCapabilities.h
@@ -25,7 +25,8 @@ namespace Pins {
         PinCapabilities& operator=(const PinCapabilities&) = default;
 
         // All the capabilities we use and test:
-        static PinCapabilities None;
+        static PinCapabilities None;      // Nonexistent pin
+        static PinCapabilities Reserved;  // Pin reserved for system use
 
         static PinCapabilities Input;     // NOTE: Mapped in PinAttributes!
         static PinCapabilities Output;    // NOTE: Mapped in PinAttributes!

--- a/FluidNC/src/StackTrace/AssertionFailed.cpp
+++ b/FluidNC/src/StackTrace/AssertionFailed.cpp
@@ -8,7 +8,9 @@
 
 #ifdef ESP32
 
-#    include "esp_debug_helpers.h"
+#    ifdef BACKTRACE_ON_ASSERT
+#        include "esp_debug_helpers.h"
+#    endif
 #    include "WString.h"
 #    include "stdio.h"
 
@@ -25,8 +27,10 @@ AssertionFailed AssertionFailed::create(const char* condition, const char* msg, 
 
     st += tmp;
 
+#    ifdef BACKTRACE_ON_ASSERT  // Backtraces are usually hard to decode and thus confusing
     st += " at: ";
     st += esp_backtrace_print(10);
+#    endif
 
     return AssertionFailed(st, tmp);
 }


### PR DESCRIPTION
Also improved the readability of the associated error message by reducing verbosity, and eliminated the backtrace on assertion failures.  It is rarely possible to decode the backtrace in common usage, and not particularly useful even when it can be decoded.