### PR TITLE
Corrected parser to use NoError on G38.5

### DIFF
--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -331,7 +331,7 @@ Error gc_execute_line(char* line, Channel& channel) {
                                 gc_block.modal.motion = Motion::ProbeAway;
                                 break;
                             case 50:
-                                gc_block.modal.motion = Motion::ProbeAway;
+                                gc_block.modal.motion = Motion::ProbeAwayNoError;
                                 break;
                             default:
                                 FAIL(Error::GcodeUnsupportedCommand);


### PR DESCRIPTION
Currently, G38.5 is incorrectly programmed to resolve to `Motion::ProbeAway` incorrectly (same as G38.4). This fixes it to use `Motion::ProbeAwayNoError` instead.