### PR TITLE
Example configs UART update

### DIFF
--- a/example_configs/TMC2209_corexy.yaml
+++ b/example_configs/TMC2209_corexy.yaml
@@ -1,5 +1,7 @@
 board: TMC2209 4X
 name: TMC2209 XYZA
+meta: "update for 3.6.8"
+
 stepping:
   engine: RMT
   idle_ms: 255
@@ -9,6 +11,14 @@ stepping:
 
 kinematics:
   corexy:
+  
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+  baud: 115200
+  mode: 8N1
 
 axes:
   shared_stepper_disable_pin: gpio.25:high
@@ -32,11 +42,7 @@ axes:
       hard_limits: false
       pulloff_mm: 2.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          baud: 115200
-          mode: 8N1
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -76,6 +82,7 @@ axes:
       hard_limits: false
       pulloff_mm: 2.00
       tmc_2209:
+        uart_num: 1
         addr: 1
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -114,6 +121,7 @@ axes:
       hard_limits: false
       pulloff_mm: 4.00
       tmc_2209:
+        uart_num: 1
         addr: 2
         r_sense_ohms: 0.110
         run_amps: 0.500

--- a/example_configs/TMC2209_pen.yaml
+++ b/example_configs/TMC2209_pen.yaml
@@ -1,11 +1,21 @@
 board: TMC2209 Pen
 name: TMC2209 Pen
+meta: "update for 3.6.8"
+
 stepping:
   engine: RMT
   idle_ms: 250
   pulse_us: 2
   dir_delay_us: 1
   disable_delay_us: 0
+  
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+  baud: 115200
+  mode: 8N1
 
 axes:
   shared_stepper_disable_pin: gpio.13
@@ -32,14 +42,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          rts_pin: NO_PIN
-          cts_pin: NO_PIN
-          baud: 115200
-          mode: 8N1
-
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -88,6 +91,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
+        uart_num: 1
         addr: 1
         r_sense_ohms: 0.110
         run_amps: 0.500

--- a/example_configs/TMC2209_pen_SG.yaml
+++ b/example_configs/TMC2209_pen_SG.yaml
@@ -1,11 +1,21 @@
 board: TMC2209 Pen
 name: TMC2209 Pen
+meta: "update for 3.6.8"
+
 stepping:
   engine: RMT
   idle_ms: 250
   pulse_us: 2
   dir_delay_us: 1
   disable_delay_us: 0
+  
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+  baud: 115200
+  mode: 8N1
 
 axes:
   shared_stepper_disable_pin: gpio.13
@@ -32,14 +42,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          rts_pin: NO_PIN
-          cts_pin: NO_PIN
-          baud: 115200
-          mode: 8N1
-
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 1.00
@@ -88,6 +91,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
+        uart_num: 1
         addr: 1
         r_sense_ohms: 0.110
         run_amps: 0.500

--- a/example_configs/tmc2209_10V.yaml
+++ b/example_configs/tmc2209_10V.yaml
@@ -1,5 +1,6 @@
 name: "ESP32 Dev Controller V4"
 board: "ESP32 Dev Controller V4"
+meta: "update for 3.6.8"
 
 stepping:
   engine: RMT
@@ -7,6 +8,14 @@ stepping:
   dir_delay_us: 1
   pulse_us: 2
   disable_delay_us: 0
+  
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+  baud: 115200
+  mode: 8N1
 
 axes:
   shared_stepper_disable_pin: gpio.25:high
@@ -29,11 +38,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          baud: 115200
-          mode: 8N1
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -73,11 +78,12 @@ axes:
       limit_pos_pin: gpio.34
       limit_all_pin: NO_PIN
       hard_limits: false
-      pulloff_mm:1.00
+      pulloff_mm: 1.00
       tmc_2209:
         step_pin: gpio.33
         direction_pin: gpio.32
         microsteps: 16
+        uart_num: 1
         addr: 1
 
     motor1:
@@ -102,10 +108,11 @@ axes:
       limit_pos_pin: gpio.39
       limit_all_pin: NO_PIN
       hard_limits: false
-      pulloff_mm:1.00
+      pulloff_mm: 1.00
       tmc_2209:
         step_pin: gpio.2
         direction_pin: gpio.14
+        uart_num: 1
         addr: 2
 
     motor1:
@@ -131,10 +138,11 @@ axes:
       limit_pos_pin: gpio.36
       limit_all_pin: NO_PIN
       hard_limits: false
-      pulloff_mm:1.00
+      pulloff_mm: 1.00
       tmc_2209:
         step_pin: gpio.16
         direction_pin: gpio.15
+        uart_num: 1
         addr: 3
 
     motor1:

--- a/example_configs/tmc2209_BESC.yaml
+++ b/example_configs/tmc2209_BESC.yaml
@@ -1,5 +1,6 @@
 name: "ESP32 Dev Controller V4"
 board: "ESP32 Dev Controller V4"
+meta: "update for 3.6.8"
 
 stepping:
   engine: RMT
