### PR TITLE
Minimal test harness + CI test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: FluidNC Continuous Integration (Build Only)
+name: FluidNC Continuous Integration
 on: [push, pull_request]
 jobs:
   build:
@@ -37,3 +37,50 @@ jobs:
           key: platformio-${{ runner.os }}
       - name: Build target ${{ matrix.pio_env }}${{ matrix.pio_env_variant }}
         run: pio run -e ${{ matrix.pio_env }}${{ matrix.pio_env_variant }}
+
+  tests:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            pio_env: tests
+          - os: macos-latest
+            pio_env: tests
+          - os: windows-latest
+            pio_env: tests_nosan
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      # Windows has issues running gtest code with the included gcc, so install
+      # MSYS2 and use that instead (remember to add it to the path)
+      - if: matrix.os == 'windows-latest'
+        name: Install MSYS2 (Windows)
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          location: D:\
+          install: mingw-w64-ucrt-x86_64-gcc
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: "pip"
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Cache PlatformIO
+        uses: actions/cache@v3
+        with:
+          path: ~/.platformio
+          key: platformio-${{ runner.os }}
+
+      # Separate run task for Windows, since it has issues with the included gcc
+      - if: matrix.os == 'windows-latest'
+        name: Run tests (Windows)
+        run: |
+          $env:PATH = "D:\msys64\mingw64\bin;D:\msys64\usr\bin;D:\msys64\ucrt64\bin;" + $env:PATH
+          pio test -e ${{ matrix.pio_env }} -vv
+      - if: matrix.os != 'windows-latest'
+        name: Run tests
+        run: pio test -e ${{ matrix.pio_env }} -vv

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ build/
 dist/
 *.cppx
 *.hx
+/compile_commands.json

