### PR TITLE
Support for external uart configuration

### DIFF
--- a/FluidNC/src/Configuration/AfterParse.h
+++ b/FluidNC/src/Configuration/AfterParse.h
@@ -8,6 +8,8 @@
 
 #include <vector>
 
+class Uart;
+
 namespace Configuration {
     class Configurable;
 
@@ -20,6 +22,8 @@ namespace Configuration {
     protected:
         void        enterSection(const char* name, Configurable* value) override;
         bool        matchesUninitialized(const char* name) override { return false; }
+        const char* matchUninitialized(const char* pattern) override { return nullptr; }
+
         HandlerType handlerType() override { return HandlerType::AfterParse; }
 
     public:
@@ -32,6 +36,7 @@ namespace Configuration {
         void item(const char* name, std::vector<speedEntry>& value) override {}
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override {}
         void item(const char* name, String& value, int minLength, int maxLength) override {}
+        void item(const char* name, Uart*& uart) override {}
         void item(const char* name, Pin& value) override {}
         void item(const char* name, IPAddress& value) override {}
         void item(const char* name, int& value, EnumItem* e) override {}

--- a/FluidNC/src/Configuration/Completer.h
+++ b/FluidNC/src/Configuration/Completer.h
@@ -19,6 +19,7 @@ namespace Configuration {
     protected:
         void enterSection(const char* name, Configuration::Configurable* value) override;
         bool matchesUninitialized(const char* name) override { return false; }
+        const char* matchUninitialized(const char* pattern) override { return nullptr; }
 
     public:
         Completer(const char* key, int requestedMatch, char* matchedStr);
@@ -33,6 +34,7 @@ namespace Configuration {
         void item(const char* name, std::vector<speedEntry>& value) override { item(name); }
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override { item(name); }
         void item(const char* name, String& value, int minLength, int maxLength) override { item(name); }
+        void item(const char* name, Uart*& uart) override { item(name); }
         void item(const char* name, Pin& value) { item(name); }
         void item(const char* name, IPAddress& value) override { item(name); }
         void item(const char* name, int& value, EnumItem* e) override { item(name); }

--- a/FluidNC/src/Configuration/ExternalList.h
+++ b/FluidNC/src/Configuration/ExternalList.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 -	Jonathan Heinen
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "../Logging.h"
+
+template <typename T>
+struct Entry {
+    const char* name;
+    T*          value;
+};
+
+template <typename T>
+class ExternalList {
+private:
+    Entry<T> entries[10] { nullptr };
+    int      size = 0;
+
+public:
+    void add(const char* name, T*& value) {
+        entries[size]       = Entry<T>();
+        entries[size].name  = name;
+        entries[size].value = value;
+        size++;
+    }
+
+    void get(const char* name, T*& value) {
+        for (int i = 0; i < size; i++) {
+            if (strcmp(entries[i].name, name)) {
+                value = entries[i].value;
+            }
+        }
+    }
+
+    const char* getName(T* value) {
+        for (int i = 0; i < size; i++) {
+            if (entries[i].value == value) {
+                return entries[i].name;
+            }
+        }
+        return nullptr;
+    }   
+};

--- a/FluidNC/src/Configuration/Generator.cpp
+++ b/FluidNC/src/Configuration/Generator.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
 
 #include "Generator.h"
-
+#include "../Uart.h"
 #include "Configurable.h"
 
 #include <cstring>
@@ -23,6 +23,11 @@ namespace Configuration {
         if (configurable != nullptr) {
             configurable->group(*this);
         }
+    }
+
+    void Generator::item(const char* name, Uart*& uart) {
+        send_item(name, Uart::externals.getName(uart));
+        indent_++;
     }
 
     void Generator::leave() {

--- a/FluidNC/src/Configuration/Generator.h
+++ b/FluidNC/src/Configuration/Generator.h
@@ -9,8 +9,11 @@
 #include "../Report.h"    // report_gcode_modes()
 #include "../Protocol.h"  // send_line()
 #include "HandlerBase.h"
+#include "./ExternalList.h"
 
-namespace Configuration {
+class Uart;
+
+ namespace Configuration {
     class Configurable;
 
     class Generator : public HandlerBase {
@@ -28,6 +31,7 @@ namespace Configuration {
     protected:
         void        enterSection(const char* name, Configurable* value) override;
         bool        matchesUninitialized(const char* name) override { return false; }
+        const char* matchUninitialized(const char* name) override { return nullptr; }
         HandlerType handlerType() override { return HandlerType::Generator; }
 
     public:
@@ -97,6 +101,8 @@ namespace Configuration {
             }
             send_item(name, s);
         }
+
+        void item(const char* name, Uart*& uart) override;
 
         void item(const char* name, String& value, int minLength, int maxLength) override { send_item(name, value.c_str()); }
 

--- a/FluidNC/src/Configuration/JsonGenerator.cpp
+++ b/FluidNC/src/Configuration/JsonGenerator.cpp
@@ -107,6 +107,10 @@ namespace Configuration {
         leave();
     }
 
+    void JsonGenerator::item(const char* name, Uart*& uart) {
+        // Not sure if we want to have the uart section here or just the name of the external uart
+    }
+
     void JsonGenerator::item(const char* name, Pin& value) {
         // We commented this out, because pins are very confusing for users. The code is correct,
         // but it really gives more support than it's worth.

--- a/FluidNC/src/Configuration/JsonGenerator.h
+++ b/FluidNC/src/Configuration/JsonGenerator.h
@@ -30,6 +30,8 @@ namespace Configuration {
     protected:
         void        enterSection(const char* name, Configurable* value) override;
         bool        matchesUninitialized(const char* name) override { return false; }
+        const char* matchUninitialized(const char* name) override { return nullptr; }
+
         HandlerType handlerType() override { return HandlerType::Generator; }
 
     public:
@@ -42,6 +44,7 @@ namespace Configuration {
         void item(const char* name, std::vector<speedEntry>& value) override;
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override;
         void item(const char* name, String& value, int minLength, int maxLength) override;
+        void item(const char* name, Uart*& uart) override;
         void item(const char* name, Pin& value) override;
         void item(const char* name, IPAddress& value) override;
         void item(const char* name, int& value, EnumItem* e) override;

--- a/FluidNC/src/Configuration/Parser.cpp
+++ b/FluidNC/src/Configuration/Parser.cpp
@@ -11,7 +11,7 @@
 
 #include <climits>
 #include <math.h>  // round
-#include <regex.h>
+#include <regex>
 
 namespace Configuration {
     Parser::Parser(const char* start, const char* end) : Tokenizer(start, end) {}
@@ -45,25 +45,13 @@ namespace Configuration {
             return nullptr;
         }
 
-        regex_t reg;
-        if (regcomp(&reg, pattern, REG_EXTENDED | REG_NOSUB) != 0) {
-            log_error("Can not compile regex: " << pattern);
-            return nullptr;
-        }
-
-        size_t length = 0;
-        for (const char* pos = token_.keyStart_; pos != token_.keyEnd_; pos++) {
-            length++;
-        }
-
+        std::regex rp(pattern);
+        size_t length = token_.keyEnd_ - token_.keyStart_;
         char name[40];
         strncpy(name, token_.keyStart_, length);
         name[length] = '\0';
 
-        int result = regexec(&reg, name, 0, 0, 0);
-        regfree(&reg);
-
-        if (result == 0) {
+        if (std::regex_search(name, rp)) {
             char* result = new char[length+1];
             strncpy(result, name, length + 1);
             return result;

--- a/FluidNC/src/Configuration/Parser.h
+++ b/FluidNC/src/Configuration/Parser.h
@@ -8,11 +8,14 @@
 #include "../StringRange.h"
 #include "../EnumItem.h"
 #include "../UartTypes.h"
+
 #include "HandlerBase.h"
 
 #include <stack>
 #include <cstring>
 #include <IPAddress.h>
+
+class Uart; 
 
 namespace Configuration {
     class Parser : public Tokenizer {
@@ -22,6 +25,7 @@ namespace Configuration {
         Parser(const char* start, const char* end);
 
         bool is(const char* expected);
+        char const* match(const char* regex);
 
         StringRange             stringValue() const;
         bool                    boolValue() const;
@@ -29,6 +33,7 @@ namespace Configuration {
         uint32_t                uintValue() const;
         std::vector<speedEntry> speedEntryValue() const;
         float                   floatValue() const;
+        void                    uartValue(Uart*& uart) const;
         Pin                     pinValue() const;
         int                     enumValue(EnumItem* e) const;
         IPAddress               ipValue() const;

--- a/FluidNC/src/Configuration/ParserHandler.h
+++ b/FluidNC/src/Configuration/ParserHandler.h
@@ -92,7 +92,13 @@ namespace Configuration {
             _path.erase(_path.begin() + (_path.size() - 1));
         }
 
-        bool matchesUninitialized(const char* name) override { return _parser.is(name); }
+        bool matchesUninitialized(const char* name) override {
+             return _parser.is(name); 
+        }
+
+        const char* matchUninitialized(const char* pattern) override {
+             return _parser.match(pattern); 
+        }
 
     public:
         ParserHandler(Configuration::Parser& parser) : _parser(parser) {}
@@ -139,6 +145,12 @@ namespace Configuration {
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override {
             if (_parser.is(name)) {
                 _parser.uartMode(wordLength, parity, stopBits);
+            }
+        }
+
+        void item(const char* name, Uart*& uart) override {
+            if (_parser.is(name)) {
+                _parser.uartValue(uart);
             }
         }
 

--- a/FluidNC/src/Configuration/RuntimeSetting.cpp
+++ b/FluidNC/src/Configuration/RuntimeSetting.cpp
@@ -6,6 +6,7 @@
 #include "../Report.h"
 #include "../Protocol.h"  // send_line()
 
+#include "../Uart.h"
 #include <cstdlib>
 #include <atomic>
 
@@ -116,6 +117,17 @@ namespace Configuration {
                 log_to(out_, "", setting_prefix() << value);
             } else {
                 value = String(newValue_);
+            }
+        }
+    }
+
+    void RuntimeSetting::item(const char* name, Uart*& value) {
+        if (is(name)) {
+            isHandled_ = true;
+            if (newValue_ == nullptr) {
+                out_ << "$/" << setting_ << "=" << Uart::externals.getName(value) << '\n';
+            } else {
+                Uart::externals.get(newValue_, value);
             }
         }
     }

--- a/FluidNC/src/Configuration/RuntimeSetting.h
+++ b/FluidNC/src/Configuration/RuntimeSetting.h
@@ -29,7 +29,7 @@ namespace Configuration {
     protected:
         void enterSection(const char* name, Configuration::Configurable* value) override;
         bool matchesUninitialized(const char* name) override { return false; }
-
+        const char* matchUninitialized(const char* pattern) override { return nullptr; }
     public:
         RuntimeSetting(const char* key, const char* value, Channel& out);
 
@@ -40,6 +40,7 @@ namespace Configuration {
         void item(const char* name, std::vector<speedEntry>& value) override;
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override {}
         void item(const char* name, String& value, int minLength, int maxLength) override;
+        void item(const char* name, Uart*& uart) override;
         void item(const char* name, Pin& value) override;
         void item(const char* name, IPAddress& value) override;
         void item(const char* name, int& value, EnumItem* e) override;

--- a/FluidNC/src/Configuration/Validator.h
+++ b/FluidNC/src/Configuration/Validator.h
@@ -20,6 +20,7 @@ namespace Configuration {
     protected:
         void        enterSection(const char* name, Configurable* value) override;
         bool        matchesUninitialized(const char* name) override { return false; }
+        const char* matchUninitialized(const char* pattern) override { return nullptr; }
         HandlerType handlerType() override { return HandlerType::Validator; }
 
     public:
@@ -32,6 +33,7 @@ namespace Configuration {
         void item(const char* name, std::vector<speedEntry>& value) override {}
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override {}
         void item(const char* name, String& value, int minLength, int maxLength) override {}
+        void item(const char* name, Uart*& uart) override {}
         void item(const char* name, Pin& value) override {}
         void item(const char* name, IPAddress& value) override {}
         void item(const char* name, int& value, EnumItem* e) override {}

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -35,7 +35,7 @@ namespace Machine {
         handler.item("name", _name);
         handler.item("meta", _meta);
 
-        handler.extSection("uart_", &Uart::externals);
+        handler.extSection("^uart_", &Uart::externals);
 
         handler.section("stepping", _stepping);
         handler.section("axes", _axes);

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -35,6 +35,8 @@ namespace Machine {
         handler.item("name", _name);
         handler.item("meta", _meta);
 
+        handler.extSection("uart_", &Uart::externals);
+
         handler.section("stepping", _stepping);
         handler.section("axes", _axes);
         handler.section("kinematics", _kinematics);

--- a/FluidNC/src/Motors/TMC2208Driver.cpp
+++ b/FluidNC/src/Motors/TMC2208Driver.cpp
@@ -12,12 +12,8 @@
 namespace MotorDrivers {
 
     void TMC2208Driver::init() {
-        if (!_uart_started) {
-            _uart->begin();
-            _uart->config_message("Trinamic", " Stepper ");
-            _uart_started = true;
-        }
-
+        TrinamicUartDriver::initUart(_uart);
+        
         if (_r_sense == 0) {
             _r_sense = TMC2208_RSENSE_DEFAULT;
         }

--- a/FluidNC/src/Motors/TMC2209Driver.cpp
+++ b/FluidNC/src/Motors/TMC2209Driver.cpp
@@ -12,11 +12,7 @@
 namespace MotorDrivers {
 
     void TMC2209Driver::init() {
-        if (!_uart_started) {
-            _uart->begin();
-            _uart->config_message("Trinamic", " Stepper ");
-            _uart_started = true;
-        }
+        TrinamicUartDriver::initUart(_uart);
 
         if (_r_sense == 0) {
             _r_sense = TMC2209_RSENSE_DEFAULT;

--- a/FluidNC/src/Motors/TrinamicUartDriver.cpp
+++ b/FluidNC/src/Motors/TrinamicUartDriver.cpp
@@ -19,17 +19,14 @@
 
 namespace MotorDrivers {
 
-    Uart* TrinamicUartDriver::_uart         = nullptr;
-    bool  TrinamicUartDriver::_uart_started = false;
-
-    void TrinamicUartDriver::init() {}
+    void TrinamicUartDriver::init() { }
 
     /*
         This is the startup message showing the basic definition. 
     */
     void TrinamicUartDriver::config_message() {  //TODO: The RX/TX pin could be added to the msg.
         log_info("    " << name() << " Step:" << _step_pin.name() << " Dir:" << _dir_pin.name() << " Disable:" << _disable_pin.name()
-                        << " Addr:" << _addr << " R:" << _r_sense);
+                        << " RX: " << _uart->_rxd_pin.name() << " TX: " << _uart->_txd_pin.name() << " Addr:" << _addr << " R:" << _r_sense);
     }
 
     void TrinamicUartDriver::finalInit() {
@@ -65,6 +62,33 @@ namespace MotorDrivers {
             return _toff_disable;
         }
         return _mode == TrinamicMode::StealthChop ? _toff_stealthchop : _toff_coolstep;
+    }
+
+
+    // this code is to track uarts that are initialsed
+
+    static Uart* initializedUarts[3]{nullptr};
+
+    void TrinamicUartDriver::initUart(Uart* uart) {
+        // nothing to do if already initialised 
+        for(int i = 0; i < 3; i++){
+            if(initializedUarts[i] == uart){
+                return;
+            }
+        }
+
+        // init uart
+        uart->begin();
+        uart->config_message("Trinamic", " Stepper ");
+
+        // add to list of initialised uarts
+        for(int i = 0; i < 3; i++){
+            if(initializedUarts[i] == nullptr){
+                initializedUarts[i] = uart;
+                return;
+            }
+        }
+
     }
 
 }

--- a/FluidNC/src/Motors/TrinamicUartDriver.h
+++ b/FluidNC/src/Motors/TrinamicUartDriver.h
@@ -8,6 +8,7 @@
 #include "../Pin.h"
 #include "../Uart.h"
 
+#include "../Logging.h"
 #include <cstdint>
 
 namespace MotorDrivers {
@@ -48,18 +49,18 @@ namespace MotorDrivers {
             // $CD), _uart will be non-null, so we use the instance
             // variable _addr to force the generation of only one
             // uart: section, beneath the tmc_220x: section for addr 0.
+            handler.item("uart", _uart);
             handler.item("addr", _addr);
-            if (_uart == nullptr || _addr == 0) {
-                handler.section("uart", _uart);
-            }
+            // if (_uart == nullptr || _addr == 0) {
+            //     handler.section("uart", _uart);
+            // }
         }
 
     protected:
-        static Uart* _uart;
+        Uart* _uart;
 
-        static bool _uart_started;
-        void        config_message() override;
-
+        static void initUart(Uart* uart);
+        void config_message() override;
         void finalInit();
 
         uint8_t toffValue();  // TO DO move to Base?

--- a/FluidNC/src/Uart.cpp
+++ b/FluidNC/src/Uart.cpp
@@ -10,6 +10,8 @@
 #include <driver/uart.h>
 #include <esp_ipc.h>
 
+ExternalList<Uart> Uart::externals = ExternalList<Uart>();
+
 Uart::Uart(int uart_num, bool addCR) : Channel("uart", addCR) {
     // Auto-assign Uart harware engine numbers; the pins will be
     // assigned to the engines separately

--- a/FluidNC/src/Uart.h
+++ b/FluidNC/src/Uart.h
@@ -6,6 +6,7 @@
 #include "Config.h"
 
 #include "Configuration/Configurable.h"
+#include "Configuration/ExternalList.h"
 #include "UartTypes.h"
 
 #include "lineedit.h"
@@ -25,6 +26,8 @@ private:
     int _pushback = -1;
 
 public:
+    static ExternalList<Uart> externals;
+
     // These are public so that validators from classes
     // that use Uart can check that the setup is suitable.
     // E.g. some uses require an RTS pin.


### PR DESCRIPTION
This is an attempt to use multiple UARTs for TMC2009. 
I am using this branch for a while now to run my MPCNC with five TMC2009 drivers.

Note: You need to specify the UART before using within a TMC2009 config:

```yaml
uart_xy:
  rxd_pin:  gpio.2
  txd_pin:  gpio.15
  baud: 115200
  mode: 8N1

uart_z:
  rxd_pin: gpio.16
  txd_pin: gpio.4
  baud: 115200
  mode: 8N1

[...]

axes:  
  x:
   motor0:
      limit_neg_pin: gpio.36:low
      pulloff_mm: 2.000
      tmc_2209:
        uart: uart_xy
        addr: 0
        r_sense_ohms: 0.110
        [...]
  y:
    motor0:
      limit_neg_pin: gpio.32:low
      pulloff_mm: 1.000
      tmc_2209:
        uart: uart_z
        addr: 0
        [...]
```

You can still use a direct specification of the UART - but with the known limitations of using a single UART.