### PR TITLE
Create build-only CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: FluidNC Continuous Integration (Build Only)
+on: [push, pull_request]
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        pio_env:
+          - noradio
+          - wifi
+          - bt
+        # - wifibt
+        # - debug
+        pio_env_variant:
+          - ""
+        # - "_s2"
+        # - "_s3"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: "pip"
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Cache PlatformIO
+        uses: actions/cache@v3
+        with:
+          path: ~/.platformio
+          key: platformio-${{ runner.os }}
+      - name: Build target ${{ matrix.pio_env }}${{ matrix.pio_env_variant }}
+        run: pio run -e ${{ matrix.pio_env }}${{ matrix.pio_env_variant }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+platformio == 6.1.*


### PR DESCRIPTION
Followup to discussion on Discord regarding having a CI pipeline for FluidNC.

### Summary

This CI workflow triggers a Github action to:
- Install PlatformIO at a known version (modulo minor revision)
- Runs against Windows, Linux, and MacOS
- Builds a number of PlatformIO environments

The PlatformIO environments built are initially noradio, wifi, and bt. It is easy to include additional environments, but in the spirit of having a CI which balances speed with catching true-positive failures, we select only these three.

In addition, there is support for additional "_s2", "_s3" variants, but for this initial CI pipeline, they are not built, as they greatly increase CI time.

### Timing

CI is relatively fast with a warm cache.

- Linux: ~3 minutes
- MacOS: ~3 minutes
- Windows: ~5 minutes

The build matrix does not run fully in parallel (free-tier resource limitations), so a full run takes ~8 minutes.

### Example

My [fork of FluidNC](https://github.com/dymk/FluidNC) has this action enabled. Here's an example PR opened against that fork, to demonstrate the Checks ran against the changed code: https://github.com/dymk/FluidNC/pull/1

Example action run logs: [link](https://github.com/dymk/FluidNC/actions/runs/5346967123/jobs/9695052850)