### PR TITLE
Use vector for tracking all Setting / Command objects

### DIFF
--- a/FluidNC/src/Configuration/Completer.cpp
+++ b/FluidNC/src/Configuration/Completer.cpp
@@ -81,7 +81,7 @@ int num_initial_matches(char* key, int keylen, int matchnum, char* matchname) {
         nfound = completer._numMatches;
     } else {
         // Match NVS settings
-        for (Setting* s = Setting::List; s; s = s->next()) {
+        for (Setting* s : Setting::List) {
             if (isInitialSubstringCI(key, s->getName())) {
                 if (matchname && nfound == matchnum) {
                     strcpy(matchname, s->getName());

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -47,7 +47,7 @@ static bool auth_failed(Word* w, const char* value, WebUI::AuthenticationLevel a
             if (!value) {                              // User can read anything
                 return false;                          // No read is a User auth fail
             }
-            return permissions == WA;  // User cannot write WA
+            return permissions == WA;                  // User cannot write WA
         default:
             return true;
     }
@@ -133,10 +133,10 @@ void settings_restore(uint8_t restore_flag) {
 
     if (restore_flag & SettingsRestore::Defaults) {
         bool restore_startup = restore_flag & SettingsRestore::StartupLines;
-        for (Setting* s = Setting::List; s; s = s->next()) {
+        for (Setting* s : Setting::List) {
             if (!s->getDescription()) {
                 const char* name = s->getName();
-                if (restore_startup) {  // all settings get restored
+                if (restore_startup) {                                                      // all settings get restored
                     s->setDefault();
                 } else if ((strcmp(name, "Line0") != 0) && (strcmp(name, "Line1") != 0)) {  // non startup settings get restored
                     s->setDefault();
@@ -157,7 +157,7 @@ void settings_restore(uint8_t restore_flag) {
 
 // Get settings values from non volatile storage into memory
 static void load_settings() {
-    for (Setting* s = Setting::List; s; s = s->next()) {
+    for (Setting* s : Setting::List) {
         s->load();
     }
 }
@@ -186,7 +186,7 @@ static Error report_gcode(const char* value, WebUI::AuthenticationLevel auth_lev
 }
 
 static void show_settings(Channel& out, type_t type) {
-    for (Setting* s = Setting::List; s; s = s->next()) {
+    for (Setting* s : Setting::List) {
         if (s->getType() == type && s->getGrblName()) {
             // The following test could be expressed more succinctly with XOR,
             // but is arguably clearer when written out
@@ -199,7 +199,7 @@ static Error report_normal_settings(const char* value, WebUI::AuthenticationLeve
     return Error::Ok;
 }
 static Error list_grbl_names(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    for (Setting* setting = Setting::List; setting; setting = setting->next()) {
+    for (Setting* setting : Setting::List) {
         const char* gn = setting->getGrblName();
         if (gn) {
             log_to(out, "$", gn << " => $" << setting->getName());
@@ -208,7 +208,7 @@ static Error list_grbl_names(const char* value, WebUI::AuthenticationLevel auth_
     return Error::Ok;
 }
 static Error list_settings(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    for (Setting* s = Setting::List; s; s = s->next()) {
+    for (Setting* s : Setting::List) {
         const char* displayValue = auth_failed(s, value, auth_level) ? "<Authentication required>" : s->getStringValue();
         if (s->getType() != PIN) {
             show_setting(s->getName(), displayValue, NULL, out);
@@ -217,7 +217,7 @@ static Error list_settings(const char* value, WebUI::AuthenticationLevel auth_le
     return Error::Ok;
 }
 static Error list_changed_settings(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    for (Setting* s = Setting::List; s; s = s->next()) {
+    for (Setting* s : Setting::List) {
         const char* value = s->getStringValue();
         if (!auth_failed(s, value, auth_level) && strcmp(value, s->getDefaultString())) {
             if (s->getType() != PIN) {
@@ -229,7 +229,7 @@ static Error list_changed_settings(const char* value, WebUI::AuthenticationLevel
     return Error::Ok;
 }
 static Error list_commands(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    for (Command* cp = Command::List; cp; cp = cp->next()) {
+    for (Command* cp : Command::List) {
         const char* name    = cp->getName();
         const char* oldName = cp->getGrblName();
         LogStream   s(out, "$");
@@ -890,7 +890,7 @@ Error do_command_or_setting(const char* key, char* value, WebUI::AuthenticationL
 
     // Next search the settings list by text name. If found, set a new
     // value if one is given, otherwise display the current value
-    for (Setting* s = Setting::List; s; s = s->next()) {
+    for (Setting* s : Setting::List) {
         if (strcasecmp(s->getName(), key) == 0) {
             if (auth_failed(s, value, auth_level)) {
                 return Error::AuthenticationFailed;
@@ -906,7 +906,7 @@ Error do_command_or_setting(const char* key, char* value, WebUI::AuthenticationL
 
     // Then search the setting list by compatible name.  If found, set a new
     // value if one is given, otherwise display the current value in compatible mode
-    for (Setting* s = Setting::List; s; s = s->next()) {
+    for (Setting* s : Setting::List) {
         if (s->getGrblName() && strcasecmp(s->getGrblName(), key) == 0) {
             if (auth_failed(s, value, auth_level)) {
                 return Error::AuthenticationFailed;
@@ -922,7 +922,7 @@ Error do_command_or_setting(const char* key, char* value, WebUI::AuthenticationL
     // If we did not find a setting, look for a command.  Commands
     // handle values internally; you cannot determine whether to set
     // or display solely based on the presence of a value.
-    for (Command* cp = Command::List; cp; cp = cp->next()) {
+    for (Command* cp : Command::List) {
         if ((strcasecmp(cp->getName(), key) == 0) || (cp->getGrblName() && strcasecmp(cp->getGrblName(), key) == 0)) {
             if (auth_failed(cp, value, auth_level)) {
                 return Error::AuthenticationFailed;
@@ -938,7 +938,7 @@ Error do_command_or_setting(const char* key, char* value, WebUI::AuthenticationL
     Error retval = Error::InvalidStatement;
     if (!value) {
         bool found = false;
-        for (Setting* s = Setting::List; s; s = s->next()) {
+        for (Setting* s : Setting::List) {
             auto test = s->getName();
             // The C++ standard regular expression library supports many more
             // regular expression forms than the simple one in Regex.cpp, but

--- a/FluidNC/src/Settings.cpp
+++ b/FluidNC/src/Settings.cpp
@@ -12,6 +12,9 @@
 #include <vector>
 #include <nvs.h>
 
+std::vector<Setting*> Setting::List = {};
+std::vector<Command*> Command::List = {};
+
 bool anyState() {
     return false;
 }
@@ -28,24 +31,18 @@ bool cycleOrHold() {
 Word::Word(type_t type, permissions_t permissions, const char* description, const char* grblName, const char* fullName) :
     _description(description), _grblName(grblName), _fullName(fullName), _type(type), _permissions(permissions) {}
 
-Command* Command::List = NULL;
-
 Command::Command(
     const char* description, type_t type, permissions_t permissions, const char* grblName, const char* fullName, bool (*cmdChecker)()) :
     Word(type, permissions, description, grblName, fullName),
     _cmdChecker(cmdChecker) {
-    link = List;
-    List = this;
+    List.push_back(this);
 }
-
-Setting* Setting::List = NULL;
 
 Setting::Setting(
     const char* description, type_t type, permissions_t permissions, const char* grblName, const char* fullName, bool (*checker)(char*)) :
     Word(type, permissions, description, grblName, fullName),
     _checker(checker) {
-    link = List;
-    List = this;
+    List.push_back(this);
 
     // NVS keys are limited to 15 characters, so if the setting name is longer
     // than that, we derive a 15-character name from a hash function

--- a/FluidNC/src/Settings.h
+++ b/FluidNC/src/Settings.h
@@ -24,11 +24,6 @@ enum SettingsRestore {
 // Restore subsets of settings to default values
 void settings_restore(uint8_t restore_flag);
 
-// Command::List is a linked list of all settings,
-// so common code can enumerate them.
-class Command;
-// extern Command *CommandsList;
-
 // This abstract class defines the generic interface that
 // is used to set and get values for all settings independent
 // of their underlying data type.  The values are always
@@ -78,12 +73,12 @@ public:
 
 class Command : public Word {
 protected:
-    Command* link;  // linked list of setting objects
     bool (*_cmdChecker)();
 
 public:
-    static Command* List;
-    Command*        next() { return link; }
+    // Command::List is a vector of all commands,
+    // so common code can enumerate them.
+    static std::vector<Command*> List;
 
     ~Command() {}
     Command(const char* description, type_t type, permissions_t permissions, const char* grblName, const char* fullName, bool (*cmdChecker)());
@@ -99,8 +94,7 @@ class Setting : public Word {
 private:
 protected:
     // group_t _group;
-    axis_t   _axis = NO_AXIS;
-    Setting* link;  // linked list of setting objects
+    axis_t _axis = NO_AXIS;
 
     bool (*_checker)(char*);
     const char* _keyName;
@@ -108,8 +102,10 @@ protected:
 public:
     static nvs_handle _handle;
     static void       init();
-    static Setting*   List;
-    Setting*          next() { return link; }
+
+    // Setting::List is a vector of all settings,
+    // so common code can enumerate them.
+    static std::vector<Setting*> List;
 
     Error check(char* s);
 

--- a/FluidNC/src/WebUI/WebSettings.cpp
+++ b/FluidNC/src/WebUI/WebSettings.cpp
@@ -255,7 +255,7 @@ namespace WebUI {
 
         // NVS settings
         j.setCategory("nvs");
-        for (Setting* js = Setting::List; js; js = js->next()) {
+        for (Setting* js : Setting::List) {
             js->addWebui(&j);
         }
 
@@ -584,7 +584,7 @@ namespace WebUI {
         log_to(out, "ESPname FullName         Description");
         log_to(out, "------- --------         -----------");
         ;
-        for (Setting* setting = Setting::List; setting; setting = setting->next()) {
+        for (Setting* setting : Setting::List) {
             if (setting->getType() == WEBSET) {
                 log_to(out,
                        "",
@@ -597,7 +597,7 @@ namespace WebUI {
         log_to(out, "ESPname FullName         Values");
         log_to(out, "------- --------         ------");
 
-        for (Command* cp = Command::List; cp; cp = cp->next()) {
+        for (Command* cp : Command::List) {
             if (cp->getType() == WEBCMD) {
                 LogStream s(out, "");
                 s << LeftJustify(cp->getGrblName() ? cp->getGrblName() : "", 8) << LeftJustify(cp->getName(), 25 - 8);

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -772,7 +772,7 @@ namespace WebUI {
         bool error = false;
         // XXX this is probably wrong for YAML land.
         // We might want this function to go away.
-        for (Setting* s = Setting::List; s; s = s->next()) {
+        for (Setting* s : Setting::List) {
             if (s->getDescription()) {
                 s->setDefault();
             }


### PR DESCRIPTION
Simple cleanup, reduces the size of a Setting / Command by one pointer, and allows the use of for-loop iterator sugar. 