### PR TITLE
Remove leading and trailing blanks when parsing most config values

### DIFF
--- a/FluidNC/src/Configuration/Parser.cpp
+++ b/FluidNC/src/Configuration/Parser.cpp
@@ -38,7 +38,8 @@ namespace Configuration {
         return result;
     }
 
-    StringRange Parser::stringValue() const { return StringRange(token_.sValueStart_, token_.sValueEnd_); }
+    // String values might have meaningful leading and trailing spaces so we avoid trimming the string (false)
+    StringRange Parser::stringValue() const { return StringRange(token_.sValueStart_, token_.sValueEnd_, false); }
 
     bool Parser::boolValue() const {
         auto str = StringRange(token_.sValueStart_, token_.sValueEnd_);

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -187,7 +187,8 @@ namespace Machine {
                 return false;
             }
             log_info("Configuration file:" << filename);
-            bool retval = load(new StringRange(buffer, buffer + filesize));
+            // Trimming the overall config file could influence indentation, hence false
+            bool retval = load(new StringRange(buffer, buffer + filesize, false));
             delete[] buffer;
             return retval;
         } catch (...) {

--- a/FluidNC/src/StringRange.h
+++ b/FluidNC/src/StringRange.h
@@ -14,7 +14,17 @@ public:
 
     StringRange(const char* str) : start_(str), end_(str + strlen(str)) {}
 
-    StringRange(const char* start, const char* end) : start_(start), end_(end) {}
+    // We usually want to ignore leading and trailing blanks, so we default to trim=true
+    StringRange(const char* start, const char* end, bool trim = true) : start_(start), end_(end) {
+        if (trim) {
+            while (start_ != end_ && isspace(*start_)) {
+                ++start_;
+            }
+            while (end_ != start_ && isspace(*(end_ - 1))) {
+                --end_;
+            }
+        }
+    }
 
     StringRange(const StringRange& o) = default;
     StringRange(StringRange&& o)      = default;


### PR DESCRIPTION
A user recently had a config parse error that was hard to find because the trailing blanks that caused it were hard to see.  In config values, there is hardly ever a case where leading and trailing blanks matter.  The only place where it might matter is for string values like board: and name:, and even then those strings are not really used except for display purposes.  This patch removes leading and trailing blanks when parsing non-string config values like numbers, booleans, pin specs, speed maps and whatnot.

The tokenizer already removes leading blanks, so that part is unnecessary, but harmless.

I tested it by polluting a config file with leading and/or trailing blanks in many different config values.