### PR TITLE
Configuration::Configurable::validate changed to non-const.

### DIFF
--- a/FluidNC/src/Configuration/Configurable.h
+++ b/FluidNC/src/Configuration/Configurable.h
@@ -19,7 +19,7 @@ namespace Configuration {
     public:
         Configurable() = default;
 
-        virtual void validate() const {};
+        virtual void validate() {};
         virtual void group(HandlerBase& handler) = 0;
         virtual void afterParse() {}
         // virtual const char* name() const = 0;

--- a/FluidNC/src/Configuration/ConfigurationHandlers.md
+++ b/FluidNC/src/Configuration/ConfigurationHandlers.md
@@ -40,7 +40,7 @@ public:
     Pin _data;
     Pin _ws;
 
-    void validate() const override {
+    void validate() override {
         if (!_bck.undefined() || !_data.undefined() || !_ws.undefined()) {
             Assert(!_bck.undefined(), "I2SO BCK pin should be configured once.");
             Assert(!_data.undefined(), "I2SO Data pin should be configured once.");

--- a/FluidNC/src/Configuration/_Overview.md
+++ b/FluidNC/src/Configuration/_Overview.md
@@ -45,7 +45,7 @@ public:
     Pin _bck;
     // ...
 
-    void validate() const override {
+    void validate() override {
         if (!_bck.undefined() || !_data.undefined() || !_ws.undefined()) {
             Assert(!_bck.undefined(), "I2SO BCK pin should be configured once.");
             // ...

--- a/FluidNC/src/Kinematics/Cartesian.h
+++ b/FluidNC/src/Kinematics/Cartesian.h
@@ -36,7 +36,7 @@ namespace Kinematics {
         // Configuration handlers:
         void afterParse() override {}
         void group(Configuration::HandlerBase& handler) override {}
-        void validate() const override {}
+        void validate() override {}
 
         // Name of the configurable. Must match the name registered in the cpp file.
         const char* name() const override { return "Cartesian"; }

--- a/FluidNC/src/Kinematics/CoreXY.h
+++ b/FluidNC/src/Kinematics/CoreXY.h
@@ -36,7 +36,7 @@ namespace Kinematics {
         bool limitReached(AxisMask& axisMask, MotorMask& motors, MotorMask limited);
 
         // Configuration handlers:
-        void         validate() const override {}
+        void         validate() override {}
         virtual void group(Configuration::HandlerBase& handler) override;
         void         afterParse() override {}
 

--- a/FluidNC/src/Kinematics/Kinematics.h
+++ b/FluidNC/src/Kinematics/Kinematics.h
@@ -80,7 +80,7 @@ namespace Kinematics {
         // Configuration interface.
         void afterParse() override {}
         void group(Configuration::HandlerBase& handler) override {}
-        void validate() const override {}
+        void validate() override {}
 
         // Name of the configurable. Must match the name registered in the cpp file.
         virtual const char* name() const = 0;

--- a/FluidNC/src/Kinematics/WallPlotter.h
+++ b/FluidNC/src/Kinematics/WallPlotter.h
@@ -31,7 +31,7 @@ namespace Kinematics {
         void transform_cartesian_to_motors(float* cartesian, float* motors) override;
 
         // Configuration handlers:
-        void validate() const override {}
+        void validate() override {}
         void group(Configuration::HandlerBase& handler) override;
         void afterParse() override {}
 

--- a/FluidNC/src/Machine/Homing.h
+++ b/FluidNC/src/Machine/Homing.h
@@ -55,7 +55,7 @@ namespace Machine {
         float    _feed_scaler       = 1.1f;    // multiplier to pulloff for moving to switch after pulloff
 
         // Configuration system helpers:
-        void validate() const override { Assert(_cycle >= set_mpos_only, "Homing cycle must be defined"); }
+        void validate() override { Assert(_cycle >= set_mpos_only, "Homing cycle must be defined"); }
 
         void group(Configuration::HandlerBase& handler) override {
             handler.item("cycle", _cycle, set_mpos_only, MAX_N_AXIS);

--- a/FluidNC/src/Machine/I2CBus.cpp
+++ b/FluidNC/src/Machine/I2CBus.cpp
@@ -7,7 +7,7 @@
 namespace Machine {
     I2CBus::I2CBus(int busNumber) : _busNumber(busNumber) {}
 
-    void I2CBus::validate() const {
+    void I2CBus::validate() {
         if (_sda.defined() || _scl.defined()) {
             Assert(_sda.defined(), "I2C SDA pin configured multiple times");
             Assert(_scl.defined(), "I2C SCL pin configured multiple times");

--- a/FluidNC/src/Machine/I2CBus.h
+++ b/FluidNC/src/Machine/I2CBus.h
@@ -23,7 +23,7 @@ namespace Machine {
         uint32_t _frequency = 100000;
 
         void init();
-        void validate() const override;
+        void validate() override;
         void group(Configuration::HandlerBase& handler) override;
 
         int write(uint8_t address, const uint8_t* data, size_t count);

--- a/FluidNC/src/Machine/I2SOBus.cpp
+++ b/FluidNC/src/Machine/I2SOBus.cpp
@@ -6,7 +6,7 @@
 #include "../I2SOut.h"
 
 namespace Machine {
-    void I2SOBus::validate() const {
+    void I2SOBus::validate() {
         if (_bck.defined() || _data.defined() || _ws.defined()) {
             Assert(_bck.defined(), "I2SO BCK pin should be configured once");
             Assert(_data.defined(), "I2SO Data pin should be configured once");

--- a/FluidNC/src/Machine/I2SOBus.h
+++ b/FluidNC/src/Machine/I2SOBus.h
@@ -15,7 +15,7 @@ namespace Machine {
         Pin _data;
         Pin _ws;
 
-        void validate() const override;
+        void validate() override;
         void group(Configuration::HandlerBase& handler) override;
 
         void init();

--- a/FluidNC/src/Machine/SPIBus.cpp
+++ b/FluidNC/src/Machine/SPIBus.cpp
@@ -8,7 +8,7 @@
 #include "src/SettingsDefinitions.h"
 
 namespace Machine {
-    void SPIBus::validate() const {
+    void SPIBus::validate() {
         if (_miso.defined() || _mosi.defined() || _sck.defined()) {
             Assert(_miso.defined(), "SPI MISO pin should be configured once");
             Assert(_mosi.defined(), "SPI MOSI pin should be configured once");

--- a/FluidNC/src/Machine/SPIBus.h
+++ b/FluidNC/src/Machine/SPIBus.h
@@ -15,7 +15,7 @@ namespace Machine {
         Pin _mosi;
         Pin _sck;
 
-        void validate() const override;
+        void validate() override;
         void group(Configuration::HandlerBase& handler) override;
         void afterParse() override;
 

--- a/FluidNC/src/Machine/WifiAPConfig.h
+++ b/FluidNC/src/Machine/WifiAPConfig.h
@@ -14,7 +14,7 @@ namespace Machine {
 
         int _channel = 1;
 
-        void validate() const override {
+        void validate() override {
             WifiConfig::validate();
             Assert(_channel >= 1 && _channel <= 16, "WIFI channel %d is out of bounds", _channel);  // TODO: I guess?
         }

--- a/FluidNC/src/Machine/WifiSTAConfig.h
+++ b/FluidNC/src/Machine/WifiSTAConfig.h
@@ -12,7 +12,7 @@ namespace Machine {
     public:
         WifiSTAConfig() = default;
 
-        void validate() const override { WifiConfig::validate(); }
+        void validate() override { WifiConfig::validate(); }
 
         void group(Configuration::HandlerBase& handler) override { WifiConfig::group(handler); }
 

--- a/FluidNC/src/Motors/Dynamixel2.h
+++ b/FluidNC/src/Motors/Dynamixel2.h
@@ -106,7 +106,7 @@ namespace MotorDrivers {
         void config_motor() override;
 
         // Configuration handlers:
-        void validate() const override {
+        void validate() override {
             Assert(_uart_num != -1, "Dynamixel: Missing uart_num configuration");
             Assert(_id != 255, "Dynamixel: ID must be configured.");
         }

--- a/FluidNC/src/Motors/StandardStepper.cpp
+++ b/FluidNC/src/Motors/StandardStepper.cpp
@@ -115,7 +115,7 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<StandardStepper> registration("standard_stepper");
     }
 
-    void StandardStepper::validate() const {
+    void StandardStepper::validate() {
         Assert(_step_pin.defined(), "Step pin must be configured.");
         bool isI2SO = config->_stepping->_engine == Stepping::I2S_STREAM || config->_stepping->_engine == Stepping::I2S_STATIC;
         if (isI2SO) {

--- a/FluidNC/src/Motors/StandardStepper.h
+++ b/FluidNC/src/Motors/StandardStepper.h
@@ -32,7 +32,7 @@ namespace MotorDrivers {
         Pin _disable_pin;
 
         // Configuration handlers:
-        void validate() const override;
+        void validate() override;
 
         void group(Configuration::HandlerBase& handler) override {
             handler.item("step_pin", _step_pin);

--- a/FluidNC/src/Motors/StepStick.cpp
+++ b/FluidNC/src/Motors/StepStick.cpp
@@ -18,7 +18,7 @@ namespace MotorDrivers {
     }
 
     // Configuration handlers:
-    void StepStick::validate() const { StandardStepper::validate(); }
+    void StepStick::validate() { StandardStepper::validate(); }
 
     void StepStick::group(Configuration::HandlerBase& handler) {
         StandardStepper::group(handler);

--- a/FluidNC/src/Motors/StepStick.h
+++ b/FluidNC/src/Motors/StepStick.h
@@ -22,7 +22,7 @@ namespace MotorDrivers {
         void init() override;
 
         // Configuration handlers:
-        void validate() const override;
+        void validate() override;
         void group(Configuration::HandlerBase& handler) override;
 
         void afterParse() override;

--- a/FluidNC/src/Motors/TMC2130Driver.h
+++ b/FluidNC/src/Motors/TMC2130Driver.h
@@ -20,7 +20,7 @@ namespace MotorDrivers {
         void set_disable(bool disable);
         void config_motor() override;
         void debug_message() override;
-        void validate() const override { StandardStepper::validate(); }
+        void validate() override { StandardStepper::validate(); }
 
         // Name of the configurable. Must match the name registered in the cpp file.
         const char* name() const override { return "tmc_2130"; }

--- a/FluidNC/src/Motors/TMC2208Driver.h
+++ b/FluidNC/src/Motors/TMC2208Driver.h
@@ -20,7 +20,7 @@ namespace MotorDrivers {
         void set_disable(bool disable);
         void config_motor() override;
         void debug_message() override;
-        void validate() const override { StandardStepper::validate(); }
+        void validate() override { StandardStepper::validate(); }
 
         void group(Configuration::HandlerBase& handler) override {
             TrinamicUartDriver::group(handler);

--- a/FluidNC/src/Motors/TMC2209Driver.h
+++ b/FluidNC/src/Motors/TMC2209Driver.h
@@ -20,7 +20,7 @@ namespace MotorDrivers {
         void set_disable(bool disable);
         void config_motor() override;
         void debug_message() override;
-        void validate() const override { StandardStepper::validate(); }
+        void validate() override { StandardStepper::validate(); }
 
         void group(Configuration::HandlerBase& handler) override {
             TrinamicUartDriver::group(handler);

--- a/FluidNC/src/Motors/TMC5160Driver.h
+++ b/FluidNC/src/Motors/TMC5160Driver.h
@@ -20,7 +20,7 @@ namespace MotorDrivers {
         void set_disable(bool disable);
         void config_motor() override;
         void debug_message() override;
-        void validate() const override { StandardStepper::validate(); }
+        void validate() override { StandardStepper::validate(); }
 
         void group(Configuration::HandlerBase& handler) override {
             TrinamicSpiDriver::group(handler);

--- a/FluidNC/src/Motors/TMC5160ProDriver.h
+++ b/FluidNC/src/Motors/TMC5160ProDriver.h
@@ -32,7 +32,7 @@ namespace MotorDrivers {
         void set_disable(bool disable);
         void config_motor() override;
         void debug_message() override;
-        void validate() const override { StandardStepper::validate(); }
+        void validate() override { StandardStepper::validate(); }
 
         void group(Configuration::HandlerBase& handler) override {
             //handler.item("tpfd", _tpfd, 0, 15);

--- a/FluidNC/src/Motors/TrinamicSpiDriver.h
+++ b/FluidNC/src/Motors/TrinamicSpiDriver.h
@@ -49,7 +49,7 @@ namespace MotorDrivers {
             _spi_setup_done = true;
         }
 
-        void validate() const override { StandardStepper::validate(); }
+        void validate() override { StandardStepper::validate(); }
 
         void group(Configuration::HandlerBase& handler) override {
             TrinamicBase::group(handler);

--- a/FluidNC/src/Motors/TrinamicUartDriver.h
+++ b/FluidNC/src/Motors/TrinamicUartDriver.h
@@ -28,7 +28,7 @@ namespace MotorDrivers {
         uint8_t _addr;
 
         // Configuration handlers:
-        void validate() const override { StandardStepper::validate(); }
+        void validate() override { StandardStepper::validate(); }
 
         void afterParse() override {
             StandardStepper::validate();

--- a/FluidNC/src/Motors/UnipolarMotor.h
+++ b/FluidNC/src/Motors/UnipolarMotor.h
@@ -18,7 +18,7 @@ namespace MotorDrivers {
         void step() override;
 
         // Configuration handlers:
-        void validate() const override {
+        void validate() override {
             Assert(!_pin_phase0.undefined(), "Phase 0 pin should be configured.");
             Assert(!_pin_phase1.undefined(), "Phase 1 pin should be configured.");
             Assert(!_pin_phase2.undefined(), "Phase 2 pin should be configured.");

--- a/FluidNC/src/OLED.h
+++ b/FluidNC/src/OLED.h
@@ -117,7 +117,7 @@ public:
     size_t timedReadBytes(char* buffer, size_t length, TickType_t timeout) override { return 0; }
 
     // Configuration handlers:
-    void validate() const override {}
+    void validate() override {}
 
     void afterParse() override;
 

--- a/FluidNC/src/Probe.cpp
+++ b/FluidNC/src/Probe.cpp
@@ -36,7 +36,7 @@ bool IRAM_ATTR Probe::tripped() {
     return _probePin.read() ^ _isProbeAway;
 }
 
-void Probe::validate() const {}
+void Probe::validate() {}
 
 void Probe::group(Configuration::HandlerBase& handler) {
     handler.item("pin", _probePin);

--- a/FluidNC/src/Probe.h
+++ b/FluidNC/src/Probe.h
@@ -46,7 +46,7 @@ public:
     bool IRAM_ATTR tripped();
 
     // Configuration handlers.
-    void validate() const override;
+    void validate() override;
     void group(Configuration::HandlerBase& handler) override;
 
     ~Probe() = default;

--- a/FluidNC/src/Spindles/10vSpindle.h
+++ b/FluidNC/src/Spindles/10vSpindle.h
@@ -33,7 +33,7 @@ namespace Spindles {
         void deinit() override;
 
         // Configuration handlers:
-        void validate() const override { PWM::validate(); }
+        void validate() override { PWM::validate(); }
 
         void group(Configuration::HandlerBase& handler) override {
             handler.item("forward_pin", _forward_pin);

--- a/FluidNC/src/Spindles/BESCSpindle.h
+++ b/FluidNC/src/Spindles/BESCSpindle.h
@@ -56,7 +56,7 @@ namespace Spindles {
         void set_output(uint32_t duty) override;
 
         // Configuration handlers:
-        void validate() const override { PWM::validate(); }
+        void validate() override { PWM::validate(); }
 
         void group(Configuration::HandlerBase& handler) override {
             PWM::group(handler);

--- a/FluidNC/src/Spindles/HBridgeSpindle.h
+++ b/FluidNC/src/Spindles/HBridgeSpindle.h
@@ -47,7 +47,7 @@ namespace Spindles {
         void setState(SpindleState state, SpindleSpeed speed) override;
         void config_message() override;
         // Configuration handlers:
-        void validate() const override { Spindle::validate(); }
+        void validate() override { Spindle::validate(); }
 
         void group(Configuration::HandlerBase& handler) override {
             // The APB clock frequency is 80MHz and the maximum divisor

--- a/FluidNC/src/Spindles/OnOffSpindle.h
+++ b/FluidNC/src/Spindles/OnOffSpindle.h
@@ -46,7 +46,7 @@ namespace Spindles {
         virtual void set_enable(bool enable);
 
         // Configuration handlers:
-        void validate() const override { Spindle::validate(); }
+        void validate() override { Spindle::validate(); }
 
         void group(Configuration::HandlerBase& handler) override {
             handler.item("direction_pin", _direction_pin);

--- a/FluidNC/src/Spindles/PWMSpindle.h
+++ b/FluidNC/src/Spindles/PWMSpindle.h
@@ -33,7 +33,7 @@ namespace Spindles {
         void setState(SpindleState state, SpindleSpeed speed) override;
         void config_message() override;
         // Configuration handlers:
-        void validate() const override { Spindle::validate(); }
+        void validate() override { Spindle::validate(); }
 
         void group(Configuration::HandlerBase& handler) override {
             // The APB clock frequency is 80MHz and the maximum divisor

--- a/FluidNC/src/Spindles/Spindle.h
+++ b/FluidNC/src/Spindles/Spindle.h
@@ -73,7 +73,7 @@ namespace Spindles {
         virtual const char* name() const = 0;
 
         // Configuration handlers:
-        void validate() const override {
+        void validate() override {
             // TODO: Validate spinup/spindown delay?
         }
 

--- a/FluidNC/src/Spindles/VFDSpindle.h
+++ b/FluidNC/src/Spindles/VFDSpindle.h
@@ -94,7 +94,7 @@ namespace Spindles {
         SpindleSpeed      _slop;
 
         // Configuration handlers:
-        void validate() const override {
+        void validate() override {
             Spindle::validate();
             Assert(_uart != nullptr || _uart_num != -1, "VFD: missing UART configuration");
             Assert(!(_uart != nullptr && _uart_num != -1), "VFD: conflicting UART configuration");

--- a/FluidNC/src/Uart.h
+++ b/FluidNC/src/Uart.h
@@ -74,7 +74,7 @@ public:
     bool setHalfDuplex();
 
     // Configuration handlers:
-    void validate() const override {
+    void validate() override {
         Assert(!_txd_pin.undefined(), "UART: TXD is undefined");
         Assert(!_rxd_pin.undefined(), "UART: RXD is undefined");
         // RTS and CTS are optional.


### PR DESCRIPTION
Separate PR which is trivial and only hold removal of const.

This was discussed in here. #829 