### PR TITLE
Added Beeper control and full pin map info

### DIFF
--- a/MKS_DLC32_v21_laser.yaml
+++ b/MKS_DLC32_v21_laser.yaml
@@ -1,0 +1,202 @@
+# Basic configuration file for X/Y Laser using GT2 belts 1.8ºNEMA motors
+# at 16 microSteps and 16 Tooth pulleys
+
+board: MKS-DLC32 V2.1
+name: 3dpBurner3
+meta: villamany 30/Jan/2023
+
+kinematics:
+  Cartesian:
+
+stepping:
+  engine: I2S_STATIC
+  idle_ms: 255
+  pulse_us: 4
+  dir_delay_us: 1
+  disable_delay_us: 0
+axes:
+  shared_stepper_disable_pin: I2SO.0
+  x:
+    steps_per_mm: 100
+    max_rate_mm_per_min: 16000
+    acceleration_mm_per_sec2: 1500
+    max_travel_mm: 895
+    soft_limits: false
+    homing:
+      cycle: 0
+      positive_direction: false
+      mpos_mm: 0.000
+      feed_mm_per_min: 500.000
+      seek_mm_per_min: 16000.000
+      settle_ms: 500
+      seek_scaler: 1.100
+      feed_scaler: 1.100
+
+    motor0:
+      limit_neg_pin: gpio.36:low
+      hard_limits: false
+      pulloff_mm: 2.000
+      stepstick:
+        step_pin: I2SO.1
+        direction_pin: I2SO.2:low
+
+  y:
+    steps_per_mm: 100
+    max_rate_mm_per_min: 16000
+    acceleration_mm_per_sec2: 1500
+    max_travel_mm: 880
+    soft_limits: false
+    homing:
+      cycle: 0
+      positive_direction: false
+      mpos_mm: 0.000
+      feed_mm_per_min: 500.000
+      seek_mm_per_min: 16000.000
+      settle_ms: 500
+      seek_scaler: 1.100
+      feed_scaler: 1.100
+
+    motor0:
+      limit_neg_pin: gpio.35:low
+      hard_limits: false
+      pulloff_mm: 2.000
+      stepstick:
+        step_pin: I2SO.5
+        direction_pin: I2SO.6:high
+ 
+  z:
+    steps_per_mm: 80
+    max_rate_mm_per_min: 5000.000
+    acceleration_mm_per_sec2: 500.000
+    max_travel_mm: 80.000
+    soft_limits: true
+    homing:
+      cycle: 0
+      positive_direction: false
+      mpos_mm: 0.000
+      feed_mm_per_min: 200.000
+      seek_mm_per_min: 500.000
+      settle_ms: 500
+      seek_scaler: 1.100
+      feed_scaler: 1.100
+
+    motor0:
+      limit_neg_pin: gpio.34
+      hard_limits: false
+      pulloff_mm: 1.000
+      stepstick:
+        step_pin: I2SO.3
+        direction_pin: I2SO.4
+        
+i2so:
+  bck_pin: gpio.16
+  data_pin: gpio.21
+  ws_pin: gpio.17
+
+spi:
+  miso_pin: gpio.12
+  mosi_pin: gpio.13
+  sck_pin: gpio.14
+
+sdcard:
+  cs_pin: gpio.15
+  card_detect_pin: NO_PIN
+#  card_detect_pin: gpio.39
+  
+control:
+  safety_door_pin: NO_PIN
+  reset_pin: NO_PIN
+  feed_hold_pin: NO_PIN
+  cycle_start_pin: NO_PIN
+  macro0_pin: NO_PIN
+  macro1_pin: NO_PIN
+  macro2_pin: NO_PIN
+  macro3_pin: NO_PIN
+
+macros:
+  startup_line0:
+  startup_line1:
+  macro0:
+  macro1:
+  macro2:
+  macro3:
+
+coolant:
+  flood_pin: NO_PIN
+  mist_pin: NO_PIN
+  delay_ms: 0
+
+#probe:
+#  pin: gpio.22
+#  check_mode_start: true
+
+Laser:
+  pwm_hz: 5000
+  output_pin: gpio.32
+  disable_with_s0: false
+  s0_with_disable: false
+  tool_num: 0
+  speed_map: 0=0.000% 1000=100.000%
+#PWM:
+#  direction_pin: NO_PIN
+#  spinup_ms: 1000
+#  spindown_ms: 1000
+  
+user_outputs:
+  analog0_pin: NO_PIN
+  analog1_pin: NO_PIN
+  analog2_pin: NO_PIN
+  analog3_pin: NO_PIN
+  analog0_hz: 5000
+  analog1_hz: 5000
+  analog2_hz: 5000
+  analog3_hz: 5000
+  #Beeper connector. Command: "M62 P0" turn beeper On. 
+  #"G4 P0.5" wait for 0.5s. "M63 P0" turn beeper OFF
+  digital0_pin: I2SO.7
+  digital1_pin: NO_PIN
+  digital2_pin: NO_PIN
+  digital3_pin: NO_PIN
+
+start:
+  must_home: false
+
+
+#MKS DLC32 v2.1 pinMap
+
+# X- gpio.36
+# SD_DET gpio.39
+# Z- gpio.34
+# Y- gpio.35
+# SPINDLE PWM gpio.32
+# LCD_RS gpio.33
+# LCD_CS_INV gpio.25
+# LCD_TOUCH_CS_INV gpio.26
+# LCD_RST_INV gpio.27
+# SD_SCK gpio.14
+# SD_DO gpio.12
+# SD_DI gpio.13
+# SD_CS gpio.15
+# I2C_SDA gpio.0
+# I2C_SCL gpio.4
+# I2S_BCK gpio.16
+# I2S_WS gpio.17
+# LCD_EN_INV gpio.5
+# LCD_SCK gpio.18
+# LCD_MISO gpio.19
+# I2S_DATA gpio.21
+# RXD0 gpio.3
+# TXD0 gpio.1
+# Probe gpio.22
+# LCD_MOSI gpio.23
+
+# XYZ_EN I2SO.0
+# X_STEP I2SO.1
+# X_DIR I2SO.2
+# Z_STEP I2SO.3
+# Z_DIR I2SO.4
+# Y_STEP I2SO.5
+# Y_DIR I2SO.6
+# BEEPER I2SO.7
+
+

