### PR TITLE
Add manifest generation in the build release script

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -46,6 +46,8 @@ jobs:
         files: |
           release/*.zip
           release/*.elf
+          release/*.bin
+          release/manifest.json
         draft: True
     # - name: Upload mac bundle
     #   uses: actions/upload-artifact@v2


### PR DESCRIPTION
The build script will now generate a package manifest for different install options based on the template described here: http://wiki.fluidnc.com/en/WebInstaller.

Each binary will be copied to the release directory and should be uploaded to the github release:

<img width="225" alt="image" src="https://user-images.githubusercontent.com/8962024/223808129-eb37c76b-7b17-454a-8f4e-1407c567edf6.png">

I didn't include all elements in the manifest as I weren't sure that I was going to need them. Here is a sample of what it will look like:

```
{
    "name": "FluidNC",
    "version": "v3.6.8",
    "source_url": "https://github.com/bdring/FluidNC/tree/v3.6.8",
    "release_url": "https://github.com/bdring/FluidNC/releases/tag/v3.6.8",
    "funding_url": "https://www.paypal.com/donate/?hosted_button_id=8DYLB6ZYYDG7Y",
    "images": [
        {
            "name": "bootloader_dio_80m.bin",
            "path": "bootloader_dio_80m.bin",
            "offset": "0x1000"
        },
        {
            "name": "boot_app0.bin",
            "path": "boot_app0.bin",
            "offset": "0xe000"
        },
        {
            "name": "spiffs.bin",
            "path": "spiffs.bin",
            "offset": "0x3d0000"
        },
        {
            "name": "bt-firmware.bin",
            "path": "bt-firmware.bin",
            "offset": "0x10000"
        },
        {
            "name": "bt-firmware.bin",
            "path": "bt-firmware.bin",
            "offset": "0x10000"
        },
        {
            "name": "bt-partitions.bin",
            "path": "bt-partitions.bin",
            "offset": "0x8000"
        },
        {
            "name": "wifi-firmware.bin",
            "path": "wifi-firmware.bin",
            "offset": "0x1000"
        },
        {
            "name": "wifi-partitions.bin",
            "path": "wifi-partitions.bin",
            "offset": "0x8000"
        }
    ],
    "installables": [
        {
            "chip": "ESP32-WROOM",
            "flashSize": "4MB",
            "description": "Complete FluidNC installation, erasing all previous data.",
            "install-variant": "fresh-install",
            "variant": "wifi",
            "erase": true,
            "images": [
                "bootloader_dio_80m.bin",
                "boot_app0.bin",
                "wifi-firmware.bin",
                "wifi-partitions.bin",
                "spiffs.bin"
            ]
        },
        {
            "chip": "ESP32-WROOM",
            "flashSize": "4MB",
            "description": "Update FluidNC to latest firmware version, preserving previous filesystem data.",
            "install-variant": "firmware-update",
            "variant": "wifi",
            "erase": false,
            "images": [
                "bootloader_dio_80m.bin",
                "boot_app0.bin",
                "wifi-firmware.bin",
                "wifi-partitions.bin"
            ]
        },
        {
            "chip": "ESP32-WROOM",
            "flashSize": "4MB",
            "description": "Update FluidNC filesystem only, erasing previous filesystem contents.",
            "install-variant": "filesystem-update",
            "variant": "wifi",
            "erase": false,
            "images": [
                "spiffs.bin"
            ]
        },
        {
            "chip": "ESP32-WROOM",
            "flashSize": "4MB",
            "description": "Complete FluidNC installation, erasing all previous data.",
            "install-variant": "fresh-install",
            "variant": "bt",
            "erase": true,
            "images": [
                "bootloader_dio_80m.bin",
                "boot_app0.bin",
                "bt-firmware.bin",
                "bt-partitions.bin",
                "spiffs.bin"
            ]
        },
        {
            "chip": "ESP32-WROOM",
            "flashSize": "4MB",
            "description": "Update FluidNC to latest firmware version, preserving previous filesystem data.",
            "install-variant": "firmware-update",
            "variant": "bt",
            "erase": false,
            "images": [
                "bootloader_dio_80m.bin",
                "boot_app0.bin",
                "bt-firmware.bin",
                "bt-partitions.bin"
            ]
        },
        {
            "chip": "ESP32-WROOM",
            "flashSize": "4MB",
            "description": "Update FluidNC filesystem only, erasing previous filesystem contents.",
            "install-variant": "filesystem-update",
            "variant": "bt",
            "erase": false,
            "images": [
                "spiffs.bin"
            ]
        }
    ]
}
```