@@ -7,6 +8,14 @@ stepping:
   dir_delay_us: 1
   pulse_us: 2
   disable_delay_us: 0
+  
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+  baud: 115200
+  mode: 8N1
 
 axes:
   shared_stepper_disable_pin: gpio.25:high
@@ -29,11 +38,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          baud: 115200
-          mode: 8N1
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -73,11 +78,12 @@ axes:
       limit_pos_pin: gpio.34
       limit_all_pin: NO_PIN
       hard_limits: false
-      pulloff_mm:1.00
+      pulloff_mm: 1.00
       tmc_2209:
         step_pin: gpio.33
         direction_pin: gpio.32
         microsteps: 16
+        uart_num: 1
         addr: 1
 
     motor1:
@@ -102,10 +108,11 @@ axes:
       limit_pos_pin: gpio.39
       limit_all_pin: NO_PIN
       hard_limits: false
-      pulloff_mm:1.00
+      pulloff_mm: 1.00
       tmc_2209:
         step_pin: gpio.2
         direction_pin: gpio.14
+        uart_num: 1
         addr: 2
 
     motor1:
@@ -131,10 +138,11 @@ axes:
       limit_pos_pin: gpio.36
       limit_all_pin: NO_PIN
       hard_limits: false
-      pulloff_mm:1.00
+      pulloff_mm: 1.00
       tmc_2209:
         step_pin: gpio.16
         direction_pin: gpio.15
+        uart_num: 1
         addr: 3
 
     motor1:

--- a/example_configs/tmc2209_huanyang.yml
+++ b/example_configs/tmc2209_huanyang.yml
@@ -1,5 +1,6 @@
 name: "TMC2209 XYZA PWM Spindle"
 board: "TMC2209 4x"
+meta: "update for 3.6.8"
 
 stepping:
   engine: RMT
@@ -9,6 +10,14 @@ stepping:
   disable_delay_us: 0
 
 homing_init_lock: true
+
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+  baud: 115200
+  mode: 8N1
 
 axes:
   shared_stepper_disable_pin: gpio.25:high

--- a/example_configs/tmc2209_laser.yaml
+++ b/example_configs/tmc2209_laser.yaml
@@ -1,5 +1,6 @@
 name: "TMC2209 XYYZ Laser"
 board: "TMC2209 4x DK"
+meta: "update for 3.6.8"
 
 stepping:
   engine: RMT
@@ -7,6 +8,14 @@ stepping:
   dir_delay_us: 1
   pulse_us: 2
   disable_delay_us: 0
+  
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+  baud: 115200
+  mode: 8N1
 
 axes:
   shared_stepper_disable_pin: gpio.25:high
@@ -34,14 +43,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          rts_pin: NO_PIN
-          cts_pin: NO_PIN
-          baud: 115200
-          mode: 8N1
-
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 1.200
@@ -90,6 +92,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
+        uart_num: 1
         addr: 1
         r_sense_ohms: 0.110
         run_amps: 1.200
@@ -138,6 +141,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
+        uart_num: 1
         addr: 2
         r_sense_ohms: 0.110
         run_amps: 1.200
@@ -186,6 +190,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
+        uart_num: 1
         addr: 3
         r_sense_ohms: 0.110
         run_amps: 1.200

--- a/example_configs/tmc2209_relay.yaml
+++ b/example_configs/tmc2209_relay.yaml
@@ -1,5 +1,6 @@
 name: "TMC2209 XYYZ Laser"
 board: "TMC2209 4x DK"
+meta: "update for 3.6.8"
 
 stepping:
   engine: RMT
@@ -7,6 +8,14 @@ stepping:
   dir_delay_us: 1
   pulse_us: 2
   disable_delay_us: 0
+  
+  uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+  baud: 115200
+  mode: 8N1
 
 axes:
   shared_stepper_disable_pin: gpio.25:high
@@ -29,11 +38,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          baud: 115200
-          mode: 8N1
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -73,11 +78,12 @@ axes:
       limit_pos_pin: gpio.34
       limit_all_pin: NO_PIN
       hard_limits: false
-      pulloff_mm:1.00
+      pulloff_mm: 1.00
       tmc_2209:
         step_pin: gpio.33
         direction_pin: gpio.32
         microsteps: 16
+        uart_num: 1
         addr: 1
 
     motor1:
@@ -102,10 +108,11 @@ axes:
       limit_pos_pin: gpio.39
       limit_all_pin: NO_PIN
       hard_limits: false
-      pulloff_mm:1.00
+      pulloff_mm: 1.00
       tmc_2209:
         step_pin: gpio.2
         direction_pin: gpio.14
+        uart_num: 1
         addr: 2
 
     motor1:
@@ -131,7 +138,7 @@ axes:
       limit_pos_pin: gpio.36
       limit_all_pin: NO_PIN
       hard_limits: false
-      pulloff_mm:1.00
+      pulloff_mm: 1.00
       tmc_2209:
         step_pin: gpio.16
         direction_pin: gpio.15


### PR DESCRIPTION
Examples TMC2209 configs were not using the new UART definition method