--- a/FluidNC/tests/PinOptionsParserTest.cpp
+++ b/FluidNC/tests/PinOptionsParserTest.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) 2023 - Dylan Knutson <dymk@dymk.co>
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#include "gtest/gtest.h"
+#include "src/Pins/PinOptionsParser.h"
+
+using PinOptionsParser = Pins::PinOptionsParser;
+static void test_for_loop(PinOptionsParser& parser);
+static void test_for_loop_only_first(PinOptionsParser& parser);
+
+TEST(PinOptionsParser, WithEmptyString) {
+    char             nullDescr[1] = { '\0' };
+    PinOptionsParser parser(nullDescr, nullDescr);
+
+    {
+        auto opt    = parser.begin();
+        auto endopt = parser.end();
+        ASSERT_EQ(opt, endopt) << "Expected empty enumerator";
+    }
+
+    // Typical use is a for loop. Let's test the two ways to use it:
+    for (auto it : parser) {
+        FAIL() << "Didn't expect to get here";
+    }
+
+    for (auto it = parser.begin(); it != parser.end(); ++it) {
+        FAIL() << "Didn't expect to get here";
+    }
+}
+
+TEST(PinOptionsParser, SingleArg) {
+    const char* input = "first";
+    char        tmp[20];
+    int         n = snprintf(tmp, 20, "%s", input);
+
+    PinOptionsParser parser(tmp, tmp + n);
+
+    {
+        auto opt    = parser.begin();
+        auto endopt = parser.end();
+        ASSERT_NE(opt, endopt) << "Expected an argument";
+        ASSERT_TRUE(opt->is("first")) << "Expected 'first'";
+        ++opt;
+        ASSERT_EQ(opt, endopt) << "Expected one argument";
+    }
+
+    test_for_loop_only_first(parser);
+}
+
+TEST(PinOptionsParser, SingleArgWithWS) {
+    const char* input = "  first";
+    char        tmp[20];
+    int         n = snprintf(tmp, 20, "%s", input);
+
+    PinOptionsParser parser(tmp, tmp + n);
+
+    {
+        auto opt    = parser.begin();
+        auto endopt = parser.end();
+        ASSERT_NE(opt, endopt) << "Expected an argument";
+        ASSERT_TRUE(opt->is("first")) << "Expected 'first'";
+        ++opt;
+        ASSERT_EQ(opt, endopt) << "Expected one argument";
+    }
+
+    test_for_loop_only_first(parser);
+}
+
+TEST(PinOptionsParser, SingleArgWithWS2) {
+    const char* input = "  first  ";
+    char        tmp[20];
+    int         n = snprintf(tmp, 20, "%s", input);
+
+    PinOptionsParser parser(tmp, tmp + n);
+
+    {
+        auto opt    = parser.begin();
+        auto endopt = parser.end();
+        ASSERT_NE(opt, endopt) << "Expected an argument";
+        ASSERT_TRUE(opt->is("first")) << "Expected 'first'";
+
+        ++opt;
+        ASSERT_EQ(opt, endopt) << "Expected one argument";
+    }
+
+    test_for_loop_only_first(parser);
+}
+
+TEST(PinOptionsParser, TwoArg1) {
+    const char* input = "first;second";
+    char        tmp[20];
+    int         n = snprintf(tmp, 20, "%s", input);
+
+    PinOptionsParser parser(tmp, tmp + n);
+
+    {
+        auto opt    = parser.begin();
+        auto endopt = parser.end();
+        ASSERT_NE(opt, endopt) << "Expected an argument";
+        ASSERT_TRUE(opt->is("first")) << "Expected 'first'";
+
+        ++opt;
+        ASSERT_NE(opt, endopt) << "Expected second argument";
+        ASSERT_TRUE(opt->is("second")) << "Expected 'second'";
+
+        ++opt;
+        ASSERT_EQ(opt, endopt) << "Expected one argument";
+    }
+
+    test_for_loop(parser);
+}
+
+TEST(PinOptionsParser, TwoArg2) {
+    const char* input = "first:second";
+    char        tmp[20];
+    int         n = snprintf(tmp, 20, "%s", input);
+
+    PinOptionsParser parser(tmp, tmp + n);
+
+    {
+        auto opt    = parser.begin();
+        auto endopt = parser.end();
+        ASSERT_NE(opt, endopt) << "Expected an argument";
+        ASSERT_TRUE(opt->is("first")) << "Expected 'first'";
+
+        ++opt;
+        ASSERT_NE(opt, endopt) << "Expected second argument";
+        ASSERT_TRUE(opt->is("second")) << "Expected 'second'";
+
+        ++opt;
+        ASSERT_EQ(opt, endopt) << "Expected one argument";
+    }
+
+    test_for_loop(parser);
+}
+
+TEST(PinOptionsParser, TwoArgWithValues) {
+    const char* input = "first=12;second=13";
+    char        tmp[20];
+    int         n = snprintf(tmp, 20, "%s", input);
+
+    PinOptionsParser parser(tmp, tmp + n);
+
+    {
+        auto opt    = parser.begin();
+        auto endopt = parser.end();
+        ASSERT_NE(opt, endopt) << "Expected an argument";
+        ASSERT_TRUE(opt->is("first")) << "Expected 'first'";
+        ASSERT_EQ(strcmp("12", opt->value()), 0);
+        ASSERT_EQ(12, opt->iValue());
+        ASSERT_EQ(12, opt->dValue());
+
+        ++opt;
+        ASSERT_NE(opt, endopt) << "Expected second argument";
+        ASSERT_TRUE(opt->is("second")) << "Expected 'second'";
+        ASSERT_EQ(strcmp("13", opt->value()), 0);
+        ASSERT_EQ(13, opt->iValue());
+        ASSERT_EQ(13, opt->dValue());
+
+        ++opt;
+        ASSERT_EQ(opt, endopt) << "Expected one argument";
+    }
+
+    test_for_loop(parser);
+}
+
+static void test_for_loop(PinOptionsParser& parser) {
+    // Typical use is a for loop. Let's test the two ways to use it:
+    int ctr = 0;
+    for (auto it : parser) {
+        if (ctr == 0) {
+            ASSERT_TRUE(it.is("first")) << "Expected 'first'";
+        } else if (ctr == 1) {
+            ASSERT_TRUE(it.is("second")) << "Expected 'second'";
+        } else {
+            FAIL() << "Didn't expect to get here";
+        }
+        ++ctr;
+    }
+}
+
+static void test_for_loop_only_first(PinOptionsParser& parser) {
+    // Typical use is a for loop. Let's test the two ways to use it:
+    int ctr = 0;
+    for (auto it : parser) {
+        if (ctr == 0) {
+            ASSERT_TRUE(it.is("first")) << "Expected 'first'";
+        } else {
+            FAIL() << "Didn't expect to get here";
+        }
+        ++ctr;
+    }
+}

