### PR TITLE
Proxy legacy Grbl settings for sender compatibility

### DIFF
--- a/FluidNC/src/Error.h
+++ b/FluidNC/src/Error.h
@@ -78,6 +78,7 @@ enum class Error : uint8_t {
     ConfigurationInvalid        = 152,
     UploadFailed                = 160,
     DownloadFailed              = 161,
+    ReadOnlySetting             = 162,
 };
 
 const char* errorString(Error errorNumber);

--- a/FluidNC/src/NutsBolts.h
+++ b/FluidNC/src/NutsBolts.h
@@ -85,13 +85,6 @@ const char* to_hex(uint32_t n);
 bool  char_is_numeric(char value);
 char* trim(char* value);
 
-template <class T>
-void swap(T& a, T& b) {
-    T c(a);
-    a = b;
-    b = c;
-}
-
 template <typename T>
 T myMap(T x, T in_min, T in_max, T out_min, T out_max) {  // DrawBot_Badge
     return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;

--- a/FluidNC/src/Settings.cpp
+++ b/FluidNC/src/Settings.cpp
@@ -5,6 +5,7 @@
 #include "WebUI/Commands.h"     // WebUI::COMMANDS
 #include "System.h"             // sys
 #include "Protocol.h"           // protocol_buffer_synchronize
+#include "Machine/MachineConfig.h"
 
 #include <map>
 #include <limits>
@@ -520,4 +521,19 @@ void IPaddrSetting::addWebui(WebUI::JSONencoder* j) {
         j->begin_webui(getName(), getName(), "A", getStringValue());
         j->end_object();
     }
+}
+
+template <>
+const char* MachineConfigProxySetting<float>::getStringValue() {
+    auto got = _getter(*MachineConfig::instance());
+    _cachedValue.reserve(16);
+    std::snprintf(_cachedValue.data(), _cachedValue.capacity(), "%.3f", got);
+    return _cachedValue.c_str();
+}
+
+template <>
+const char* MachineConfigProxySetting<int32_t>::getStringValue() {
+    auto got     = _getter(*MachineConfig::instance());
+    _cachedValue = std::to_string(got);
+    return _cachedValue.c_str();
 }

--- a/FluidNC/src/Settings.h
+++ b/FluidNC/src/Settings.h
@@ -5,8 +5,14 @@
 #include "Report.h"  // info_channel
 #include "GCode.h"   // CoordIndex
 
+#include <string_view>
 #include <map>
 #include <nvs.h>
+
+// forward declarations
+namespace Machine {
+    class MachineConfig;
+}
 
 // Initialize the configuration subsystem
 void settings_init();
@@ -199,6 +205,21 @@ public:
     const char* getDefaultString();
 
     int32_t get() { return _currentValue; }
