### PR TITLE
Fix #825 - incorrect output from analog outputs

### DIFF
--- a/FluidNC/src/Machine/UserOutputs.cpp
+++ b/FluidNC/src/Machine/UserOutputs.cpp
@@ -61,13 +61,13 @@ namespace Machine {
             return percent == 0.0;
         }
 
-        uint32_t duty = uint32_t(percent / 100.0f * _denominator[io_num]);
-
         auto pwm = _pwm[io_num];
         if (!pwm) {
             log_error("M67 PWM channel error");
             return false;
         }
+
+        uint32_t duty = uint32_t(percent * pwm->period() / 100.0f);
 
         if (_current_value[io_num] == duty) {
             return true;

--- a/FluidNC/src/Machine/UserOutputs.h
+++ b/FluidNC/src/Machine/UserOutputs.h
@@ -12,7 +12,6 @@ namespace Machine {
     class UserOutputs : public Configuration::Configurable {
         PwmPin*  _pwm[MaxUserAnalogPin];
         uint32_t _current_value[MaxUserAnalogPin];
-        uint32_t _denominator[MaxUserAnalogPin];
 
     public:
         UserOutputs();


### PR DESCRIPTION
The UserOutputs code used a _denominator[] array that was not initialized.  It should have used pwm->period() as the denominator.