### PR TITLE
add option to configure Wifi regulatory domain 

### DIFF
--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -42,6 +42,103 @@ namespace WebUI {
         { "AP", WiFiAP },
         { "STA>AP", WiFiFallback },
     };
+
+    enum WiFiContry {
+        WiFiCountry01 = 0, // country "01" is the safest set of settings which complies with all regulatory domains
+        WiFiCountryAT,
+        WiFiCountryAU,
+        WiFiCountryBE,
+        WiFiCountryBG,
+        WiFiCountryBR,
+        WiFiCountryCA,
+        WiFiCountryCH,
+        WiFiCountryCN,
+        WiFiCountryCY,
+        WiFiCountryCZ,
+        WiFiCountryDE,
+        WiFiCountryDK,
+        WiFiCountryEE,
+        WiFiCountryES,
+        WiFiCountryFI,
+        WiFiCountryFR,
+        WiFiCountryGB,
+        WiFiCountryGR,
+        WiFiCountryHK,
+        WiFiCountryHR,
+        WiFiCountryHU,
+        WiFiCountryIE,
+        WiFiCountryIN,
+        WiFiCountryIS,
+        WiFiCountryIT,
+        WiFiCountryJP,
+        WiFiCountryKR,
+        WiFiCountryLI,
+        WiFiCountryLT,
+        WiFiCountryLU,
+        WiFiCountryLV,
+        WiFiCountryMT,
+        WiFiCountryMX,
+        WiFiCountryNL,
+        WiFiCountryNO,
+        WiFiCountryNZ,
+        WiFiCountryPL,
+        WiFiCountryPT,
+        WiFiCountryRO,
+        WiFiCountrySE,
+        WiFiCountrySI,
+        WiFiCountrySK,
+        WiFiCountryTW,
+        WiFiCountryUS,
+    };
+
+    enum_opt_t wifiContryOptions = {
+        { "01", WiFiCountry01 },
+        { "AT", WiFiCountryAT },
+        { "AU", WiFiCountryAU },
+        { "BE", WiFiCountryBE },
+        { "BG", WiFiCountryBG },
+        { "BR", WiFiCountryBR },
+        { "CA", WiFiCountryCA },
+        { "CH", WiFiCountryCH },
+        { "CN", WiFiCountryCN },
+        { "CY", WiFiCountryCY },
+        { "CZ", WiFiCountryCZ },
+        { "DE", WiFiCountryDE },
+        { "DK", WiFiCountryDK },
+        { "EE", WiFiCountryEE },
+        { "ES", WiFiCountryES },
+        { "FI", WiFiCountryFI },
+        { "FR", WiFiCountryFR },
+        { "GB", WiFiCountryGB },
+        { "GR", WiFiCountryGR },
+        { "HK", WiFiCountryHK },
+        { "HR", WiFiCountryHR },
+        { "HU", WiFiCountryHU },
+        { "IE", WiFiCountryIE },
+        { "IN", WiFiCountryIN },
+        { "IS", WiFiCountryIS },
+        { "IT", WiFiCountryIT },
+        { "JP", WiFiCountryJP },
+        { "KR", WiFiCountryKR },
+        { "LI", WiFiCountryLI },
+        { "LT", WiFiCountryLT },
+        { "LU", WiFiCountryLU },
+        { "LV", WiFiCountryLV },
+        { "MT", WiFiCountryMT },
+        { "MX", WiFiCountryMX },
+        { "NL", WiFiCountryNL },
+        { "NO", WiFiCountryNO },
+        { "NZ", WiFiCountryNZ },
+        { "PL", WiFiCountryPL },
+        { "PT", WiFiCountryPT },
+        { "RO", WiFiCountryRO },
+        { "SE", WiFiCountrySE },
+        { "SI", WiFiCountrySI },
+        { "SK", WiFiCountrySK },
+        { "TW", WiFiCountryTW },
+        { "US", WiFiCountryUS },
+    };
+
     EnumSetting* wifi_mode;
 
     StringSetting* wifi_sta_ssid;
@@ -56,6 +153,7 @@ namespace WebUI {
 
     StringSetting* wifi_ap_ssid;
     StringSetting* wifi_ap_password;
+    EnumSetting*   wifi_ap_country;
 
     IPaddrSetting* wifi_ap_ip;
 
@@ -274,6 +372,8 @@ namespace WebUI {
                                              (bool (*)(char*))WiFiConfig::isPasswordValid);
         wifi_ap_ssid     = new StringSetting(
             "AP SSID", WEBSET, WA, "ESP105", "AP/SSID", DEFAULT_AP_SSID, MIN_SSID_LENGTH, MAX_SSID_LENGTH, (bool (*)(char*))WiFiConfig::isSSIDValid);
+        wifi_ap_country  = new EnumSetting(
+            "AP regulatory domain", WEBSET, WA, NULL, "AP/Country", WiFiCountry01, &wifiContryOptions, NULL);
         wifi_sta_netmask = new IPaddrSetting("Station Static Mask", WEBSET, WA, NULL, "Sta/Netmask", DEFAULT_STA_MK, NULL);
         wifi_sta_gateway = new IPaddrSetting("Station Static Gateway", WEBSET, WA, NULL, "Sta/Gateway", DEFAULT_STA_GW, NULL);
         wifi_sta_ip      = new IPaddrSetting("Station Static IP", WEBSET, WA, NULL, "Sta/IP", DEFAULT_STA_IP, NULL);
@@ -600,6 +700,11 @@ namespace WebUI {
 
         WiFi.enableSTA(false);
         WiFi.mode(WIFI_AP);
+
+        const char *country = wifi_ap_country->getStringValue();
+        if (ESP_OK != esp_wifi_set_country_code(country, true)) {
+            log_error("failed to set Wifi regulatory domain to " << country);
+        }
 
         //auto comms = config->_comms;  // _comms is automatically created in afterParse
         //auto ap    = comms->_apConfig;

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -170,9 +170,12 @@ namespace WebUI {
                 print_mac(out, "Current WiFi Mode: AP", WiFi.softAPmacAddress());
 
                 wifi_config_t conf;
+                wifi_country_t country;
                 esp_wifi_get_config(WIFI_IF_AP, &conf);
+                esp_wifi_get_country(&country);
                 log_to(out, "SSID: ", (const char*)conf.ap.ssid);
                 log_to(out, "Visible: ", (conf.ap.ssid_hidden == 0 ? "Yes" : "No"));
+                log_to(out, "Radio country set: ", country.cc << " (channels " << country.schan << "-" << (country.schan+country.nchan-1) << ", max power " << country.max_tx_power << "dBm)");
 
                 const char* mode;
                 switch (conf.ap.authmode) {


### PR DESCRIPTION
This introduces a new setting `$AP/Country`.
If set to a non-empty string, it will set the Wifi country on AP startup.
This impacts the available channels and maximum transmission power.
The ESP32 boots with `CN` set as the regulatory domain by default.

Fixes #331 