### PR TITLE
M7.1 and M8.1 to turn off individual coolants

### DIFF
--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -480,7 +480,7 @@ Error gc_execute_line(char* line) {
                 break;
             case 'M':
                 // Determine 'M' command and its modal group
-                if (mantissa > 0) {
+                if (mantissa > 0 && !(int_value == 7 || int_value == 8)) {
                     FAIL(Error::GcodeCommandValueNotInteger);  // [No Mxx.x commands]
                 }
                 switch (int_value) {
@@ -533,11 +533,17 @@ Error gc_execute_line(char* line) {
                     case 9:
                         switch (int_value) {
                             case 7:
+                                if (mantissa && mantissa != 10) {
+                                    FAIL(Error::GcodeUnsupportedCommand);  // M7 and M7.1 are supported
+                                }
                                 if (config->_coolant->hasMist()) {
                                     gc_block.coolant = GCodeCoolant::M7;
                                 }
                                 break;
                             case 8:
+                                if (mantissa && mantissa != 10) {
+                                    FAIL(Error::GcodeUnsupportedCommand);  // M8 and M8.1 are supported
+                                }
                                 if (config->_coolant->hasFlood()) {
                                     gc_block.coolant = GCodeCoolant::M8;
                                 }
@@ -1449,10 +1455,10 @@ Error gc_execute_line(char* line) {
             case GCodeCoolant::None:
                 break;
             case GCodeCoolant::M7:
-                gc_state.modal.coolant.Mist = 1;
+                gc_state.modal.coolant.Mist = mantissa == 10 ? 0 : 1;
                 break;
             case GCodeCoolant::M8:
-                gc_state.modal.coolant.Flood = 1;
+                gc_state.modal.coolant.Flood = mantissa == 10 ? 0 : 1;
                 break;
             case GCodeCoolant::M9:
                 gc_state.modal.coolant = {};


### PR DESCRIPTION
Several people seem to want individual turn-off of Flood and Mist, instead of individual turn-on and combined turn-off.  The current workaround is to use the override toggles via macros, but that is clumsy, in that they are toggles that depend on the current state, and the hack to inject override characters only works with the internal macros, not file-based macros.

This patch adds M7.1 to turn off M7 and M8.1 to turn off M8.

One objection to this formulation is that no other M code has a .N suffix, so this could be seen as a violation of basic GCode syntax rules, to the extent that is a thing.

One alternative would be to use M17 and M18.  They do not conflict with any LinuxCNC Mcodes, but they do conflict with Marlin (M17/M18 are enable/disable steppers) and with Haas (turret rotation forward/reverse).  Or some other MCode numbers.

Yet another alternative would be to add a P parameter, but M7 and M8 can be used in a block with other GCodes, so that is problematic.

Another alternative is to invent some $ commands like $coolant/flood=off

Or maybe just not solve this problem.