### PR TITLE
Fix timer_ms setting in object derived from Servo.

### DIFF
--- a/FluidNC/src/Motors/Dynamixel2.h
+++ b/FluidNC/src/Motors/Dynamixel2.h
@@ -114,10 +114,10 @@ namespace MotorDrivers {
         void group(Configuration::HandlerBase& handler) override {
             handler.item("uart_num", _uart_num);
             handler.item("id", _id);
-
             handler.item("count_min", _countMin);
             handler.item("count_max", _countMax);
-            handler.item("timer_ms", _timer_ms);
+
+            Servo::group(handler);
         }
 
         // Name of the configurable. Must match the name registered in the cpp file.

--- a/FluidNC/src/Motors/RcServo.h
+++ b/FluidNC/src/Motors/RcServo.h
@@ -54,6 +54,8 @@ namespace MotorDrivers {
             handler.item("pwm_hz", _pwm_freq, SERVO_PWM_FREQ_MIN, SERVO_PWM_FREQ_MAX);
             handler.item("min_pulse_us", _min_pulse_us, SERVO_PULSE_US_MIN, SERVO_PULSE_US_MAX);
             handler.item("max_pulse_us", _max_pulse_us, SERVO_PULSE_US_MIN, SERVO_PULSE_US_MAX);
+
+            Servo::group(handler);
         }
 
         // Name of the configurable. Must match the name registered in the cpp file.


### PR DESCRIPTION
The Servo `group()` function needs to be called in overridden functions to get the timer_ms setting.