+};
+
+// See Settings.cpp for the int32_t and float specialization implementations
+template <typename T>
+class MachineConfigProxySetting : public Setting {
+    std::function<T(Machine::MachineConfig const&)> _getter;
+    std::string                                     _cachedValue;
+
+public:
+    MachineConfigProxySetting(const char* grblName, const char* fullName, std::function<T(Machine::MachineConfig const&)> getter) :
+        Setting(fullName, type_t::GRBL, permissions_t::WU, grblName, fullName, nullptr), _getter(getter), _cachedValue("") {}
+
+    const char* getStringValue() override;
+    Error       setStringValue(char* value) override { return Error::ReadOnlySetting; }
+    const char* getDefaultString() override { return ""; }
 };
 
 class Coordinates {

--- a/FluidNC/src/SettingsDefinitions.cpp
+++ b/FluidNC/src/SettingsDefinitions.cpp
@@ -1,5 +1,10 @@
+#include "Machine/MachineConfig.h"
 #include "SettingsDefinitions.h"
 #include "Config.h"
+
+#include <tuple>
+#include <array>
+#include <memory>
 
 StringSetting* config_filename;
 
@@ -12,6 +17,9 @@ IntSetting* status_mask;
 IntSetting* sd_fallback_cs;
 
 EnumSetting* message_level;
+
+std::vector<std::unique_ptr<MachineConfigProxySetting<float>>>   float_proxies;
+std::vector<std::unique_ptr<MachineConfigProxySetting<int32_t>>> int_proxies;
 
 enum_opt_t messageLevels = {
     // clang-format off
@@ -64,4 +72,47 @@ void make_settings() {
 
     start_message =
         new StringSetting("Message issued at startup", EXTENDED, WG, NULL, "Start/Message", "Grbl \\V [FluidNC \\B (\\R) \\H]", 0, 40, NULL);
+
+    // Some gcode senders expect Grbl to report certain numbered settings to improve
+    // their reporting. The following macros set up various legacy numbered Grbl settings,
+    // which are derived from MachineConfig settings.
+
+    // 130-132: Max travel (mm)
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "130", "Grbl/MaxTravel/X", [](MachineConfig const& config) { return config._axes->_axis[0]->_maxTravel; }));
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "131", "Grbl/MaxTravel/Y", [](MachineConfig const& config) { return config._axes->_axis[1]->_maxTravel; }));
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "132", "Grbl/MaxTravel/Z", [](MachineConfig const& config) { return config._axes->_axis[2]->_maxTravel; }));
+
+    // 120-122: Acceleration (mm/sec^2)
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "120", "Grbl/Acceleration/X", [](MachineConfig const& config) { return config._axes->_axis[0]->_acceleration; }));
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "121", "Grbl/Acceleration/Y", [](MachineConfig const& config) { return config._axes->_axis[1]->_acceleration; }));
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "122", "Grbl/Acceleration/Z", [](MachineConfig const& config) { return config._axes->_axis[2]->_acceleration; }));
+
+    // 110-112: Max rate (mm/min)
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "110", "Grbl/MaxRate/X", [](MachineConfig const& config) { return config._axes->_axis[0]->_maxRate; }));
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "111", "Grbl/MaxRate/Y", [](MachineConfig const& config) { return config._axes->_axis[1]->_maxRate; }));
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "112", "Grbl/MaxRate/Z", [](MachineConfig const& config) { return config._axes->_axis[2]->_maxRate; }));
+
+    // 100-102: Resolution (steps/mm)
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "100", "Grbl/Resolution/X", [](MachineConfig const& config) { return config._axes->_axis[0]->_stepsPerMm; }));
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "101", "Grbl/Resolution/Y", [](MachineConfig const& config) { return config._axes->_axis[1]->_stepsPerMm; }));
+    float_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<float>>(
+        "102", "Grbl/Resolution/Z", [](MachineConfig const& config) { return config._axes->_axis[2]->_stepsPerMm; }));
+
+    int_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<int32_t>>(
+        "20", "Grbl/SoftLimitsEnable", [](MachineConfig const& config) { return config._axes->_axis[0]->_softLimits ? 1 : 0; }));
+    int_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<int32_t>>(
+        "21", "Grbl/HardLimitsEnable", [](MachineConfig const& config) { return config._axes->hasHardLimits() ? 1 : 0; }));
+    int_proxies.emplace_back(std::make_unique<MachineConfigProxySetting<int32_t>>(
+        "22", "Grbl/HomingCycleEnable", [](MachineConfig const& config) { return Axes::homingMask ? 1 : 0; }));
 }


### PR DESCRIPTION
Some senders (such as gSender) rely on standard numbered Grbl settings for improved reporting of machine state, and some utility functionality like "Jog to this quadrant of the machine bed" - in particular, reporting of homing status and axes limits.

This adds the relevant numbered settings, derived from `MachineConfig`. They are read-only, and writing to them will result in a `error:162, ReadOnlySetting` error.

### Testing

New output for `$$`
```
Grbl 3.0 [FluidNC v3.0.x (grbl-proxy-settings-446e05d0) (noradio) '$' for help]

> $$
$22=1
$21=0
$20=0
$100=3000.000
$101=3000.000
$102=1000.000
$110=50.000
$111=50.000
$112=200.000
$120=100.000
$121=100.000
$122=100.000
$130=800.000
$131=600.000
$132=100.000
$10=1
ok

> $120 = 1
error:162
```

gSender now renders the quadrant jogging tool (it was not rendered before)
![image](https://github.com/bdring/FluidNC/assets/1578600/82f817a6-6933-4c73-ba73-911ac836a717)

Grbl firmware "state" correctly interpreted from sender:
![image](https://github.com/bdring/FluidNC/assets/1578600/87a21338-cd6e-46e7-a0c4-fca30612dd0d)

