### PR TITLE
Fixed crash due to memcpy

### DIFF
--- a/FluidNC/src/SettingsDefinitions.cpp
+++ b/FluidNC/src/SettingsDefinitions.cpp
@@ -48,6 +48,8 @@ void make_settings() {
     make_coordinate(CoordIndex::G59, "G59");
     make_coordinate(CoordIndex::G28, "G28");
     make_coordinate(CoordIndex::G30, "G30");
+    make_coordinate(CoordIndex::G92, "G92");
+    make_coordinate(CoordIndex::TLO, "TLO");
 
     message_level = new EnumSetting("Which Messages", EXTENDED, WG, NULL, "Message/Level", MsgLevelInfo, &messageLevels, NULL);
 


### PR DESCRIPTION
Added G92 and TLO to the coordinate system initialization