### PR TITLE
Fix #668 - erratic step pulse widths in RMT mode

### DIFF
--- a/FluidNC/src/I2SOut.h
+++ b/FluidNC/src/I2SOut.h
@@ -25,6 +25,10 @@
 /* 32-bit mode: 1000000 usec / ((160000000 Hz) /  5 / 2) x 32 bit/pulse x 2(stereo) = 4 usec/pulse */
 const uint32_t I2S_OUT_USEC_PER_PULSE = 4;
 
+// This value is empirically determined.  It might depend on I2S_OUT_USEC_PULSE but
+// the root cause of the limitation has not been analyzed so that is just a guess.
+const uint32_t I2S_STREAM_MAX_USEC_PER_PULSE = 20;
+
 constexpr uint32_t i2s_out_max_steps_per_sec = 1000000 / (2 * I2S_OUT_USEC_PER_PULSE);
 
 const int I2S_OUT_DMABUF_COUNT = 5;    /* number of DMA buffers to store data */

--- a/FluidNC/src/Motors/StandardStepper.cpp
+++ b/FluidNC/src/Motors/StandardStepper.cpp
@@ -28,7 +28,7 @@ namespace MotorDrivers {
             next_RMT_chan_num = static_cast<rmt_channel_t>(static_cast<int>(next_RMT_chan_num) + 1);
         }
 
-        rmt_config_t rmtConfig;
+        rmt_config_t rmtConfig                   = {};
         rmtConfig.rmt_mode                       = RMT_MODE_TX;
         rmtConfig.clk_div                        = 20;
         rmtConfig.mem_block_num                  = 2;

--- a/FluidNC/src/Stepping.cpp
+++ b/FluidNC/src/Stepping.cpp
@@ -146,8 +146,12 @@ namespace Machine {
         if (_engine == I2S_STREAM || _engine == I2S_STATIC) {
             Assert(config->_i2so, "I2SO bus must be configured for this stepping type");
             if (_pulseUsecs < I2S_OUT_USEC_PER_PULSE) {
-                log_info("Increasing stepping/pulse_us to the IS2 minimum value " << I2S_OUT_USEC_PER_PULSE);
+                log_warn("Increasing stepping/pulse_us to the IS2 minimum value " << I2S_OUT_USEC_PER_PULSE);
                 _pulseUsecs = I2S_OUT_USEC_PER_PULSE;
+            }
+            if (_engine == I2S_STREAM && _pulseUsecs > I2S_STREAM_MAX_USEC_PER_PULSE) {
+                log_warn("Decreasing stepping/pulse_us to " << I2S_STREAM_MAX_USEC_PER_PULSE << ", the maximum value for I2S_STREAM");
+                _pulseUsecs = I2S_STREAM_MAX_USEC_PER_PULSE;
             }
         }
     }

--- a/FluidNC/src/Stepping.cpp
+++ b/FluidNC/src/Stepping.cpp
@@ -136,7 +136,7 @@ namespace Machine {
     void Stepping::group(Configuration::HandlerBase& handler) {
         handler.item("engine", _engine, stepTypes);
         handler.item("idle_ms", _idleMsecs, 0, 10000000);  // full range
-        handler.item("pulse_us", _pulseUsecs, 0, 10);
+        handler.item("pulse_us", _pulseUsecs, 0, 30);
         handler.item("dir_delay_us", _directionDelayUsecs, 0, 10);
         handler.item("disable_delay_us", _disableDelayUsecs, 0, 10);
         handler.item("segments", _segments, 6, 20);


### PR DESCRIPTION
The problem is that the rmt_config structure was unitialized, leading to random values in the RMB_IDLE_OUT_LC_CH bit.  When that bit happened to be 1, it worked correctly,  When it happened to be 0, the pulse length was wrong.

I am not entirely sure how this plays out because that bit in question is set explicitly in later code, but empirically, if we initialize the structure first, the value in that bit becomes predictable and correct, whereas before, it would change from reboot to reboot.