### PR TITLE
Fix for #287 that should work for all spindle types

### DIFF
--- a/FluidNC/src/Pins/GPIOPinDetail.cpp
+++ b/FluidNC/src/Pins/GPIOPinDetail.cpp
@@ -129,12 +129,15 @@ namespace Pins {
     PinCapabilities GPIOPinDetail::capabilities() const { return _capabilities; }
 
     void IRAM_ATTR GPIOPinDetail::write(int high) {
-        if (!_attributes.has(PinAttributes::Output)) {
-            log_error(toString());
+        if (high != _lastWrittenValue) {
+            _lastWrittenValue = high;
+            if (!_attributes.has(PinAttributes::Output)) {
+                log_error(toString());
+            }
+            Assert(_attributes.has(PinAttributes::Output), "Pin %s cannot be written", toString().c_str());
+            int value = _readWriteMask ^ high;
+            __digitalWrite(_index, value);
         }
-        Assert(_attributes.has(PinAttributes::Output), "Pin %s cannot be written", toString().c_str());
-        int value = _readWriteMask ^ high;
-        __digitalWrite(_index, value);
     }
     int IRAM_ATTR GPIOPinDetail::read() {
         auto raw = __digitalRead(_index);

--- a/FluidNC/src/Pins/GPIOPinDetail.h
+++ b/FluidNC/src/Pins/GPIOPinDetail.h
@@ -15,6 +15,8 @@ namespace Pins {
 
         static std::vector<bool> _claimed;
 
+        bool _lastWrittenValue = false;
+
     public:
         static const int nGPIOPins = 40;
 

--- a/FluidNC/src/Pins/I2SOPinDetail.cpp
+++ b/FluidNC/src/Pins/I2SOPinDetail.cpp
@@ -38,15 +38,21 @@ namespace Pins {
     // The write will not happen immediately; the data is queued for
     // delivery to the serial shift register chain via DMA and a FIFO
     void IRAM_ATTR I2SOPinDetail::write(int high) {
-        int value = _readWriteMask ^ high;
-        i2s_out_write(_index, value);
+        if (high != _lastWrittenValue) {
+            _lastWrittenValue = high;
+            i2s_out_write(_index, _readWriteMask ^ high);
+        }
     }
 
     // Write and wait for completion.  Not suitable for use from an ISR
     void I2SOPinDetail::synchronousWrite(int high) {
-        write(high);
-        i2s_out_push();
-        i2s_out_delay();
+        if (high != _lastWrittenValue) {
+            _lastWrittenValue = high;
+
+            i2s_out_write(_index, _readWriteMask ^ high);
+            i2s_out_push();
+            i2s_out_delay();
+        }
     }
 
     int I2SOPinDetail::read() {

--- a/FluidNC/src/Pins/I2SOPinDetail.h
+++ b/FluidNC/src/Pins/I2SOPinDetail.h
@@ -15,6 +15,8 @@ namespace Pins {
         static const int         nI2SOPins = 32;
         static std::vector<bool> _claimed;
 
+        bool _lastWrittenValue = false;
+
     public:
         I2SOPinDetail(pinnum_t index, const PinOptionsParser& options);
 


### PR DESCRIPTION
This patch optimizes out pin writes that do not change the value, on GPIO and I2SO pin types.  The place where this matters in in Spindle::setSpeedFromISR(), which writes the spindle enable pin on every step segment reload.  It uses synchronous writes to make sure the write goes out, but in the case of I2SO pins, a synchronous write incurs an explicit delay to ensure that the result propagates through the various levels of I2S queuing.  That delay causes the stepping to stutter.