### PR TITLE
Add 'P' to $Limits printout when probe is active

### DIFF
--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -422,6 +422,9 @@ static Error show_limits(const char* value, WebUI::AuthenticationLevel auth_leve
             write_limit_set(Machine::Axes::posLimitMask, out);
             out << ' ';
             write_limit_set(Machine::Axes::negLimitMask, out);
+            if (config->_probe->get_state()) {
+                out << " P";
+            }
             out << '\n';
             limit = thisTime + interval;
         }


### PR DESCRIPTION
The Probe pin is very similar to the axis limit pins and it would be nice to be able to easily see the status in $Limits (really useful when reconnecting the machine to validate everything is correct).