--- a/example_configs/MKS_DLC32_v21_laser.yaml
+++ b/example_configs/MKS_DLC32_v21_laser.yaml
@@ -1,0 +1,202 @@
+# Basic configuration file for X/Y Laser using GT2 belts 1.8ºNEMA motors
+# at 16 microSteps and 16 Tooth pulleys
+
+board: MKS-DLC32 V2.1
+name: 3dpBurner3
+meta: villamany 30/Jan/2023
+
+kinematics:
+  Cartesian:
+
+stepping:
+  engine: I2S_STREAM
+  idle_ms: 255
+  pulse_us: 4
+  dir_delay_us: 1
+  disable_delay_us: 0
+axes:
+  shared_stepper_disable_pin: I2SO.0
+  x:
+    steps_per_mm: 100
+    max_rate_mm_per_min: 16000
+    acceleration_mm_per_sec2: 1500
+    max_travel_mm: 895
+    soft_limits: false
+    homing:
+      cycle: 0
+      positive_direction: false
+      mpos_mm: 0.000
+      feed_mm_per_min: 500.000
+      seek_mm_per_min: 16000.000
+      settle_ms: 500
+      seek_scaler: 1.100
+      feed_scaler: 1.100
+
+    motor0:
+      limit_neg_pin: gpio.36:low
+      hard_limits: false
+      pulloff_mm: 2.000
+      stepstick:
+        step_pin: I2SO.1
+        direction_pin: I2SO.2:low
+
+  y:
+    steps_per_mm: 100
+    max_rate_mm_per_min: 16000
+    acceleration_mm_per_sec2: 1500
+    max_travel_mm: 880
+    soft_limits: false
+    homing:
+      cycle: 0
+      positive_direction: false
+      mpos_mm: 0.000
+      feed_mm_per_min: 500.000
+      seek_mm_per_min: 16000.000
+      settle_ms: 500
+      seek_scaler: 1.100
+      feed_scaler: 1.100
+
+    motor0:
+      limit_neg_pin: gpio.35:low
+      hard_limits: false
+      pulloff_mm: 2.000
+      stepstick:
+        step_pin: I2SO.5
+        direction_pin: I2SO.6:high
+ 
+  z:
+    steps_per_mm: 80
+    max_rate_mm_per_min: 5000.000
+    acceleration_mm_per_sec2: 500.000
+    max_travel_mm: 80.000
+    soft_limits: true
+    homing:
+      cycle: 0
+      positive_direction: false
+      mpos_mm: 0.000
+      feed_mm_per_min: 200.000
+      seek_mm_per_min: 500.000
+      settle_ms: 500
+      seek_scaler: 1.100
+      feed_scaler: 1.100
+
+    motor0:
+      limit_neg_pin: gpio.34
+      hard_limits: false
+      pulloff_mm: 1.000
+      stepstick:
+        step_pin: I2SO.3
+        direction_pin: I2SO.4
+        
+i2so:
+  bck_pin: gpio.16
+  data_pin: gpio.21
+  ws_pin: gpio.17
+
+spi:
+  miso_pin: gpio.12
+  mosi_pin: gpio.13
+  sck_pin: gpio.14
+
+sdcard:
+  cs_pin: gpio.15
+  card_detect_pin: NO_PIN
+#  card_detect_pin: gpio.39
+  
+control:
+  safety_door_pin: NO_PIN
+  reset_pin: NO_PIN
+  feed_hold_pin: NO_PIN
+  cycle_start_pin: NO_PIN
+  macro0_pin: NO_PIN
+  macro1_pin: NO_PIN
+  macro2_pin: NO_PIN
+  macro3_pin: NO_PIN
+
+macros:
+  startup_line0:
+  startup_line1:
+  macro0:
+  macro1:
+  macro2:
+  macro3:
+
+coolant:
+  flood_pin: NO_PIN
+  mist_pin: NO_PIN
+  delay_ms: 0
+
+#probe:
+#  pin: gpio.22
+#  check_mode_start: true
+
+Laser:
+  pwm_hz: 5000
+  output_pin: gpio.32
+  disable_with_s0: false
+  s0_with_disable: false
+  tool_num: 0
+  speed_map: 0=0.000% 1000=100.000%
+#PWM:
+#  direction_pin: NO_PIN
+#  spinup_ms: 1000
+#  spindown_ms: 1000
+  
+user_outputs:
+  analog0_pin: NO_PIN
+  analog1_pin: NO_PIN
+  analog2_pin: NO_PIN
+  analog3_pin: NO_PIN
+  analog0_hz: 5000
+  analog1_hz: 5000
+  analog2_hz: 5000
+  analog3_hz: 5000
+  #Beeper connector. Command: "M62 P0" turn beeper On. 
+  #"G4 P0.5" wait for 0.5s. "M63 P0" turn beeper OFF
+  digital0_pin: I2SO.7
+  digital1_pin: NO_PIN
+  digital2_pin: NO_PIN
+  digital3_pin: NO_PIN
+
+start:
+  must_home: false
+
+
+#MKS DLC32 v2.1 pinMap
+
+# X- gpio.36
+# SD_DET gpio.39
+# Z- gpio.34
+# Y- gpio.35
+# SPINDLE PWM gpio.32
+# LCD_RS gpio.33
+# LCD_CS_INV gpio.25
+# LCD_TOUCH_CS_INV gpio.26
+# LCD_RST_INV gpio.27
+# SD_SCK gpio.14
+# SD_DO gpio.12
+# SD_DI gpio.13
+# SD_CS gpio.15
+# I2C_SDA gpio.0
+# I2C_SCL gpio.4
+# I2S_BCK gpio.16
+# I2S_WS gpio.17
+# LCD_EN_INV gpio.5
+# LCD_SCK gpio.18
+# LCD_MISO gpio.19
+# I2S_DATA gpio.21
+# RXD0 gpio.3
+# TXD0 gpio.1
+# Probe gpio.22
+# LCD_MOSI gpio.23
+
+# XYZ_EN I2SO.0
+# X_STEP I2SO.1
+# X_DIR I2SO.2
+# Z_STEP I2SO.3
+# Z_DIR I2SO.4
+# Y_STEP I2SO.5
+# Y_DIR I2SO.6
+# BEEPER I2SO.7
+
+


### PR DESCRIPTION
A MKS DLC32 v2.1 configuration file used for laser.
-Added the control of Bepper pin of this board missing in others configuration files.
-Added full pin map info at the end of the file as comments.
-Use of I2S_STATIC as recommended for this board.