### PR TITLE
Fix #782 - auto-report websocket stalls when wifi goes down

### DIFF
--- a/FluidNC/src/WebUI/WSChannel.cpp
+++ b/FluidNC/src/WebUI/WSChannel.cpp
@@ -8,11 +8,18 @@
 #    include <WebSocketsServer.h>
 #    include <WiFi.h>
 
+#    include "../Serial.h"  // is_realtime_command
+
 namespace WebUI {
+    class WSChannels;
+
     WSChannel::WSChannel(WebSocketsServer* server, uint8_t clientNum) :
         Channel("websocket"), _server(server), _clientNum(clientNum), _TXbufferSize(0), _RXbufferSize(0), _RXbufferpos(0) {}
 
     int WSChannel::read() {
+        if (_dead) {
+            return -1;
+        }
         if (_rtchar == -1) {
             return -1;
         } else {
@@ -27,7 +34,7 @@ namespace WebUI {
     size_t WSChannel::write(uint8_t c) { return write(&c, 1); }
 
     size_t WSChannel::write(const uint8_t* buffer, size_t size) {
-        if (buffer == NULL) {
+        if (buffer == NULL || _dead) {
             return 0;
         }
 
@@ -49,6 +56,9 @@ namespace WebUI {
     void WSChannel::pushRT(char ch) { _rtchar = ch; }
 
     bool WSChannel::push(const uint8_t* data, size_t length) {
+        if (_dead) {
+            return false;
+        }
         char c;
         while ((c = *data++) != '\0') {
             _queue.push(c);
@@ -59,14 +69,33 @@ namespace WebUI {
     bool WSChannel::push(std::string& s) { return push((uint8_t*)s.c_str(), s.length()); }
 
     void WSChannel::handle() {
+        if (_dead) {
+            return;
+        }
         if (_TXbufferSize > 0 && ((_TXbufferSize >= TXBUFFERSIZE) || ((millis() - _lastflush) > FLUSHTIMEOUT))) {
             flush();
         }
     }
-    size_t WSChannel::sendTXT(std::string& s) { return _server->sendTXT(_clientNum, s.c_str()); }
-    void   WSChannel::flush(void) {
+    bool WSChannel::sendTXT(std::string& s) {
+        if (_dead) {
+            return false;
+        }
+        if (!_server->sendTXT(_clientNum, s.c_str())) {
+            _dead = true;
+            WSChannels::removeChannel(this);
+            return false;
+        }
+        return true;
+    }
+    void WSChannel::flush(void) {
         if (_TXbufferSize > 0) {
-            _server->sendBIN(_clientNum, _TXbuffer, _TXbufferSize);
+            if (_dead) {
+                return;
+            }
+            if (!_server->sendBIN(_clientNum, _TXbuffer, _TXbufferSize)) {
+                _dead = true;
+                WSChannels::removeChannel(this);
+            }
 
             //refresh timout
             _lastflush = millis();
@@ -77,5 +106,143 @@ namespace WebUI {
     }
 
     WSChannel::~WSChannel() {}
+
+    std::map<uint8_t, WSChannel*> WSChannels::_wsChannels;
+    std::list<WSChannel*>         WSChannels::_webWsChannels;
+
+    WSChannel* WSChannels::_lastWSChannel = nullptr;
+
+    WSChannel* WSChannels::getWSChannel(int pageid) {
+        WSChannel* wsChannel = nullptr;
+        if (pageid != -1) {
+            try {
+                wsChannel = _wsChannels.at(pageid);
+            } catch (std::out_of_range& oor) {}
+        } else {
+            // If there is no PAGEID URL argument, it is an old version of WebUI
+            // that does not supply PAGEID in all cases.  In that case, we use
+            // the most recently used websocket if it is still in the list.
+            for (auto it = _wsChannels.begin(); it != _wsChannels.end(); ++it) {
+                if (it->second == _lastWSChannel) {
+                    wsChannel = _lastWSChannel;
+                    break;
+                }
+            }
+        }
+        _lastWSChannel = wsChannel;
+        return wsChannel;
+    }
+
+    void WSChannels::removeChannel(uint8_t num) {
+        try {
+            WSChannel* wsChannel = _wsChannels.at(num);
+            _webWsChannels.remove(wsChannel);
+            allChannels.kill(wsChannel);
+            _wsChannels.erase(num);
+        } catch (std::out_of_range& oor) {}
+    }
+
+    void WSChannels::removeChannel(WSChannel* channel) {
+        _lastWSChannel = nullptr;
+        _webWsChannels.remove(channel);
+        allChannels.kill(channel);
+        for (auto it = _wsChannels.cbegin(); it != _wsChannels.cend();) {
+            if (it->second == channel) {
+                it = _wsChannels.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    bool WSChannels::runGCode(int pageid, std::string cmd) {
+        bool has_error = false;
+
+        WSChannel* wsChannel = getWSChannel(pageid);
+        if (wsChannel) {
+            // It is very tempting to let wsChannel->push() handle the realtime
+            // character sequences so we don't have to do it here.  That does not work
+            // because we need to know whether to add a newline.  We should not add newline
+            // on a realtime sequence, but we must add one (if not already present)
+            // on a text command.
+            if (cmd.length() == 3 && cmd[0] == 0xc2 && is_realtime_command(cmd[1]) && cmd[2] == '\0') {
+                // Handles old WebUIs that send a null after high-bit-set realtime chars
+                wsChannel->pushRT(cmd[1]);
+            } else if (cmd.length() == 2 && cmd[0] == 0xc2 && is_realtime_command(cmd[1])) {
+                // Handles old WebUIs that send a null after high-bit-set realtime chars
+                wsChannel->pushRT(cmd[1]);
+            } else if (cmd.length() == 1 && is_realtime_command(cmd[0])) {
+                wsChannel->pushRT(cmd[0]);
+            } else {
+                if (cmd.length() && cmd[cmd.length() - 1] != '\n') {
+                    cmd += '\n';
+                }
+                has_error = !wsChannel->push(cmd);
+            }
+        } else {
+            has_error = true;
+        }
+        return has_error;
+    }
+
+    bool WSChannels::sendError(int pageid, std::string err) {
+        WSChannel* wsChannel = getWSChannel(pageid);
+        if (wsChannel) {
+            return !wsChannel->sendTXT(err);
+        }
+        return true;
+    }
+    void WSChannels::sendPing() {
+        for (WSChannel* wsChannel : _webWsChannels) {
+            std::string s("PING:");
+            s += wsChannel->id();
+            // sendBIN would be okay too because the string contains only
+            // ASCII characters, no UTF-8 extended characters.
+            wsChannel->sendTXT(s);
+        }
+    }
+
+    void WSChannels::handleEvent(WebSocketsServer* server, uint8_t num, uint8_t type, uint8_t* payload, size_t length) {
+        switch (type) {
+            case WStype_DISCONNECTED:
+                log_debug("WebSocket disconnect " << num);
+                WSChannels::removeChannel(num);
+                break;
+            case WStype_CONNECTED: {
+                WSChannel* wsChannel = new WSChannel(server, num);
+                if (!wsChannel) {
+                    log_error("Creating WebSocket channel failed");
+                } else {
+                    std::string uri((char*)payload, length);
+
+                    IPAddress ip = server->remoteIP(num);
+                    log_debug("WebSocket " << num << " from " << ip << " uri " << uri);
+
+                    _lastWSChannel = wsChannel;
+                    allChannels.registration(wsChannel);
+                    _wsChannels[num] = wsChannel;
+
+                    if (uri == "/") {
+                        std::string s("CURRENT_ID:");
+                        s += std::to_string(num);
+                        // send message to client
+                        _webWsChannels.push_front(wsChannel);
+                        wsChannel->sendTXT(s);
+                        s = "ACTIVE_ID:";
+                        s += std::to_string(wsChannel->id());
+                        wsChannel->sendTXT(s);
+                    }
+                }
+            } break;
+            case WStype_TEXT:
+            case WStype_BIN:
+                try {
+                    _wsChannels.at(num)->push(payload, length);
+                } catch (std::out_of_range& oor) {}
+                break;
+            default:
+                break;
+        }
+    }
 }
 #endif

--- a/FluidNC/src/WebUI/WSChannel.cpp
+++ b/FluidNC/src/WebUI/WSChannel.cpp
@@ -82,6 +82,7 @@ namespace WebUI {
         }
         if (!_server->sendTXT(_clientNum, s.c_str())) {
             _dead = true;
+            log_debug("WebSocket is unresponsive; closing");
             WSChannels::removeChannel(this);
             return false;
         }
@@ -94,6 +95,7 @@ namespace WebUI {
             }
             if (!_server->sendBIN(_clientNum, _TXbuffer, _TXbufferSize)) {
                 _dead = true;
+                log_debug("WebSocket is unresponsive; closing");
                 WSChannels::removeChannel(this);
             }
 

--- a/FluidNC/src/WebUI/WSChannel.h
+++ b/FluidNC/src/WebUI/WSChannel.h
@@ -7,6 +7,8 @@
 
 #include <cstdint>
 #include <cstring>
+#include <list>
+#include <map>
 
 class WebSocketsServer;
 
@@ -37,7 +39,7 @@ namespace WebUI {
         size_t write(uint8_t c);
         size_t write(const uint8_t* buffer, size_t size);
 
-        size_t sendTXT(std::string& s);
+        bool sendTXT(std::string& s);
 
         inline size_t write(const char* s) { return write((uint8_t*)s, ::strlen(s)); }
         inline size_t write(unsigned long n) { return write((uint8_t)n); }
@@ -45,8 +47,6 @@ namespace WebUI {
         inline size_t write(unsigned int n) { return write((uint8_t)n); }
         inline size_t write(int n) { return write((uint8_t)n); }
 
-        //        void begin(long speed);
-        //        void end();
         void handle();
 
         bool push(const uint8_t* data, size_t length);
@@ -67,6 +67,8 @@ namespace WebUI {
         int available() override { return _rtchar == -1 ? 0 : 1; }
 
     private:
+        bool _dead = false;
+
         uint32_t          _lastflush;
         WebSocketsServer* _server;
         uint8_t           _clientNum;
@@ -82,6 +84,24 @@ namespace WebUI {
         // so they can be processed immediately during operations like
         // homing where GCode handling is blocked.
         int _rtchar = -1;
+    };
+
+    class WSChannels {
+    private:
+        static std::map<uint8_t, WSChannel*> _wsChannels;
+        static std::list<WSChannel*>         _webWsChannels;
+
+        static WSChannel* _lastWSChannel;
+        static WSChannel* getWSChannel(int pageid);
+
+    public:
+        static void removeChannel(WSChannel* channel);
+        static void removeChannel(uint8_t num);
+
+        static bool runGCode(int pageid, std::string cmd);
+        static bool sendError(int pageid, std::string error);
+        static void sendPing();
+        static void handleEvent(WebSocketsServer* server, uint8_t num, uint8_t type, uint8_t* payload, size_t length);
     };
 }
 

--- a/FluidNC/src/WebUI/WebServer.cpp
+++ b/FluidNC/src/WebUI/WebServer.cpp
@@ -25,14 +25,14 @@
 #    include <DNSServer.h>
 #    include "WebSettings.h"
 
+#    include "WSChannel.h"
+
 #    include "WebClient.h"
 
 #    include "src/Protocol.h"  // protocol_send_event
 #    include "src/FluidPath.h"
 #    include "src/WebUI/JSONEncoder.h"
 #    include "Driver/localfs.h"
-
-#    include <list>
 
 namespace WebUI {
     const byte DNS_PORT = 53;
@@ -56,9 +56,6 @@ namespace WebUI {
     const int ESP_ERROR_FILE_CLOSE       = 7;
 
     static const char LOCATION_HEADER[] = "Location";
-
-    static std::map<uint8_t, WSChannel*> wsChannels;
-    static std::list<WSChannel*>         webWsChannels;
 
     Web_Server webServer;
     bool       Web_Server::_setupdone = false;
@@ -90,27 +87,6 @@ namespace WebUI {
                                                    NULL);
     }
     Web_Server::~Web_Server() { end(); }
-
-    WSChannel* Web_Server::lastWSChannel = nullptr;
-    WSChannel* Web_Server::getWSChannel() {
-        WSChannel* wsChannel = nullptr;
-        if (_webserver->hasArg("PAGEID")) {
-            int wsId  = _webserver->arg("PAGEID").toInt();
-            wsChannel = wsChannels.at(wsId);
-        } else {
-            // If there is no PAGEID URL argument, it is an old version of WebUI
-            // that does not supply PAGEID in all cases.  In that case, we use
-            // the most recently used websocket if it is still in the list.
-            for (auto it = wsChannels.begin(); it != wsChannels.end(); ++it) {
-                if (it->second == lastWSChannel) {
-                    wsChannel = lastWSChannel;
-                    break;
-                }
-            }
-        }
-        lastWSChannel = wsChannel;
-        return wsChannel;
-    }
 
     bool Web_Server::begin() {
         bool no_error = true;
@@ -406,6 +382,14 @@ namespace WebUI {
         _webserver->send(200, "text/xml", sschema);
     }
 
+    // WebUI sends a PAGEID arg to identify the websocket it is using
+    int Web_Server::getPageid() {
+        if (_webserver->hasArg("PAGEID")) {
+            return _webserver->arg("PAGEID").toInt();
+        }
+        return -1;
+    }
+
     void Web_Server::_handle_web_command(bool silent) {
         AuthenticationLevel auth_level = is_authenticated();
         std::string         cmd;
@@ -452,31 +436,7 @@ namespace WebUI {
                 _webserver->send(401, "text/plain", "Authentication failed\n");
                 return;
             }
-            bool hasError = false;
-            try {
-                WSChannel* wsChannel = getWSChannel();
-                if (wsChannel) {
-                    // It is very tempting to let Serial_2_Socket.push() handle the realtime
-                    // character sequences so we don't have to do it here.  That does not work
-                    // because we need to know whether to add a newline.  We should not add one
-                    // on a realtime sequence, but we must add one (if not already present)
-                    // on a text command.
-                    if (cmd.length() == 3 && cmd[0] == 0xc2 && is_realtime_command(cmd[1]) && cmd[2] == '\0') {
-                        // Handles old WebUIs that send a null after high-bit-set realtime chars
-                        wsChannel->pushRT(cmd[1]);
-                    } else if (cmd.length() == 2 && cmd[0] == 0xc2 && is_realtime_command(cmd[1])) {
-                        // Handles old WebUIs that send a null after high-bit-set realtime chars
-                        wsChannel->pushRT(cmd[1]);
-                    } else if (cmd.length() == 1 && is_realtime_command(cmd[0])) {
-                        wsChannel->pushRT(cmd[0]);
-                    } else {
-                        if (cmd.length() && cmd[cmd.length() - 1] != '\n') {
-                            cmd += '\n';
-                        }
-                        hasError = !wsChannel->push(cmd);
-                    }
-                }
-            } catch (std::out_of_range& oor) { hasError = true; }
+            bool hasError = WSChannels::runGCode(getPageid(), cmd);
 
             _webserver->send(200, "text/plain", hasError ? "Error" : "");
         }
@@ -671,12 +631,8 @@ namespace WebUI {
             s += std::to_string(code) + ":";
             s += st;
 
-            try {
-                WSChannel* wsChannel = getWSChannel();
-                if (wsChannel) {
-                    wsChannel->sendTXT(s);
-                }
-            } catch (std::out_of_range& oor) {}
+            WSChannels::sendError(getPageid(), st);
+
             if (web_error != 0 && _webserver && _webserver->client().available() > 0) {
                 _webserver->send(web_error, "text/xml", st);
             }
@@ -1115,63 +1071,13 @@ namespace WebUI {
             _socket_server->loop();
         }
         if ((millis() - start_time) > 10000 && _socket_server) {
-            for (WSChannel* wsChannel : webWsChannels) {
-                std::string s("PING:");
-                s += wsChannel->id();
-                wsChannel->sendTXT(s);
-            }
-
+            WSChannels::sendPing();
             start_time = millis();
         }
     }
 
     void Web_Server::handle_Websocket_Event(uint8_t num, uint8_t type, uint8_t* payload, size_t length) {
-        char data[length + 1];
-        memcpy(data, (char*)payload, length);
-        data[length] = '\0';
-
-        switch (type) {
-            case WStype_DISCONNECTED:
-                log_debug("WebSocket disconnect " << num);
-                try {
-                    WSChannel* wsChannel = wsChannels.at(num);
-                    webWsChannels.remove(wsChannel);
-                    allChannels.kill(wsChannel);
-                    wsChannels.erase(num);
-                } catch (std::out_of_range& oor) {}
-                break;
-            case WStype_CONNECTED: {
-                IPAddress  ip        = _socket_server->remoteIP(num);
-                WSChannel* wsChannel = new WSChannel(_socket_server, num);
-                if (!wsChannel) {
-                    log_error("Creating WebSocket channel failed");
-                } else {
-                    lastWSChannel = wsChannel;
-                    log_debug("WebSocket " << num << " from " << ip << " uri " << data);
-                    allChannels.registration(wsChannel);
-                    wsChannels[num] = wsChannel;
-
-                    if (strcmp(data, "/") == 0) {
-                        std::string s("CURRENT_ID:");
-                        s += std::to_string(num);
-                        // send message to client
-                        webWsChannels.push_front(wsChannel);
-                        wsChannel->sendTXT(s);
-                        s = "ACTIVE_ID:";
-                        s += std::to_string(wsChannel->id());
-                        wsChannel->sendTXT(s);
-                    }
-                }
-            } break;
-            case WStype_TEXT:
-            case WStype_BIN:
-                try {
-                    wsChannels.at(num)->push(payload, length);
-                } catch (std::out_of_range& oor) {}
-                break;
-            default:
-                break;
-        }
+        WSChannels::handleEvent(_socket_server, num, type, payload, length);
     }
 
     //Convert file extension to content type

--- a/FluidNC/src/WebUI/WebServer.h
+++ b/FluidNC/src/WebUI/WebServer.h
@@ -11,7 +11,6 @@
 #    include "../Settings.h"
 #    include "Authentication.h"  // AuthenticationLevel
 #    include "Commands.h"
-#    include "WSChannel.h"
 
 class WebSocketsServer;
 class WebServer;
@@ -115,8 +114,7 @@ namespace WebUI {
         static void sendCaptivePortal();
         static void send404Page();
 
-        static WSChannel* lastWSChannel;
-        static WSChannel* getWSChannel();
+        static int getPageid();
     };
 
     extern Web_Server webServer;


### PR DESCRIPTION
In the process, I moved a lot of websocket code from WebServer.cpp into WSChannel.cpp because WebSocket.cpp is too complex.

To test on Windows 11:
* Connect with FluidTerm and $report/interval=1000 - so you can see progress
* Connect with WebUI and run a file from SD
* Turn off Wifi on Windows, so the PC loses access to WiFi with the browser still running
* The FluidTerm progress reports should pause, then about 6 seconds later they will resume, when FluidNC notices that the websocket can no longer send data.  It will then close the websocket and the job will continue.