### PR TITLE
Configurable SD SPI speed via sdcard/frequency_hz:

### DIFF
--- a/FluidNC/esp32/sdspi.cpp
+++ b/FluidNC/esp32/sdspi.cpp
@@ -67,7 +67,7 @@ static void call_host_deinit(const sdmmc_host_t* host_config) {
     }
 }
 
-bool sd_init_slot(int cs_pin, int cd_pin, int wp_pin) {
+bool sd_init_slot(uint32_t freq_hz, int cs_pin, int cd_pin, int wp_pin) {
     esp_err_t err;
 
     // Note: esp_vfs_fat_sdmmc/sdspi_mount is all-in-one convenience functions.
@@ -77,6 +77,11 @@ bool sd_init_slot(int cs_pin, int cd_pin, int wp_pin) {
     bool host_inited = false;
 
     sdspi_device_config_t slot_config;
+
+    // If freq_hz is 0, use the system default
+    if (freq_hz) {
+        host_config.max_freq_khz = freq_hz / 1000;
+    }
 
     err = host_config.init();
     CHECK_EXECUTE_RESULT(err, "host init failed");
@@ -91,6 +96,18 @@ bool sd_init_slot(int cs_pin, int cd_pin, int wp_pin) {
 
     err = sdspi_host_init_device(&slot_config, &(host_config.slot));
     CHECK_EXECUTE_RESULT(err, "slot init failed");
+
+    // Empirically it is necessary to set the frequency twice.
+    // If you do it only above, the max frequency will be pinned
+    // at the highest "standard" frequency lower than the requested
+    // one, which is 400 kHz for requested frequencies < 20 MHz.
+    // If you do it only once below, the attempt to change it seems to
+    // be ignored, and you get 20 MHz regardless of what you ask for.
+    if (freq_hz) {
+        printf("hz = %d\n", freq_hz);
+        err = sdspi_host_set_card_clk(host_config.slot, freq_hz / 1000);
+        CHECK_EXECUTE_RESULT(err, "set slot clock speed failed");
+    }
 
     return true;
 

--- a/FluidNC/include/Driver/sdspi.h
+++ b/FluidNC/include/Driver/sdspi.h
@@ -1,6 +1,6 @@
 #include <system_error>
 
-bool sd_init_slot(int cs_pin, int cd_pin = -1, int wp_pin = -1);
+bool sd_init_slot(uint32_t freq_hz, int cs_pin, int cd_pin = -1, int wp_pin = -1);
 void sd_unmount();
 void sd_deinit_slot();
 

--- a/FluidNC/src/SDCard.cpp
+++ b/FluidNC/src/SDCard.cpp
@@ -43,9 +43,9 @@ void SDCard::init() {
     if (_cardDetect.defined()) {
         _cardDetect.setAttr(Pin::Attr::Input);
         auto cdPin = _cardDetect.getNative(Pin::Capabilities::Input | Pin::Capabilities::Native);
-        sd_init_slot(csPin, cdPin);
+        sd_init_slot(_frequency_hz, csPin, cdPin);
     } else {
-        sd_init_slot(csPin);
+        sd_init_slot(_frequency_hz, csPin);
     }
 }
 

--- a/FluidNC/src/SDCard.h
+++ b/FluidNC/src/SDCard.h
@@ -25,9 +25,6 @@
 
 #include <cstdint>
 
-// XXX This should be a configuration parameter of the SPI bus
-const int32_t SPIfreq = 4000000;
-
 class SDCard : public Configuration::Configurable {
 public:
     enum class State : uint8_t {
@@ -45,6 +42,8 @@ private:
     Pin   _cardDetect;
     Pin   _cs;
 
+    uint32_t _frequency_hz = 0;  // Set to nonzero to override the default
+
 public:
     SDCard();
     SDCard(const SDCard&) = delete;
@@ -61,6 +60,7 @@ public:
     void group(Configuration::HandlerBase& handler) override {
         handler.item("cs_pin", _cs);
         handler.item("card_detect_pin", _cardDetect);
+        handler.item("frequency_hz", _frequency_hz);
     }
 
     ~SDCard();


### PR DESCRIPTION
The SPI speed for the SD card can now be configured via

```yaml
sdcard:
    frequency_hz: 10000000
```
That sets the SPI clock frequency to be used with the SD Card to 10 MHz, as opposed to the 20 Mhz that the ESP-IDF sdspi driver uses by default.

If frequency_hz is omitted or set to 0, the system default will be used.

Note that, in the SD Card probing process, the driver cycles through several frequencies, going slowly when probing the card, then switching to the highest frequency that it thinks the system and particular card can handle.  In the default case, the system often settles on 20 MHz, which typically works well for onboard SD card sockets with short wires, but is sometimes too fast for external adapters with level translators.  In that case, dialing back the frequency could make those adapters work.

Possible fix for #671 and #736