### PR TITLE
log_* collects the line in a buffer before sending to output

### DIFF
--- a/FluidNC/src/Logging.cpp
+++ b/FluidNC/src/Logging.cpp
@@ -20,14 +20,29 @@ bool atMsgLevel(MsgLevel level) {
 #endif
 
 DebugStream::DebugStream(const char* name) {
-    DEBUG_OUT << "[MSG:" << name << ": ";
+    _charcnt = 0;
+    print("[MSG:");
+    if (*name) {
+        print(name);
+        print(": ");
+    } else {
+        print(" ");
+    }
 }
 
 size_t DebugStream::write(uint8_t c) {
-    DEBUG_OUT << static_cast<char>(c);
-    return 1;
+    if (_charcnt < MAXLINE - 2) {
+        // Leave room for ]\n\0
+        _outline[_charcnt++] = (char)c;
+        return 1;
+    }
+    return 0;
 }
 
 DebugStream::~DebugStream() {
-    DEBUG_OUT << "]\n";
+    // write() leaves space for three characters at the end
+    _outline[_charcnt++] = ']';
+    _outline[_charcnt++] = '\n';
+    _outline[_charcnt++] = '\0';
+    DEBUG_OUT << _outline;
 }

--- a/FluidNC/src/Logging.h
+++ b/FluidNC/src/Logging.h
@@ -30,6 +30,14 @@ enum MsgLevel {
 #include "MyIOStream.h"
 
 class DebugStream : public Print {
+    // Log lines are collected in a buffer and sent to the output stream
+    // when the line is complete, thus avoiding the possibility of interleaving
+    // output from multiple cores.
+    static const int MAXLINE = 256;
+
+    char _outline[MAXLINE];
+    int  _charcnt = 0;
+
 public:
     DebugStream(const char* name);
     size_t write(uint8_t c) override;


### PR DESCRIPTION
That prevents output from the other CPU core from being injected into the middle of a log message.