### PR TITLE
align tmc2209 examples to the new uart format

### DIFF
--- a/example_configs/TMC2209_corexy.yaml
+++ b/example_configs/TMC2209_corexy.yaml
@@ -10,6 +10,12 @@ stepping:
 kinematics:
   corexy:
 
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  baud: 115200
+  mode: 8N1
+
 axes:
   shared_stepper_disable_pin: gpio.25:high
   
@@ -32,11 +38,7 @@ axes:
       hard_limits: false
       pulloff_mm: 2.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          baud: 115200
-          mode: 8N1
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -76,6 +78,7 @@ axes:
       hard_limits: false
       pulloff_mm: 2.00
       tmc_2209:
+        uart_num: 1
         addr: 1
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -114,6 +117,7 @@ axes:
       hard_limits: false
       pulloff_mm: 4.00
       tmc_2209:
+        uart_num: 1
         addr: 2
         r_sense_ohms: 0.110
         run_amps: 0.500

--- a/example_configs/TMC2209_pen.yaml
+++ b/example_configs/TMC2209_pen.yaml
@@ -7,6 +7,14 @@ stepping:
   dir_delay_us: 1
   disable_delay_us: 0
 
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+  baud: 115200
+  mode: 8N1
+
 axes:
   shared_stepper_disable_pin: gpio.13
   x:
@@ -32,14 +40,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          rts_pin: NO_PIN
-          cts_pin: NO_PIN
-          baud: 115200
-          mode: 8N1
-
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -88,6 +89,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
+        uart_num: 1
         addr: 1
         r_sense_ohms: 0.110
         run_amps: 0.500

--- a/example_configs/TMC2209_pen_SG.yaml
+++ b/example_configs/TMC2209_pen_SG.yaml
@@ -7,6 +7,14 @@ stepping:
   dir_delay_us: 1
   disable_delay_us: 0
 
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  baud: 115200
+  mode: 8N1
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+
 axes:
   shared_stepper_disable_pin: gpio.13
   x:
@@ -32,14 +40,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          rts_pin: NO_PIN
-          cts_pin: NO_PIN
-          baud: 115200
-          mode: 8N1
-
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 1.00
@@ -88,6 +89,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
+        uart_num: 1
         addr: 1
         r_sense_ohms: 0.110
         run_amps: 0.500

--- a/example_configs/tmc2209_10V.yaml
+++ b/example_configs/tmc2209_10V.yaml
@@ -8,6 +8,12 @@ stepping:
   pulse_us: 2
   disable_delay_us: 0
 
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  baud: 115200
+  mode: 8N1
+
 axes:
   shared_stepper_disable_pin: gpio.25:high
   
@@ -29,11 +35,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          baud: 115200
-          mode: 8N1
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -78,6 +80,7 @@ axes:
         step_pin: gpio.33
         direction_pin: gpio.32
         microsteps: 16
+        uart_num: 1
         addr: 1
 
     motor1:
@@ -106,6 +109,7 @@ axes:
       tmc_2209:
         step_pin: gpio.2
         direction_pin: gpio.14
+        uart_num: 1
         addr: 2
 
     motor1:
@@ -135,6 +139,7 @@ axes:
       tmc_2209:
         step_pin: gpio.16
         direction_pin: gpio.15
+        uart_num: 1
         addr: 3
 
     motor1:

--- a/example_configs/tmc2209_BESC.yaml
+++ b/example_configs/tmc2209_BESC.yaml
@@ -8,6 +8,12 @@ stepping:
   pulse_us: 2
   disable_delay_us: 0
 
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  baud: 115200
+  mode: 8N1
+
 axes:
   shared_stepper_disable_pin: gpio.25:high
   
@@ -29,11 +35,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          baud: 115200
-          mode: 8N1
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -78,6 +80,7 @@ axes:
         step_pin: gpio.33
         direction_pin: gpio.32
         microsteps: 16
+        uart_num: 1
         addr: 1
 
     motor1:
@@ -106,6 +109,7 @@ axes:
       tmc_2209:
         step_pin: gpio.2
         direction_pin: gpio.14
+        uart_num: 1
         addr: 2
 
     motor1:
@@ -135,6 +139,7 @@ axes:
       tmc_2209:
         step_pin: gpio.16
         direction_pin: gpio.15
+        uart_num: 1
         addr: 3
 
     motor1:

--- a/example_configs/tmc2209_huanyang.yml
+++ b/example_configs/tmc2209_huanyang.yml
@@ -8,6 +8,12 @@ stepping:
   pulse_us: 2
   disable_delay_us: 0
 
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  baud: 115200
+  mode: 8N1
+
 homing_init_lock: true
 
 axes:
@@ -31,11 +37,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          baud: 115200
-          mode: 8N1
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -107,6 +109,7 @@ axes:
       tmc_2209:
         step_pin: gpio.2
         direction_pin: gpio.14
+        uart_num: 1
         addr: 2
 
     motor1:
@@ -136,6 +139,7 @@ axes:
       tmc_2209:
         step_pin: gpio.16
         direction_pin: gpio.15
+        uart_num: 1
         addr: 3
 
     motor1:

--- a/example_configs/tmc2209_laser.yaml
+++ b/example_configs/tmc2209_laser.yaml
@@ -8,6 +8,12 @@ stepping:
   pulse_us: 2
   disable_delay_us: 0
 
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  baud: 115200
+  mode: 8N1
+
 axes:
   shared_stepper_disable_pin: gpio.25:high
   
@@ -34,14 +40,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          rts_pin: NO_PIN
-          cts_pin: NO_PIN
-          baud: 115200
-          mode: 8N1
-
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 1.200
@@ -90,6 +89,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
+        uart_num: 1
         addr: 1
         r_sense_ohms: 0.110
         run_amps: 1.200
@@ -138,6 +138,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
+        uart_num: 1
         addr: 2
         r_sense_ohms: 0.110
         run_amps: 1.200
@@ -186,6 +187,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
+        uart_num: 1
         addr: 3
         r_sense_ohms: 0.110
         run_amps: 1.200

--- a/example_configs/tmc2209_relay.yaml
+++ b/example_configs/tmc2209_relay.yaml
@@ -8,6 +8,12 @@ stepping:
   pulse_us: 2
   disable_delay_us: 0
 
+uart1:
+  txd_pin: gpio.22
+  rxd_pin: gpio.21
+  baud: 115200
+  mode: 8N1
+
 axes:
   shared_stepper_disable_pin: gpio.25:high
   
@@ -29,11 +35,7 @@ axes:
       hard_limits: false
       pulloff_mm: 1.000
       tmc_2209:
-        uart:
-          txd_pin: gpio.22
-          rxd_pin: gpio.21
-          baud: 115200
-          mode: 8N1
+        uart_num: 1
         addr: 0
         r_sense_ohms: 0.110
         run_amps: 0.500
@@ -78,6 +80,7 @@ axes:
         step_pin: gpio.33
         direction_pin: gpio.32
         microsteps: 16
+        uart_num: 1
         addr: 1
 
     motor1:
@@ -106,6 +109,7 @@ axes:
       tmc_2209:
         step_pin: gpio.2
         direction_pin: gpio.14
+        uart_num: 1
         addr: 2
 
     motor1:
@@ -135,6 +139,7 @@ axes:
       tmc_2209:
         step_pin: gpio.16
         direction_pin: gpio.15
+        uart_num: 1
         addr: 3
 
     motor1:


### PR DESCRIPTION
This PR to update the various TMC2209 examples to the new format with separate uart section instead of uar section inside the TMC element


Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>