--- a/FluidNC/tests/test_main.cpp
+++ b/FluidNC/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    // if you plan to use GMock, replace the line above with
+    // ::testing::InitGoogleMock(&argc, argv);
+
+    if (RUN_ALL_TESTS()) {}
+
+    // Always return zero-code and allow PlatformIO to parse results
+    return 0;
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = FluidNC
 include_dir = FluidNC/include
 ; lib_dir = libraries
-test_dir = FluidNC/test
+test_dir = FluidNC/tests
 data_dir = FluidNC/data
 default_envs = wifi
 ;extra_configs=debug.ini
@@ -157,16 +157,33 @@ extends = common_esp32_s3
 lib_deps = ${common.lib_deps} ${common.bt_deps} ${common.wifi_deps}
 build_flags = ${common_esp32.build_flags}  ${common_wifi.build_flags} ${common_bt.build_flags}
 
-[env:native]
+; This environment has bit-rot, and does not build.
+; Files relevant to it reside in ./X86TestSupport and ./FluidNC/test
+; TODO - Migrate tests over to [env:tests] environment
+; [env:native]
+; platform = native
+; test_build_src = true
+; build_src_filter =
+; 	+<*.h> +<*.s> +<*.S> +<*.cpp> +<*.c> +<src/>
+; 	+<X86TestSupport/>
+; 	-<src/I2SOut.cpp> -<src\Motors\Trinamic*.cpp>
+; build_flags = -IX86TestSupport -std=c++17 -limagehlp
+; lib_compat_mode = off
+; lib_deps = 
+;     google/googletest @ ^1.10.0
+; lib_extra_dirs = 
+; 	X86TestSupport
+
+[tests_common]
 platform = native
+test_framework = googletest
 test_build_src = true
-build_src_filter =
-	+<*.h> +<*.s> +<*.S> +<*.cpp> +<*.c> +<src/>
-	+<X86TestSupport/>
-	-<src/I2SOut.cpp> -<src\Motors\Trinamic*.cpp>
-build_flags = -IX86TestSupport -std=c++17 -limagehlp
-lib_compat_mode = off
-lib_deps = 
-    google/googletest @ ^1.10.0
-lib_extra_dirs = 
-	X86TestSupport
+build_src_filter = +<src/Pins/PinOptionsParser.cpp>
+build_flags = -std=c++17 -g
+
+[env:tests]
+extends = tests_common
+build_flags = ${tests_common.build_flags} -fsanitize=address,undefined
+
+[env:tests_nosan]
+extends = tests_common


### PR DESCRIPTION
Leaves the current tests in `FluidNC/test` alone, for future organization. Relocates the test harness to be in `FluidNC/tests` (plural), and sets up a CI job to run tests on macOS, Linux and Windows. 

Linux and macOS support [Address Sanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) (catches memory errors) and [UBSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) (catches undefined behavior), and so tests are built and ran with those. Windows does not, but tests are still ran (the `tests_nosan` environment). 

Initially, I've just ported over the tests for `PinOptionsParser` from the previous test harness to `gtest`.

Example run: [link](https://github.com/dymk/FluidNC/actions/runs/5361782110)

Takes about 1 minute on Linux and macOS, and 2 minutes on Windows to run tests with a warm cache.
