### PR TITLE
Add timer_ms config option

### DIFF
--- a/FluidNC/src/Motors/RcServo.h
+++ b/FluidNC/src/Motors/RcServo.h
@@ -30,6 +30,8 @@ namespace MotorDrivers {
         int _axis_index = -1;
 
         bool _has_errors = false;
+        
+        int _timer_ms = 75;
 
     public:
         RcServo() = default;
@@ -54,6 +56,7 @@ namespace MotorDrivers {
             handler.item("pwm_hz", _pwm_freq, SERVO_PWM_FREQ_MIN, SERVO_PWM_FREQ_MAX);
             handler.item("min_pulse_us", _min_pulse_us, SERVO_PULSE_US_MIN, SERVO_PULSE_US_MAX);
             handler.item("max_pulse_us", _max_pulse_us, SERVO_PULSE_US_MIN, SERVO_PULSE_US_MAX);
+            handler.item("timer_ms", _timer_ms);
         }
 
         // Name of the configurable. Must match the name registered in the cpp file.


### PR DESCRIPTION
When using fast servos, the default timer update frequency of 75ms results in rough motion.

Adding the timer_ms config option allows a user to define how often the PWM signal is updated.