### PR TITLE
Fix hashing

### DIFF
--- a/FluidNC/src/FileStream.cpp
+++ b/FluidNC/src/FileStream.cpp
@@ -3,7 +3,6 @@
 
 #include "FileStream.h"
 #include "Machine/MachineConfig.h"  // config->
-#include "Driver/localfs.h"
 
 std::string FileStream::path() {
     return _fpath.c_str();

--- a/FluidNC/src/FluidPath.cpp
+++ b/FluidNC/src/FluidPath.cpp
@@ -3,7 +3,6 @@
 
 #include "FluidPath.h"
 #include "Driver/sdspi.h"
-#include "Driver/localfs.h"
 #include "Config.h"
 #include "Error.h"
 #include "HashFS.h"
@@ -68,11 +67,5 @@ FluidPath::~FluidPath() {
     // log_debug("~ refcnt " << _isSD << " " << _refcnt);
     if (_isSD && (_refcnt && --_refcnt == 0)) {
         sd_unmount();
-    }
-}
-
-void FluidPath::rehash_fs() {
-    if (!_isSD) {
-        HashFS::rehash();
     }
 }

--- a/FluidNC/src/FluidPath.h
+++ b/FluidNC/src/FluidPath.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <filesystem>
 #include <string>
+#include "Driver/localfs.h"
 
 namespace stdfs = std::filesystem;
 
@@ -25,8 +26,6 @@ public:
     // true if there is something after the mount name.
     // /localfs/foo -> true,  /localfs -> false
     bool hasTail() { return ++(++begin()) != end(); }
-
-    void rehash_fs();
 
 private:
     FluidPath(const char* name, const char* fs, std::error_code*);

--- a/FluidNC/src/HashFS.h
+++ b/FluidNC/src/HashFS.h
@@ -1,10 +1,13 @@
 #pragma once
 #include <string>
 #include <map>
+#include <filesystem>
+
 class HashFS {
 public:
     static std::map<std::string, std::string> localFsHashes;
 
+    static void        rehash_file(const std::filesystem::path& path);
     static void        rehash();
     static std::string hash(std::string name);
 

--- a/FluidNC/src/HashFS.h
+++ b/FluidNC/src/HashFS.h
@@ -7,9 +7,11 @@ class HashFS {
 public:
     static std::map<std::string, std::string> localFsHashes;
 
+    static bool        file_is_hashed(const std::filesystem::path& path);
+    static void        delete_file(const std::filesystem::path& path);
     static void        rehash_file(const std::filesystem::path& path);
-    static void        rehash();
-    static std::string hash(std::string name);
+    static void        hash_all();
+    static std::string hash(const std::filesystem::path& path);
 
 private:
 };

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -25,6 +25,7 @@
 #include "Driver/fluidnc_gpio.h"  // gpio_dump()
 
 #include "FluidPath.h"
+#include "HashFS.h"
 
 #include <cstring>
 #include <map>
@@ -634,8 +635,10 @@ static Error xmodem_receive(const char* value, WebUI::AuthenticationLevel auth_l
     } else {
         log_info("Reception failed or was canceled");
     }
-    outfile->fpath().rehash_fs();
+    std::filesystem::path fname = outfile->fpath();
     delete outfile;
+    HashFS::rehash_file(fname);
+
     return size < 0 ? Error::UploadFailed : Error::Ok;
 }
 

--- a/FluidNC/stdfs/std-ops.cpp
+++ b/FluidNC/stdfs/std-ops.cpp
@@ -907,8 +907,10 @@ bool fs::remove(const path& p) {
     return result;
 }
 bool fs::remove(const path& p, error_code& ec) noexcept {
-    if (exists(symlink_status(p, ec))) {
-        if (::remove(p.c_str()) == 0) {
+    auto fs = symlink_status(p, ec);
+    if (exists(fs)) {
+        int res = fs.type() == file_type::directory ? ::rmdir(p.c_str()) : ::remove(p.c_str());
+        if (res == 0) {
             ec.clear();
             return true;
         } else


### PR DESCRIPTION
The code that manages the hashes for local files sometimes failed to pick up changes, probably because the rehash was done before all of the writes to the filesystem were committed.  I improved the code so that, instead of rehashing the entire local filesystem on any change, only the affected file is rehashed.

I also fixed a bug in the std::filesystem code that prevented the deletion of localfs subdirectories.