### PR TITLE
Fix706

### DIFF
--- a/FluidNC/src/Kinematics/WallPlotter.cpp
+++ b/FluidNC/src/Kinematics/WallPlotter.cpp
@@ -24,9 +24,12 @@ namespace Kinematics {
         // The motors assume they start from (0, 0, 0).
         // So we need to derive the zero lengths to satisfy the kinematic equations.
         xy_to_lengths(0, 0, zero_left, zero_right);
-        last_left  = zero_left;
-        last_right = zero_right;
-        last_z     = 0;
+        last_motor_segment_end[0] = zero_left;
+        last_motor_segment_end[1] = zero_right;
+        auto n_axis               = config->_axes->_numberAxis;
+        for (size_t axis = Z_AXIS; axis < n_axis; axis++) {
+            last_motor_segment_end[axis] = 0.0;
+        }
     }
 
     void WallPlotter::transform_cartesian_to_motors(float* cartesian, float* motors) {
@@ -39,70 +42,93 @@ namespace Kinematics {
       All linear motions pass through cartesian_to_motors() to be planned as mc_move_motors operations.
 
       Parameters:
-        target = an MAX_N_AXIS array of target positions (where the move is supposed to go)
+        target = an n_axis array of target positions (where the move is supposed to go)
         pl_data = planner data (see the definition of this type to see what it is)
-        position = an MAX_N_AXIS array of where the machine is starting from for this move
+        position = an n_axis array of where the machine is starting from for this move
     */
     bool WallPlotter::cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) {
         float    dx, dy, dz;     // segment distances in each cartesian axis
         uint32_t segment_count;  // number of segments the move will be broken in to.
 
+        auto n_axis = config->_axes->_numberAxis;
+
+        float total_cartesian_distance = vector_distance(position, target, n_axis);
+        if (total_cartesian_distance == 0) {
+            mc_move_motors(target, pl_data);
+            return true;
+        }
+
+        float cartesian_feed_rate = pl_data->feed_rate;
+
         // calculate the total X,Y axis move distance
         // Z axis is the same in both coord systems, so it does not undergo conversion
-        float dist = vector_distance(target, position, 2); // Only compute distance for both axes. X and Y
+        float xydist = vector_distance(target, position, 2);  // Only compute distance for both axes. X and Y
         // Segment our G1 and G0 moves based on yaml file. If we choose a small enough _segment_length we can hide the nonlinearity
-        segment_count = dist / _segment_length;
+        segment_count = xydist / _segment_length;
         if (segment_count < 1) {  // Make sure there is at least one segment, even if there is no movement
             // We need to do this to make sure other things like S and M codes get updated properly by
             // the planner even if there is no movement??
             segment_count = 1;
         }
-        // Calc distance of individual cartesian segments
-        dx = (target[X_AXIS] - position[X_AXIS])/segment_count; 
-        dy = (target[Y_AXIS] - position[Y_AXIS])/segment_count; 
-        dz = (target[Z_AXIS] - position[Z_AXIS])/segment_count;
-        // Current cartesian end point of the segment        
-        float seg_x = position[X_AXIS];  
-        float seg_y = position[Y_AXIS];
-        float seg_z = position[Z_AXIS];
+        float cartesian_segment_length = total_cartesian_distance / segment_count;
+
+        // Calc length of each cartesian segment - the same for all segments
+        float cartesian_segment_components[n_axis];
+        for (size_t axis = X_AXIS; axis < n_axis; axis++) {
+            cartesian_segment_components[axis] = (target[axis] - position[axis]) / segment_count;
+        }
+
+        float cartesian_segment_end[n_axis];
+        copyAxes(cartesian_segment_end, position);
+
         // Calculate desired cartesian feedrate distance ratio. Same for each seg.
-        float vdcart_ratio = pl_data->feed_rate/(dist/segment_count);
         for (uint32_t segment = 1; segment <= segment_count; segment++) {
-            // calc next cartesian end point of the next segment
-            seg_x += dx;
-            seg_y += dy;
-            seg_z += dz;
+            // calculate the cartesian end point of the next segment
+            for (size_t axis = X_AXIS; axis < n_axis; axis++) {
+                cartesian_segment_end[axis] += cartesian_segment_components[axis];
+            }
+
             // Convert cartesian space coords to motor space
-            float seg_left, seg_right; 
-            xy_to_lengths(seg_x, seg_y, seg_left, seg_right);
+            float motor_segment_end[n_axis];
+            xy_to_lengths(cartesian_segment_end[X_AXIS], cartesian_segment_end[Y_AXIS], motor_segment_end[0], motor_segment_end[1]);
+            for (size_t axis = Z_AXIS; axis < n_axis; axis++) {
+                motor_segment_end[axis] = cartesian_segment_end[axis];
+            }
+
 #ifdef USE_CHECKED_KINEMATICS
             // Check the inverse computation.
             float cx, cy;
-            // These are absolute.
-            lengths_to_xy(seg_left, seg_right, cx, cy);
+            lengths_to_xy(motor_segment_end[0], motor_segment_end[1], cx, cy);
 
-            if (abs(seg_x - cx) > 0.1 || abs(seg_y - cy) > 0.1) {
+            if (abs(cartesian_segment_end[X_AXIS] - cx) > 0.1 || abs(cartesian_segment_end[Y_AXIS] - cy) > 0.1) {
                 // FIX: Produce an alarm state?
             }
-#endif  // end USE_CHECKED_KINEMATICS
-            // Set interpolated feedrate in motor space for this segment to
-            // get desired feedrate in cartesian space
-            if (!pl_data->motion.rapidMotion) { // Rapid motions ignore feedrate. Don't convert.
-              // T=D/V, Tcart=Tmotor, Dcart/Vcart=Dmotor/Vmotor
-              // Vmotor = Dmotor*(Vcart/Dcart)
-              pl_data->feed_rate = hypot_f(last_left-seg_left,last_right-seg_right)*vdcart_ratio; 
+#endif
+            // Adjust feedrate by the ratio of the segment lengths in motor and cartesian spaces,
+            // accounting for all axes
+            if (!pl_data->motion.rapidMotion) {  // Rapid motions ignore feedrate. Don't convert.
+                                                 // T=D/V, Tcart=Tmotor, Dcart/Vcart=Dmotor/Vmotor
+                                                 // Vmotor = Dmotor*(Vcart/Dcart)
+                float motor_segment_length = vector_distance(last_motor_segment_end, motor_segment_end, n_axis);
+                pl_data->feed_rate         = cartesian_feed_rate * motor_segment_length / cartesian_segment_length;
             }
-            // TODO: G93 pl_data->motion.inverseTime logic?? Does this even make sense for wallplotter? 
-            // Remember absolute motor lengths for next time
-            last_left  = seg_left;
-            last_right = seg_right;
-            last_z     = seg_z;
+
+            // TODO: G93 pl_data->motion.inverseTime logic?? Does this even make sense for wallplotter?
+
+            // Remember the last motor position so the length can be computed the next time
+            copyAxes(last_motor_segment_end, motor_segment_end);
+
             // Initiate motor movement with converted feedrate and converted position
             // mc_move_motors() returns false if a jog is cancelled.
             // In that case we stop sending segments to the planner.
             // Note that the left motor runs backward.
             // TODO: It might be better to adjust motor direction in .yaml file by inverting direction pin??
-            float cables[MAX_N_AXIS] = { 0 - (seg_left - zero_left), 0 + (seg_right - zero_right), seg_z };
+            float cables[n_axis];
+            cables[0] = 0 - (motor_segment_end[0] - zero_left);
+            cables[1] = 0 + (motor_segment_end[1] - zero_right);
+            for (size_t axis = Z_AXIS; axis < n_axis; axis++) {
+                cables[axis] = cartesian_segment_end[axis];
+            }
             if (!mc_move_motors(cables, pl_data)) {
                 // TODO fixup last_left last_right?? What is position state when jog is cancelled?
                 return false;
@@ -115,19 +141,21 @@ namespace Kinematics {
       The status command uses motors_to_cartesian() to convert
       your motor positions to cartesian X,Y,Z... coordinates.
 
-      Convert the MAX_N_AXIS array of motor positions to cartesian in your code.
+      Convert the n_axis array of motor positions to cartesian in your code.
     */
     void WallPlotter::motors_to_cartesian(float* cartesian, float* motors, int n_axis) {
         // The motors start at zero, but effectively at zero_left, so we need to correct for the computation.
         // Note that the left motor runs backward.
         // TODO: It might be better to adjust motor direction in .yaml file by inverting direction pin??
+
         float absolute_x, absolute_y;
         lengths_to_xy((0 - motors[_left_axis]) + zero_left, (0 + motors[_right_axis]) + zero_right, absolute_x, absolute_y);
 
         cartesian[X_AXIS] = absolute_x;
         cartesian[Y_AXIS] = absolute_y;
-        cartesian[Z_AXIS] = motors[Z_AXIS];
-
+        for (size_t axis = Z_AXIS; axis < n_axis; axis++) {
+            cartesian[axis] = motors[axis];
+        }
         // Now we have numbers that if fed back into the system should produce the same values.
     }
 

--- a/FluidNC/src/Kinematics/WallPlotter.h
+++ b/FluidNC/src/Kinematics/WallPlotter.h
@@ -45,9 +45,7 @@ namespace Kinematics {
         // State
         float zero_left;   //  The left cord offset corresponding to cartesian (0, 0).
         float zero_right;  //  The right cord offset corresponding to cartesian (0, 0).
-        float last_left;   //  The last produced left cord length.
-        float last_right;  //  The last produced right cord length.
-        float last_z;      //  The last produced z value.
+        float last_motor_segment_end[MAX_N_AXIS];
 
         // Parameters
         int   _left_axis     = 0;

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -279,8 +279,10 @@ static void protocol_do_alarm() {
 
 static void protocol_start_holding() {
     if (!(sys.suspend.bit.motionCancel || sys.suspend.bit.jogCancel)) {  // Block, if already holding.
-        Stepper::update_plan_block_parameters();                         // Notify stepper module to recompute for hold deceleration.
-        sys.step_control             = {};
+        sys.step_control = {};
+        if (!Stepper::update_plan_block_parameters()) {  // Notify stepper module to recompute for hold deceleration.
+            sys.step_control.endMotion = true;
+        }
         sys.step_control.executeHold = true;  // Initiate suspend state with active flag.
     }
 }

--- a/FluidNC/src/Stepper.cpp
+++ b/FluidNC/src/Stepper.cpp
@@ -324,12 +324,14 @@ void Stepper::reset() {
 }
 
 // Called by planner_recalculate() when the executing block is updated by the new plan.
-void Stepper::update_plan_block_parameters() {
+bool Stepper::update_plan_block_parameters() {
     if (pl_block != NULL) {  // Ignore if at start of a new block.
         prep.recalculate_flag.recalculate = 1;
         pl_block->entry_speed_sqr         = prep.current_speed * prep.current_speed;  // Update entry speed.
         pl_block                          = NULL;  // Flag prep_segment() to load and check active velocity profile.
+        return true;
     }
+    return false;
 }
 
 // Changes the run state of the step segment buffer to execute the special parking motion.

--- a/FluidNC/src/Stepper.h
+++ b/FluidNC/src/Stepper.h
@@ -40,7 +40,7 @@ namespace Stepper {
     void prep_buffer();
 
     // Called by planner_recalculate() when the executing block is updated by the new plan.
-    void update_plan_block_parameters();
+    bool update_plan_block_parameters();
 
     // Called by realtime status reporting if realtime rate reporting is enabled in config.h.
     float get_realtime_rate();


### PR DESCRIPTION
When executing a GCode file with lots of short segments, like with a laser raster image, feedhold would go into hold state but motion would continue, slowly.