### PR TITLE
New alarms

### DIFF
--- a/FluidNC/src/Control.cpp
+++ b/FluidNC/src/Control.cpp
@@ -9,7 +9,7 @@
 Control::Control() {
     // The SafetyDoor pin must be defined first because it is checked explicity in safety_door_ajar()
     _pins.push_back(new ControlPin(&safetyDoorEvent, "safety_door_pin", 'D'));
-    _pins.push_back(new ControlPin(&resetEvent, "reset_pin", 'R'));
+    _pins.push_back(new ControlPin(&rtResetEvent, "reset_pin", 'R'));
     _pins.push_back(new ControlPin(&feedHoldEvent, "feed_hold_pin", 'H'));
     _pins.push_back(new ControlPin(&cycleStartEvent, "cycle_start_pin", 'S'));
     _pins.push_back(new ControlPin(&macro0Event, "macro0_pin", '0'));

--- a/FluidNC/src/CoolantControl.cpp
+++ b/FluidNC/src/CoolantControl.cpp
@@ -55,7 +55,7 @@ void CoolantControl::write(CoolantState state) {
     }
 }
 
-// Directly called by coolant_init(), coolant_set_state(), and mc_reset(), which can be at
+// Directly called by coolant_init(), coolant_set_state(), which can be at
 // an interrupt-level. No report flag set, but only called by routines that don't need it.
 void CoolantControl::stop() {
     CoolantState disable = {};

--- a/FluidNC/src/Jog.cpp
+++ b/FluidNC/src/Jog.cpp
@@ -12,9 +12,7 @@
 // Sets up valid jog motion received from g-code parser, checks for soft-limits, and executes the jog.
 // cancelledInflight will be set to true if was not added to parser due to a cancelJog.
 Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block, bool* cancelledInflight) {
-    if (config->_kinematics->invalid_line(gc_block->values.xyz)) {
-        config->_kinematics->constrain_line(gc_block->values.xyz, gc_state.position);
-    }
+    config->_kinematics->constrain_jog(gc_block->values.xyz, pl_data, gc_state.position);
 
     // Initialize planner data struct for jogging motions.
     // NOTE: Spindle and coolant are allowed to fully function with overrides during a jog.

--- a/FluidNC/src/Jog.cpp
+++ b/FluidNC/src/Jog.cpp
@@ -12,14 +12,16 @@
 // Sets up valid jog motion received from g-code parser, checks for soft-limits, and executes the jog.
 // cancelledInflight will be set to true if was not added to parser due to a cancelJog.
 Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block, bool* cancelledInflight) {
+    if (config->_kinematics->invalid_line(gc_block->values.xyz)) {
+        config->_kinematics->constrain_line(gc_block->values.xyz, gc_state.position);
+    }
+
     // Initialize planner data struct for jogging motions.
     // NOTE: Spindle and coolant are allowed to fully function with overrides during a jog.
     pl_data->feed_rate             = gc_block->values.f;
     pl_data->motion.noFeedOverride = 1;
     pl_data->is_jog                = true;
     pl_data->line_number           = gc_block->values.n;
-
-    constrainToSoftLimits(gc_block->values.xyz);
 
     if (!mc_linear(gc_block->values.xyz, pl_data, gc_state.position)) {
         return Error::JogCancelled;

--- a/FluidNC/src/Kinematics/Cartesian.cpp
+++ b/FluidNC/src/Kinematics/Cartesian.cpp
@@ -18,6 +18,234 @@ namespace Kinematics {
         }
     }
 
+    // Check that the arc does not exceed the soft limits using a fast
+    // algorithm that requires no transcendental functions.
+    // caxes[] depends on the plane selection via G17, G18, and G19.  caxes[0] is the first
+    // circle plane axis, caxes[1] is the second circle plane axis, and caxes[2] is the
+    // orthogonal plane.  So for G17 mode, caxes[] is { 0, 1, 2} for { X, Y, Z}.  G18 is {2, 0, 1} i.e. {Z, X, Y}, and G19 is {1, 2, 0} i.e. {Y, Z, X}
+    bool Cartesian::invalid_arc(float* target, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
+        auto axes = config->_axes;
+
+        // Handle the orthognal axis first to get it out of the way.
+        size_t the_axis = caxes[2];
+        if (axes->_axis[the_axis]->_softLimits) {
+            float amin = std::min(position[the_axis], target[the_axis]);
+            if (amin < limitsMinPosition(the_axis)) {
+                limit_error(the_axis, amin);
+                return true;
+            }
+            float amax = std::max(position[the_axis], target[the_axis]);
+            if (amax > limitsMaxPosition(the_axis)) {
+                limit_error(the_axis, amax);
+                return true;
+            }
+        }
+
+        bool limited[2] = { axes->_axis[caxes[0]]->_softLimits, axes->_axis[caxes[1]]->_softLimits };
+
+        // If neither axis of the circular plane has limits enabled, skip the computation
+        if (!(limited[0] || limited[1])) {
+            return false;
+        }
+
+        // The origin for this calculation's coordinate system is at the center of the arc.
+        // The 0 and 1 entries are for the circle plane
+        // and the 2 entry is the orthogonal (linear) direction
+
+        float s[2], e[2];  // Start and end of arc in the circle plane, relative to center
+
+        // Depending on the arc direction, set the arc start and end points relative
+        // to the arc center.  Afterwards, end is always counterclockwise relative to
+        // start, thus simplifying the following decision tree.
+        if (is_clockwise_arc) {
+            s[0] = target[caxes[0]] - center[0];
+            s[1] = target[caxes[1]] - center[1];
+            e[0] = position[caxes[0]] - center[0];
+            e[1] = position[caxes[1]] - center[1];
+        } else {
+            s[0] = position[caxes[0]] - center[0];
+            s[1] = position[caxes[1]] - center[1];
+            e[0] = target[caxes[0]] - center[0];
+            e[1] = target[caxes[1]] - center[1];
+        }
+
+        // Axis crossings - plus and minus caxes[0] and caxes[1]
+        bool p[2] = { false, false };
+        bool m[2] = { false, false };
+
+        // The following decision tree determines whether the arc crosses
+        // the horizontal and vertical axes of the circular plane in the
+        // positive and negative half planes.  There are ways to express
+        // it in fewer lines of code by converting to alternate
+        // representations like angles, but this way is computationally
+        // efficient since it avoids any use of transcendental functions.
+        // Every path through this decision tree is either 4 or 5 simple
+        // comparisons.
+        if (e[1] >= 0) {                     // End in upper half plane
+            if (e[0] > 0) {                  // End in quadrant 0 - X+ Y+
+                if (s[1] >= 0) {             // Start in upper half plane
+                    if (s[0] > 0) {          // Start in quadrant 0 - X+ Y+
+                        if (s[0] <= e[0]) {  // wraparound
+                            p[0] = p[1] = m[0] = m[1] = true;
+                        }
+                    } else {  // Start in quadrant 1 - X- Y+
+                        m[0] = m[1] = p[0] = true;
+                    }
+                } else {             // Start in lower half plane
+                    if (s[0] > 0) {  // Start in quadrant 3 - X+ Y-
+                        p[0] = true;
+                    } else {  // Start in quadrant 2 - X- Y-
+                        m[1] = p[0] = true;
+                    }
+                }
+            } else {                 // End in quadrant 1 - X- Y+
+                if (s[1] >= 0) {     // Start in upper half plane
+                    if (s[0] > 0) {  // Start in quadrant 0 - X+ Y+
+                        p[1] = true;
+                    } else {                 // Start in quadrant 1 - X- Y+
+                        if (s[0] <= e[0]) {  // wraparound
+                            p[0] = p[1] = m[0] = m[1] = true;
+                        }
+                    }
+                } else {             // Start in lower half plane
+                    if (s[0] > 0) {  // Start in quadrant 3 - X+ Y-
+                        p[0] = p[1] = true;
+                    } else {  // Start in quadrant 2 - X- Y-
+                        m[1] = p[0] = p[1] = true;
+                    }
+                }
+            }
+        } else {                     // e[1] < 0 - end in lower half plane
+            if (e[0] > 0) {          // End in quadrant 3 - X+ Y+
+                if (s[1] >= 0) {     // Start in upper half plane
+                    if (s[0] > 0) {  // Start in quadrant 0 - X+ Y+
+                        p[1] = m[0] = m[1] = true;
+                    } else {  // Start in quadrant 1 - X- Y+
+                        m[0] = m[1] = true;
+                    }
+                } else {                     // Start in lower half plane
+                    if (s[0] > 0) {          // Start in quadrant 3 - X+ Y-
+                        if (s[0] >= e[0]) {  // wraparound
+                            p[0] = p[1] = m[0] = m[1] = true;
+                        }
+                    } else {  // Start in quadrant 2 - X- Y-
+                        m[1] = true;
+                    }
+                }
+            } else {                 // End in quadrant 2 - X- Y+
+                if (s[1] >= 0) {     // Start in upper half plane
+                    if (s[0] > 0) {  // Start in quadrant 0 - X+ Y+
+                        p[1] = m[0] = true;
+                    } else {  // Start in quadrant 1 - X- Y+
+                        m[0] = true;
+                    }
+                } else {             // Start in lower half plane
+                    if (s[0] > 0) {  // Start in quadrant 3 - X+ Y-
+                        p[0] = p[1] = m[0] = true;
+                    } else {                 // Start in quadrant 2 - X- Y-
+                        if (s[0] >= e[0]) {  // wraparound
+                            p[0] = p[1] = m[0] = m[1] = true;
+                        }
+                    }
+                }
+            }
+        }
+        // Now check limits based on arc endpoints and axis crossings
+        for (size_t a = 0; a < 2; ++a) {
+            the_axis = caxes[a];
+            if (limited[a]) {
+                // If we crossed the axis in the positive half plane, the
+                // maximum extent along that axis is at center + radius.
+                // Otherwise it is the maximum coordinate of the start and
+                // end positions.  Similarly for the negative half plane
+                // and the minimum extent.
+                float amin = m[a] ? center[a] - radius : std::min(target[the_axis], position[the_axis]);
+                if (amin < limitsMinPosition(the_axis)) {
+                    limit_error(the_axis, amin);
+                    return true;
+                }
+                float amax = p[a] ? center[a] + radius : std::max(target[the_axis], position[the_axis]);
+                if (amax > limitsMaxPosition(the_axis)) {
+                    limit_error(the_axis, amax);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    void Cartesian::constrain_line(float* target, float* position) {
+        auto axes   = config->_axes;
+        auto n_axis = config->_axes->_numberAxis;
+
+        float*    current_position = get_mpos();
+        MotorMask lim_pin_state    = limits_get_state();
+
+        for (int axis = 0; axis < n_axis; axis++) {
+            auto axisSetting = axes->_axis[axis];
+            // If the axis is moving from the current location and soft limits are on.
+            if (axisSetting->_softLimits && target[axis] != current_position[axis]) {
+                // When outside the axis range, only small nudges to clear switches are allowed
+                bool move_positive = target[axis] > current_position[axis];
+                if ((!move_positive && (current_position[axis] < limitsMinPosition(axis))) ||
+                    (move_positive && (current_position[axis] > limitsMaxPosition(axis)))) {
+                    // only allow a nudge if a switch is active
+                    if (bitnum_is_false(lim_pin_state, Machine::Axes::motor_bit(axis, 0)) &&
+                        bitnum_is_false(lim_pin_state, Machine::Axes::motor_bit(axis, 1))) {
+                        target[axis] = current_position[axis];  // cancel the move on this axis
+                        log_debug("Soft limit violation on " << Machine::Axes::_names[axis]);
+                        continue;
+                    }
+                    float jog_dist = target[axis] - current_position[axis];
+
+                    MotorMask axisMotors = Machine::Axes::axes_to_motors(1 << axis);
+                    bool      posLimited = bits_are_true(Machine::Axes::posLimitMask, axisMotors);
+                    bool      negLimited = bits_are_true(Machine::Axes::negLimitMask, axisMotors);
+
+                    // if jog is positive and only the positive switch is active, then kill the move
+                    // if jog is negative and only the negative switch is active, then kill the move
+                    if (posLimited != negLimited) {  // XOR, because ambiguous (both) is OK
+                        if ((negLimited && (jog_dist < 0)) || (posLimited && (jog_dist > 0))) {
+                            target[axis] = current_position[axis];  // cancel the move on this axis
+                            log_debug("Jog into active switch blocked on " << Machine::Axes::_names[axis]);
+                            continue;
+                        }
+                    }
+
+                    auto nudge_max = axisSetting->_motors[0]->_pulloff;
+                    if (abs(jog_dist) > nudge_max) {
+                        target[axis] = (jog_dist >= 0) ? current_position[axis] + nudge_max : current_position[axis] + nudge_max;
+                        log_debug("Jog amount limited when outside soft limits")
+                    }
+                    continue;
+                }
+
+                if (target[axis] < limitsMinPosition(axis)) {
+                    target[axis] = limitsMinPosition(axis);
+                } else if (target[axis] > limitsMaxPosition(axis)) {
+                    target[axis] = limitsMaxPosition(axis);
+                } else {
+                    continue;
+                }
+                log_debug("Jog constrained to axis range");
+            }
+        }
+    }
+
+    bool Cartesian::invalid_line(float* cartesian) {
+        auto axes   = config->_axes;
+        auto n_axis = config->_axes->_numberAxis;
+
+        for (int axis = 0; axis < n_axis; axis++) {
+            float coordinate = cartesian[axis];
+            if (axes->_axis[axis]->_softLimits && (coordinate < limitsMinPosition(axis) || coordinate > limitsMaxPosition(axis))) {
+                limit_error(axis, coordinate);
+                return true;
+            }
+        }
+        return false;
+    }
+
     bool Cartesian::cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) {
         // Motor space is cartesian space, so we do no transform.
         return mc_move_motors(target, pl_data);

--- a/FluidNC/src/Kinematics/Cartesian.cpp
+++ b/FluidNC/src/Kinematics/Cartesian.cpp
@@ -23,9 +23,11 @@ namespace Kinematics {
     // caxes[] depends on the plane selection via G17, G18, and G19.  caxes[0] is the first
     // circle plane axis, caxes[1] is the second circle plane axis, and caxes[2] is the
     // orthogonal plane.  So for G17 mode, caxes[] is { 0, 1, 2} for { X, Y, Z}.  G18 is {2, 0, 1} i.e. {Z, X, Y}, and G19 is {1, 2, 0} i.e. {Y, Z, X}
-    bool Cartesian::invalid_arc(float* target, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
-        auto axes = config->_axes;
+    bool Cartesian::invalid_arc(
+        float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
+        pl_data->limits_checked = true;
 
+        auto axes = config->_axes;
         // Handle the orthognal axis first to get it out of the way.
         size_t the_axis = caxes[2];
         if (axes->_axis[the_axis]->_softLimits) {
@@ -174,7 +176,7 @@ namespace Kinematics {
         return false;
     }
 
-    void Cartesian::constrain_line(float* target, float* position) {
+    void Cartesian::constrain_jog(float* target, plan_line_data_t* pl_data, float* position) {
         auto axes   = config->_axes;
         auto n_axis = config->_axes->_numberAxis;
 
@@ -230,6 +232,7 @@ namespace Kinematics {
                 log_debug("Jog constrained to axis range");
             }
         }
+        pl_data->limits_checked = true;
     }
 
     bool Cartesian::invalid_line(float* cartesian) {

--- a/FluidNC/src/Kinematics/Cartesian.h
+++ b/FluidNC/src/Kinematics/Cartesian.h
@@ -23,9 +23,15 @@ namespace Kinematics {
 
         // Kinematic Interface
 
-        virtual void constrain_line(float* cartesian, float* position) override;
+        virtual void constrain_jog(float* cartesian, plan_line_data_t* pl_data, float* position) override;
         virtual bool invalid_line(float* cartesian) override;
-        virtual bool invalid_arc(float* target, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) override;
+        virtual bool invalid_arc(float*            target,
+                                 plan_line_data_t* pl_data,
+                                 float*            position,
+                                 float             center[3],
+                                 float             radius,
+                                 size_t            caxes[3],
+                                 bool              is_clockwise_arc) override;
 
         virtual bool cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) override;
         virtual void init() override;

--- a/FluidNC/src/Kinematics/Cartesian.h
+++ b/FluidNC/src/Kinematics/Cartesian.h
@@ -16,12 +16,16 @@ namespace Kinematics {
     public:
         Cartesian() = default;
 
-        Cartesian(const Cartesian&)            = delete;
-        Cartesian(Cartesian&&)                 = delete;
+        Cartesian(const Cartesian&) = delete;
+        Cartesian(Cartesian&&)      = delete;
         Cartesian& operator=(const Cartesian&) = delete;
-        Cartesian& operator=(Cartesian&&)      = delete;
+        Cartesian& operator=(Cartesian&&) = delete;
 
         // Kinematic Interface
+
+        virtual void constrain_line(float* cartesian, float* position) override;
+        virtual bool invalid_line(float* cartesian) override;
+        virtual bool invalid_arc(float* target, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) override;
 
         virtual bool cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) override;
         virtual void init() override;

--- a/FluidNC/src/Kinematics/Kinematics.cpp
+++ b/FluidNC/src/Kinematics/Kinematics.cpp
@@ -8,9 +8,9 @@
 #include "Cartesian.h"
 
 namespace Kinematics {
-    void Kinematics::constrain_line(float* target, float* position) {
+    void Kinematics::constrain_jog(float* target, plan_line_data_t* pl_data, float* position) {
         Assert(_system != nullptr, "No kinematic system");
-        return _system->constrain_line(target, position);
+        return _system->constrain_jog(target, pl_data, position);
     }
 
     bool Kinematics::invalid_line(float* target) {
@@ -18,9 +18,10 @@ namespace Kinematics {
         return _system->invalid_line(target);
     }
 
-    bool Kinematics::invalid_arc(float* target, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
+    bool Kinematics::invalid_arc(
+        float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
         Assert(_system != nullptr, "No kinematic system");
-        return _system->invalid_arc(target, position, center, radius, caxes, is_clockwise_arc);
+        return _system->invalid_arc(target, pl_data, position, center, radius, caxes, is_clockwise_arc);
     }
 
     bool Kinematics::cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) {

--- a/FluidNC/src/Kinematics/Kinematics.cpp
+++ b/FluidNC/src/Kinematics/Kinematics.cpp
@@ -8,6 +8,21 @@
 #include "Cartesian.h"
 
 namespace Kinematics {
+    void Kinematics::constrain_line(float* target, float* position) {
+        Assert(_system != nullptr, "No kinematic system");
+        return _system->constrain_line(target, position);
+    }
+
+    bool Kinematics::invalid_line(float* target) {
+        Assert(_system != nullptr, "No kinematic system");
+        return _system->invalid_line(target);
+    }
+
+    bool Kinematics::invalid_arc(float* target, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
+        Assert(_system != nullptr, "No kinematic system");
+        return _system->invalid_arc(target, position, center, radius, caxes, is_clockwise_arc);
+    }
+
     bool Kinematics::cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) {
         Assert(_system != nullptr, "No kinematic system");
         return _system->cartesian_to_motors(target, pl_data, position);

--- a/FluidNC/src/Kinematics/Kinematics.h
+++ b/FluidNC/src/Kinematics/Kinematics.h
@@ -48,6 +48,10 @@ namespace Kinematics {
         void motors_to_cartesian(float* cartesian, float* motors, int n_axis);
         void transform_cartesian_to_motors(float* motors, float* cartesian);
 
+        void constrain_line(float* target, float* position);
+        bool invalid_line(float* target);
+        bool invalid_arc(float* target, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc);
+
         bool canHome(AxisMask axisMask);
         void releaseMotors(AxisMask axisMask, MotorMask motors);
         bool limitReached(AxisMask& axisMask, MotorMask& motors, MotorMask limited);
@@ -60,15 +64,22 @@ namespace Kinematics {
     public:
         KinematicSystem() = default;
 
-        KinematicSystem(const KinematicSystem&)            = delete;
-        KinematicSystem(KinematicSystem&&)                 = delete;
+        KinematicSystem(const KinematicSystem&) = delete;
+        KinematicSystem(KinematicSystem&&)      = delete;
         KinematicSystem& operator=(const KinematicSystem&) = delete;
-        KinematicSystem& operator=(KinematicSystem&&)      = delete;
+        KinematicSystem& operator=(KinematicSystem&&) = delete;
 
         // Kinematic system interface.
         virtual bool cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) = 0;
         virtual void init()                                                                         = 0;
-        virtual void init_position()                                                  = 0;  // used to set the machine position at init
+        virtual void init_position() = 0;  // used to set the machine position at init
+
+        virtual void constrain_line(float* cartesian, float* position) {}
+        virtual bool invalid_line(float* cartesian) { return false; }
+        virtual bool invalid_arc(float* target, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
+            return false;
+        }
+
         virtual void motors_to_cartesian(float* cartesian, float* motors, int n_axis) = 0;
 
         virtual void transform_cartesian_to_motors(float* motors, float* cartesian) = 0;

--- a/FluidNC/src/Kinematics/Kinematics.h
+++ b/FluidNC/src/Kinematics/Kinematics.h
@@ -48,9 +48,10 @@ namespace Kinematics {
         void motors_to_cartesian(float* cartesian, float* motors, int n_axis);
         void transform_cartesian_to_motors(float* motors, float* cartesian);
 
-        void constrain_line(float* target, float* position);
+        void constrain_jog(float* target, plan_line_data_t* pl_data, float* position);
         bool invalid_line(float* target);
-        bool invalid_arc(float* target, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc);
+        bool invalid_arc(
+            float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc);
 
         bool canHome(AxisMask axisMask);
         void releaseMotors(AxisMask axisMask, MotorMask motors);
@@ -74,9 +75,10 @@ namespace Kinematics {
         virtual void init()                                                                         = 0;
         virtual void init_position() = 0;  // used to set the machine position at init
 
-        virtual void constrain_line(float* cartesian, float* position) {}
+        virtual void constrain_jog(float* cartesian, plan_line_data_t* pl_data, float* position) {}
         virtual bool invalid_line(float* cartesian) { return false; }
-        virtual bool invalid_arc(float* target, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
+        virtual bool invalid_arc(
+            float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
             return false;
         }
 

--- a/FluidNC/src/Limits.h
+++ b/FluidNC/src/Limits.h
@@ -16,6 +16,8 @@ void limits_init();
 // Returns limit state
 MotorMask limits_get_state();
 
+void limit_error(size_t axis, float cordinate);
+
 // Check for soft limit violations
 void limits_soft_check(float* cartesian);
 

--- a/FluidNC/src/Limits.h
+++ b/FluidNC/src/Limits.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "System.h"  // AxisMask
+#include "System.h"
 
 #include <cstdint>
 
@@ -17,12 +17,6 @@ void limits_init();
 MotorMask limits_get_state();
 
 void limit_error(size_t axis, float cordinate);
-
-// Check for soft limit violations
-void limits_soft_check(float* cartesian);
-
-// Constrain the coordinates to stay within the soft limit envelope
-void constrainToSoftLimits(float* cartesian);
 
 float limitsMaxPosition(size_t axis);
 float limitsMinPosition(size_t axis);

--- a/FluidNC/src/Machine/Axes.cpp
+++ b/FluidNC/src/Machine/Axes.cpp
@@ -13,9 +13,10 @@ EnumItem axisType[] = { { 0, "X" }, { 1, "Y" }, { 2, "Z" }, { 3, "A" }, { 4, "B"
 namespace Machine {
     MotorMask Axes::posLimitMask = 0;
     MotorMask Axes::negLimitMask = 0;
-    MotorMask Axes::homingMask   = 0;
     MotorMask Axes::limitMask    = 0;
     MotorMask Axes::motorMask    = 0;
+
+    AxisMask Axes::homingMask = 0;
 
     Axes::Axes() : _axis() {
         for (int i = 0; i < MAX_N_AXIS; ++i) {

--- a/FluidNC/src/Machine/Axes.h
+++ b/FluidNC/src/Machine/Axes.h
@@ -24,9 +24,10 @@ namespace Machine {
         // Bitmasks to collect information about axes that have limits and homing
         static MotorMask posLimitMask;
         static MotorMask negLimitMask;
-        static MotorMask homingMask;
         static MotorMask limitMask;
         static MotorMask motorMask;
+
+        static AxisMask homingMask;
 
         Pin _sharedStepperDisable;
         Pin _sharedStepperReset;
@@ -72,7 +73,8 @@ namespace Machine {
         void config_motors();
 
         std::string maskToNames(AxisMask mask);
-        bool        namesToMask(const char* names, AxisMask& mask);
+
+        bool namesToMask(const char* names, AxisMask& mask);
 
         std::string motorMaskToNames(MotorMask mask);
 

--- a/FluidNC/src/Machine/Axis.cpp
+++ b/FluidNC/src/Machine/Axis.cpp
@@ -45,7 +45,7 @@ namespace Machine {
                 m->init();
             }
         }
-        if (_homing) {
+        if (_homing->_cycle) {
             _homing->init();
             set_bitnum(Axes::homingMask, _axis);
         }

--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -1,10 +1,9 @@
 #include "Homing.h"
 
-#include "../MotionControl.h"  // mc_reset
-#include "../System.h"         // sys.*
-#include "../Stepper.h"        // st_wake
-#include "../Protocol.h"       // protocol_handle_events
-#include "../Limits.h"         // ambiguousLimit
+#include "../System.h"    // sys.*
+#include "../Stepper.h"   // st_wake
+#include "../Protocol.h"  // protocol_handle_events
+#include "../Limits.h"    // ambiguousLimit
 #include "../Machine/Axes.h"
 #include "../Machine/MachineConfig.h"  // config
 

--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -351,7 +351,7 @@ namespace Machine {
 
     void Homing::fail(ExecAlarm alarm) {
         Stepper::reset();  // Stop moving
-        rtAlarm = alarm;
+        send_alarm(alarm);
         config->_axes->set_homing_mode(_cycleAxes, false);  // tell motors homing is done...failed
         config->_axes->set_disable(config->_stepping->_idleMsecs != 255);
     }

--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -59,7 +59,7 @@ namespace Machine {
         float target[config->_axes->_numberAxis];
         axisVector(_phaseAxes, _phaseMotors, _phase, target, rate, _settling_ms);
 
-        plan_line_data_t plan_data;
+        plan_line_data_t plan_data      = {};
         plan_data.spindle_speed         = 0;
         plan_data.motion                = {};
         plan_data.motion.systemMotion   = 1;

--- a/FluidNC/src/Machine/Homing.h
+++ b/FluidNC/src/Machine/Homing.h
@@ -11,6 +11,8 @@
 
 namespace Machine {
     class Homing : public Configuration::Configurable {
+        static AxisMask _unhomed_axes;
+
     public:
         static enum Phase {
             None         = 0,
@@ -22,6 +24,14 @@ namespace Machine {
             Pulloff2     = 6,
             CycleDone    = 7,
         } _phase;
+
+        static AxisMask unhomed_axes();
+
+        static void set_axis_homed(size_t axis);
+        static void set_axis_unhomed(size_t axis);
+        static bool axis_is_homed(size_t axis);
+        static void set_all_axes_homed();
+        static void set_all_axes_unhomed();
 
         Homing() = default;
 
@@ -44,7 +54,7 @@ namespace Machine {
 
         // The homing cycles are 1,2,3 etc.  0 means not homed as part of home-all,
         // but you can still home it manually with e.g. $HA
-        int      _cycle             = -1;    // what auto-homing cycle does this axis home on?
+        int      _cycle             = 0;     // what auto-homing cycle does this axis home on?
         bool     _allow_single_axis = true;  // Allow use of $H<axis> command on this axis
         bool     _positiveDirection = true;
         float    _mpos              = 0.0f;    // After homing this will be the mpos of the switch location

--- a/FluidNC/src/Machine/LimitPin.cpp
+++ b/FluidNC/src/Machine/LimitPin.cpp
@@ -2,7 +2,6 @@
 #include "src/Machine/Axes.h"
 #include "src/Machine/MachineConfig.h"  // config
 
-#include "src/MotionControl.h"  // mc_reset
 #include "src/Limits.h"
 #include "src/Protocol.h"  // protocol_send_event_from_ISR()
 

--- a/FluidNC/src/Machine/Macros.cpp
+++ b/FluidNC/src/Machine/Macros.cpp
@@ -18,7 +18,9 @@ void MacroEvent::run(void* arg) {
 
 std::string Macros::_startup_line[n_startup_lines];
 std::string Macros::_macro[n_macros];
-std::string Macros::_post_homing_line;
+std::string Macros::_after_homing_line;
+std::string Macros::_after_reset_line;
+std::string Macros::_after_unlock_line;
 
 MacroEvent macro0Event { 0 };
 MacroEvent macro1Event { 1 };

--- a/FluidNC/src/Machine/Macros.cpp
+++ b/FluidNC/src/Machine/Macros.cpp
@@ -61,6 +61,7 @@ bool Macros::run_macro(const std::string& s) {
         return true;
     }
 
+    log_info("Running macro: " << s);
     char c;
     for (int i = 0; i < s.length(); i++) {
         c = s[i];

--- a/FluidNC/src/Machine/Macros.h
+++ b/FluidNC/src/Machine/Macros.h
@@ -30,13 +30,16 @@ namespace Machine {
         static const int n_macros        = 4;
 
     private:
-        std::string _startup_line[n_startup_lines];
-        std::string _macro[n_macros];
+        static std::string _startup_line[n_startup_lines];
+        static std::string _macro[n_macros];
 
     public:
+        static std::string _post_homing_line;
+
         Macros() = default;
 
         bool run_macro(size_t index);
+        bool run_macro(const std::string& s);
 
         std::string startup_line(size_t index) {
             if (index >= n_startup_lines) {
@@ -63,6 +66,7 @@ namespace Machine {
             handler.item("macro1", _macro[1]);
             handler.item("macro2", _macro[2]);
             handler.item("macro3", _macro[3]);
+            handler.item("post_homing", _post_homing_line);
         }
 
         ~Macros() {}

--- a/FluidNC/src/Machine/Macros.h
+++ b/FluidNC/src/Machine/Macros.h
@@ -24,39 +24,41 @@ extern MacroEvent macro2Event;
 extern MacroEvent macro3Event;
 
 namespace Machine {
+    class Macro {
+    public:
+        std::string _gcode;
+        std::string _name;
+        Macro(const char* name) : _name(name) {}
+        bool run();
+    };
+
     class Macros : public Configuration::Configurable {
     public:
         static const int n_startup_lines = 2;
         static const int n_macros        = 4;
 
-    private:
-        static std::string _macro[n_macros];
-
-    public:
-        static std::string _startup_line[n_startup_lines];
-        static std::string _after_homing_line;
-        static std::string _after_reset_line;
-        static std::string _after_unlock_line;
+        static Macro _macro[n_macros];
+        static Macro _startup_line[n_startup_lines];
+        static Macro _after_homing;
+        static Macro _after_reset;
+        static Macro _after_unlock;
 
         Macros() = default;
-
-        bool run_macro(size_t index);
-        bool run_macro(const std::string& s);
 
         // Configuration helpers:
 
         // TODO: We could validate the startup lines
 
         void group(Configuration::HandlerBase& handler) override {
-            handler.item("startup_line0", _startup_line[0]);
-            handler.item("startup_line1", _startup_line[1]);
-            handler.item("macro0", _macro[0]);
-            handler.item("macro1", _macro[1]);
-            handler.item("macro2", _macro[2]);
-            handler.item("macro3", _macro[3]);
-            handler.item("after_homing", _after_homing_line);
-            handler.item("after_reset", _after_reset_line);
-            handler.item("after_unlock", _after_unlock_line);
+            handler.item(_startup_line[0]._name.c_str(), _startup_line[0]._gcode);
+            handler.item(_startup_line[1]._name.c_str(), _startup_line[1]._gcode);
+            handler.item(_macro[0]._name.c_str(), _macro[0]._gcode);
+            handler.item(_macro[1]._name.c_str(), _macro[1]._gcode);
+            handler.item(_macro[2]._name.c_str(), _macro[2]._gcode);
+            handler.item(_macro[3]._name.c_str(), _macro[3]._gcode);
+            handler.item(_after_homing._name.c_str(), _after_homing._gcode);
+            handler.item(_after_reset._name.c_str(), _after_reset._gcode);
+            handler.item(_after_unlock._name.c_str(), _after_unlock._gcode);
         }
 
         ~Macros() {}

--- a/FluidNC/src/Machine/Macros.h
+++ b/FluidNC/src/Machine/Macros.h
@@ -30,30 +30,16 @@ namespace Machine {
         static const int n_macros        = 4;
 
     private:
-        static std::string _startup_line[n_startup_lines];
         static std::string _macro[n_macros];
 
     public:
+        static std::string _startup_line[n_startup_lines];
         static std::string _post_homing_line;
 
         Macros() = default;
 
         bool run_macro(size_t index);
         bool run_macro(const std::string& s);
-
-        std::string startup_line(size_t index) {
-            if (index >= n_startup_lines) {
-                return "";
-            }
-            auto s = _startup_line[index];
-            if (s == "") {
-                return s;
-            }
-            // & is a proxy for newlines in startup lines, because you cannot
-            // enter a newline directly in a config file string value.
-            std::replace(s.begin(), s.end(), '&', '\n');
-            return s + "\n";
-        }
 
         // Configuration helpers:
 

--- a/FluidNC/src/Machine/Macros.h
+++ b/FluidNC/src/Machine/Macros.h
@@ -34,7 +34,9 @@ namespace Machine {
 
     public:
         static std::string _startup_line[n_startup_lines];
-        static std::string _post_homing_line;
+        static std::string _after_homing_line;
+        static std::string _after_reset_line;
+        static std::string _after_unlock_line;
 
         Macros() = default;
 
@@ -52,7 +54,9 @@ namespace Machine {
             handler.item("macro1", _macro[1]);
             handler.item("macro2", _macro[2]);
             handler.item("macro3", _macro[3]);
-            handler.item("post_homing", _post_homing_line);
+            handler.item("after_homing", _after_homing_line);
+            handler.item("after_reset", _after_reset_line);
+            handler.item("after_unlock", _after_unlock_line);
         }
 
         ~Macros() {}

--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -127,9 +127,11 @@ void setup() {
             // NOTE: The startup script will run after successful completion of the homing cycle, but
             // not after disabling the alarm locks. Prevents motion startup blocks from crashing into
             // things uncontrollably. Very bad.
+            Homing::set_all_axes_homed();
             if (config->_start->_mustHome && Machine::Axes::homingMask) {
+                Homing::set_all_axes_unhomed();
                 // If there is an axis with homing configured, enter Alarm state on startup
-                sys.state = State::Alarm;
+                send_alarm(ExecAlarm::Unhomed);
             }
             for (auto s : config->_spindles) {
                 s->init();

--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -107,32 +107,12 @@ void setup() {
             config->_control->init();
 
             config->_kinematics->init();
+
+            limits_init();
         }
 
         // Initialize system state.
         if (sys.state != State::ConfigAlarm) {
-            if (FORCE_INITIALIZATION_ALARM) {
-                // Force ALARM state upon a power-cycle or hard reset.
-                sys.state = State::Alarm;
-            } else {
-                sys.state = State::Idle;
-            }
-
-            limits_init();
-
-            // Check for power-up and set system alarm if homing is enabled to force homing cycle
-            // by setting alarm state. Alarm locks out all g-code commands, including the
-            // startup scripts, but allows access to settings and internal commands. Only a homing
-            // cycle '$H' or kill alarm locks '$X' will disable the alarm.
-            // NOTE: The startup script will run after successful completion of the homing cycle, but
-            // not after disabling the alarm locks. Prevents motion startup blocks from crashing into
-            // things uncontrollably. Very bad.
-            Homing::set_all_axes_homed();
-            if (config->_start->_mustHome && Machine::Axes::homingMask) {
-                Homing::set_all_axes_unhomed();
-                // If there is an axis with homing configured, enter Alarm state on startup
-                send_alarm(ExecAlarm::Unhomed);
-            }
             for (auto s : config->_spindles) {
                 s->init();
             }
@@ -154,40 +134,12 @@ void setup() {
     }
 
     allChannels.deregistration(&startupLog);
-}
-
-static void reset_variables() {
-    // Reset primary systems.
-    system_reset();
-    protocol_reset();
-    gc_init();  // Set g-code parser to default state
-    // Spindle should be set either by the configuration
-    // or by the post-configuration fixup, but we test
-    // it anyway just for safety.  We want to avoid any
-    // possibility of crashing at this point.
-
-    plan_reset();  // Clear block buffer and planner variables
-
-    if (sys.state != State::ConfigAlarm) {
-        if (spindle) {
-            spindle->stop();
-            report_ovr_counter = 0;  // Set to report change immediately
-        }
-        Stepper::reset();  // Clear stepper subsystem variables
-    }
-
-    // Sync cleared gcode and planner positions to current system position.
-    plan_sync_position();
-    gc_sync_position();
-    allChannels.flushRx();
-    report_init_message(allChannels);
-    mc_init();
+    protocol_send_event(&startEvent);
 }
 
 void loop() {
     static int tries = 0;
     try {
-        reset_variables();
         // Start the main loop. Processes program inputs and executes them.
         // This can exit on a system abort condition, in which case run_once()
         // is re-executed by an enclosing loop.  It can also exit via a

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -108,7 +108,7 @@ static bool mc_linear_no_check(float* target, plan_line_data_t* pl_data, float* 
     return config->_kinematics->cartesian_to_motors(target, pl_data, position);
 }
 bool mc_linear(float* target, plan_line_data_t* pl_data, float* position) {
-    if (!pl_data->is_jog) {  // soft limits for jogs have already been dealt with
+    if (!pl_data->is_jog && !pl_data->limits_checked) {  // soft limits for jogs have already been dealt with
         if (config->_kinematics->invalid_line(target)) {
             return false;
         }
@@ -137,7 +137,7 @@ void mc_arc(float*            target,
 
     // The first two axes are the circle plane and the third is the orthogonal plane
     size_t caxes[3] = { axis_0, axis_1, axis_linear };
-    if (config->_kinematics->invalid_arc(target, position, center, radius, caxes, is_clockwise_arc)) {
+    if (config->_kinematics->invalid_arc(target, pl_data, position, center, radius, caxes, is_clockwise_arc)) {
         return;
     }
 
@@ -251,7 +251,7 @@ void mc_arc(float*            target,
                 position[i] += linear_per_segment[i];
             }
             pl_data->feed_rate = original_feedrate;  // This restores the feedrate kinematics may have altered
-            mc_linear_no_check(position, pl_data, previous_position);
+            mc_linear(position, pl_data, previous_position);
             previous_position[axis_0]      = position[axis_0];
             previous_position[axis_1]      = position[axis_1];
             previous_position[axis_linear] = position[axis_linear];
@@ -262,7 +262,7 @@ void mc_arc(float*            target,
         }
     }
     // Ensure last segment arrives at target location.
-    mc_linear_no_check(target, pl_data, previous_position);
+    mc_linear(target, pl_data, previous_position);
 }
 
 // Execute dwell in seconds.

--- a/FluidNC/src/MotionControl.h
+++ b/FluidNC/src/MotionControl.h
@@ -56,7 +56,7 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, bool away, 
 void mc_override_ctrl_update(Override override_state);
 
 // Performs system reset. If in motion state, kills all motion and sets system alarm.
-void mc_reset();
+void mc_critical(ExecAlarm alarm);
 
 void mc_cancel_jog();
 

--- a/FluidNC/src/Motors/StandardStepper.cpp
+++ b/FluidNC/src/Motors/StandardStepper.cpp
@@ -84,7 +84,9 @@ namespace MotorDrivers {
             _step_pin.setAttr(Pin::Attr::Output);
         }
 
-        _disable_pin.setAttr(Pin::Attr::Output);
+        if (_disable_pin.defined()) {
+            _disable_pin.setAttr(Pin::Attr::Output);
+        }
     }
 
     void StandardStepper::config_message() {

--- a/FluidNC/src/Parking.cpp
+++ b/FluidNC/src/Parking.cpp
@@ -64,6 +64,7 @@ void Parking::setup() {
     plan_data.motion.systemMotion   = 1;
     plan_data.motion.noFeedOverride = 1;
     plan_data.line_number           = PARKING_MOTION_LINE_NUMBER;
+    plan_data.is_jog                = false;
     block                           = plan_get_current_block();
 
     if (block) {

--- a/FluidNC/src/Planner.h
+++ b/FluidNC/src/Planner.h
@@ -62,13 +62,14 @@ struct plan_block_t {
 
 // Planner data prototype. Must be used when passing new motions to the planner.
 struct plan_line_data_t {
-    float        feed_rate;      // Desired feed rate for line motion. Value is ignored, if rapid motion.
-    SpindleSpeed spindle_speed;  // Desired spindle speed through line motion.
-    PlMotion     motion;         // Bitflag variable to indicate motion conditions. See defines above.
-    SpindleState spindle;        // Spindle enable state
-    CoolantState coolant;        // Coolant state
-    int32_t      line_number;    // Desired line number to report when executing.
-    bool         is_jog;         // true if this was generated due to a jog command
+    float        feed_rate;       // Desired feed rate for line motion. Value is ignored, if rapid motion.
+    SpindleSpeed spindle_speed;   // Desired spindle speed through line motion.
+    PlMotion     motion;          // Bitflag variable to indicate motion conditions. See defines above.
+    SpindleState spindle;         // Spindle enable state
+    CoolantState coolant;         // Coolant state
+    int32_t      line_number;     // Desired line number to report when executing.
+    bool         is_jog;          // true if this was generated due to a jog command
+    bool         limits_checked;  // true if soft limits already checked
 };
 
 void plan_init();

--- a/FluidNC/src/Planner.h
+++ b/FluidNC/src/Planner.h
@@ -12,6 +12,7 @@
 #include "Config.h"            // MAX_N_AXIS
 #include "SpindleDatatypes.h"  // SpindleState
 #include "GCode.h"             // CoolantState
+#include "Types.h"             // AxisMask
 
 #include <cstdint>
 

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -440,9 +440,9 @@ static Error get_report_build_info(const char* value, WebUI::AuthenticationLevel
     }
     return Error::InvalidStatement;
 }
-static Error report_startup_lines(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+static Error show_startup_lines(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     for (int i = 0; i < config->_macros->n_startup_lines; i++) {
-        log_to(out, "$N", i << "=" << config->_macros->startup_line(i));
+        log_to(out, "$N", i << "=" << config->_macros->_startup_line[i]);
     }
     return Error::Ok;
 }
@@ -798,7 +798,7 @@ void make_user_commands() {
 
     new UserCommand("SLP", "System/Sleep", go_to_sleep, notIdleOrAlarm);
     new UserCommand("I", "Build/Info", get_report_build_info, notIdleOrAlarm);
-    new UserCommand("N", "GCode/StartupLines", report_startup_lines, notIdleOrAlarm);
+    new UserCommand("N", "GCode/StartupLines", show_startup_lines, notIdleOrAlarm);
     new UserCommand("RST", "Settings/Restore", restore_settings, notIdleOrAlarm, WA);
 
     new UserCommand("Heap", "Heap/Show", showHeap, anyState);
@@ -993,8 +993,10 @@ void settings_execute_startup() {
     }
     Error status_code;
     for (int i = 0; i < config->_macros->n_startup_lines; i++) {
-        auto str = config->_macros->startup_line(i);
+        auto str = config->_macros->_startup_line[i];
         if (str.length()) {
+            config->_macros->run_macro(str);
+#if 0
             // We have to copy this to a mutable array because
             // gc_execute_line modifies the line while parsing.
             char gcline[256];
@@ -1004,6 +1006,7 @@ void settings_execute_startup() {
             if (status_code != Error::Ok) {
                 log_error("Startup line: " << errorString(status_code));
             }
+#endif
         }
     }
 }

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -329,7 +329,7 @@ static Error home(AxisMask axisMask) {
         protocol_execute_realtime();
     } while (sys.state == State::Homing);
 
-    settings_execute_startup();
+    config->_macros->run_macro(Macros::_post_homing_line);
 
     return Error::Ok;
 }
@@ -988,6 +988,9 @@ Error settings_execute_line(char* line, Channel& out, WebUI::AuthenticationLevel
 }
 
 void settings_execute_startup() {
+    if (sys.state != State::Idle) {
+        return;
+    }
     Error status_code;
     for (int i = 0; i < config->_macros->n_startup_lines; i++) {
         auto str = config->_macros->startup_line(i);
@@ -997,7 +1000,7 @@ void settings_execute_startup() {
             char gcline[256];
             strncpy(gcline, str.c_str(), 255);
             status_code = gc_execute_line(gcline);
-            // Uart0 << ">" << gcline << ":";
+            // Uart0 << ">" << gcline << "\n";
             if (status_code != Error::Ok) {
                 log_error("Startup line: " << errorString(status_code));
             }

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -267,12 +267,12 @@ static Error toggle_check_mode(const char* value, WebUI::AuthenticationLevel aut
 static Error isStuck() {
     // Block if a control pin is stuck on
     if (config->_control->safety_door_ajar()) {
-        rtAlarm = ExecAlarm::ControlPin;
+        send_alarm(ExecAlarm::ControlPin);
         return Error::CheckDoor;
     }
     if (config->_control->stuck()) {
         log_info("Control pins:" << config->_control->report_status());
-        rtAlarm = ExecAlarm::ControlPin;
+        send_alarm(ExecAlarm::ControlPin);
         return Error::CheckControlPins;
     }
     return Error::Ok;
@@ -495,8 +495,8 @@ static Error doJog(const char* value, WebUI::AuthenticationLevel auth_level, Cha
 static Error listAlarms(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     if (sys.state == State::ConfigAlarm) {
         log_to(out, "Configuration alarm is active. Check the boot messages for 'ERR'.");
-    } else if (rtAlarm != ExecAlarm::None) {
-        log_to(out, "Active alarm: ", int(rtAlarm) << " (" << alarmString(rtAlarm));
+    } else if (sys.state == State::Alarm) {
+        log_to(out, "Active alarm: ", int(lastAlarm) << " (" << alarmString(lastAlarm));
     }
     if (value) {
         char*   endptr      = NULL;

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -289,9 +289,9 @@ static Error disable_alarm_lock(const char* value, WebUI::AuthenticationLevel au
         Homing::set_all_axes_homed();
         report_feedback_message(Message::AlarmUnlock);
         sys.state = State::Idle;
-
-        config->_macros->_after_unlock.run();
-    }  // Otherwise, no effect.
+    }
+    // Run the after_unlock macro even if no unlock was necessary
+    config->_macros->_after_unlock.run();
     return Error::Ok;
 }
 static Error report_ngc(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -253,9 +253,8 @@ static Error toggle_check_mode(const char* value, WebUI::AuthenticationLevel aut
     // idle and ready, regardless of alarm locks. This is mainly to keep things
     // simple and consistent.
     if (sys.state == State::CheckMode) {
-        log_debug("Check mode");
-        mc_reset();
         report_feedback_message(Message::Disabled);
+        sys.abort = true;
     } else {
         if (sys.state != State::Idle) {
             return Error::IdleError;  // Requires no alarm mode.

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -290,7 +290,7 @@ static Error disable_alarm_lock(const char* value, WebUI::AuthenticationLevel au
         report_feedback_message(Message::AlarmUnlock);
         sys.state = State::Idle;
 
-        // Don't run startup script. Prevents stored moves in startup from causing accidents.
+        config->_macros->run_macro(Macros::_after_unlock_line);
     }  // Otherwise, no effect.
     return Error::Ok;
 }
@@ -329,7 +329,7 @@ static Error home(AxisMask axisMask) {
         protocol_execute_realtime();
     } while (sys.state == State::Homing);
 
-    config->_macros->run_macro(Macros::_post_homing_line);
+    config->_macros->run_macro(Macros::_after_homing_line);
 
     return Error::Ok;
 }

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -286,6 +286,7 @@ static Error disable_alarm_lock(const char* value, WebUI::AuthenticationLevel au
         if (err != Error::Ok) {
             return err;
         }
+        Homing::set_all_axes_homed();
         report_feedback_message(Message::AlarmUnlock);
         sys.state = State::Idle;
 

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -36,6 +36,7 @@ std::map<ExecAlarm, const char*> AlarmNames = {
     { ExecAlarm::ControlPin, "Control Pin Initially On" },
     { ExecAlarm::HomingAmbiguousSwitch, "Ambiguous Switch" },
     { ExecAlarm::HardStop, "Hard Stop" },
+    { ExecAlarm::Unhomed, "Unhomed" },
 };
 
 const char* alarmString(ExecAlarm alarmNumber) {

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -388,7 +388,7 @@ static void protocol_do_restart() {
         send_alarm(ExecAlarm::ControlPin);
     } else {
         if (sys.state == State::Idle) {
-            config->_macros->run_macro(Macros::_after_reset_line);
+            config->_macros->_after_reset.run();
         }
     }
 }

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -386,6 +386,10 @@ static void protocol_do_restart() {
         mc_critical(ExecAlarm::HardLimit);
     } else if (config->_control->startup_check()) {
         send_alarm(ExecAlarm::ControlPin);
+    } else {
+        if (sys.state == State::Idle) {
+            config->_macros->run_macro(Macros::_after_reset_line);
+        }
     }
 }
 

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -64,6 +64,7 @@ enum class ExecAlarm : uint8_t {
     ControlPin            = 11,
     HomingAmbiguousSwitch = 12,
     HardStop              = 13,
+    Unhomed               = 14,
 };
 
 extern volatile ExecAlarm lastAlarm;
@@ -97,6 +98,7 @@ extern NoArgEvent motionCancelEvent;
 extern NoArgEvent sleepEvent;
 extern NoArgEvent rtResetEvent;
 extern NoArgEvent debugEvent;
+extern NoArgEvent unhomedEvent;
 
 // extern NoArgEvent statusReportEvent;
 

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -65,6 +65,7 @@ enum class ExecAlarm : uint8_t {
     HomingAmbiguousSwitch = 12,
     HardStop              = 13,
     Unhomed               = 14,
+    Init                  = 15,
 };
 
 extern volatile ExecAlarm lastAlarm;
@@ -99,6 +100,10 @@ extern NoArgEvent sleepEvent;
 extern NoArgEvent rtResetEvent;
 extern NoArgEvent debugEvent;
 extern NoArgEvent unhomedEvent;
+extern NoArgEvent startEvent;
+extern NoArgEvent restartEvent;
+
+extern NoArgEvent runStartupLinesEvent;
 
 // extern NoArgEvent statusReportEvent;
 

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -66,7 +66,7 @@ enum class ExecAlarm : uint8_t {
     HardStop              = 13,
 };
 
-extern volatile ExecAlarm rtAlarm;  // Global realtime executor variable for setting various alarms.
+extern volatile ExecAlarm lastAlarm;
 
 #include <map>
 extern std::map<ExecAlarm, const char*> AlarmNames;
@@ -111,6 +111,9 @@ struct EventItem {
 
 void protocol_send_event(Event*, void* arg = 0);
 void protocol_handle_events();
+
+void send_alarm(ExecAlarm alarm);
+void send_alarm_from_ISR(ExecAlarm alarm);
 
 inline void protocol_send_event(Event* evt, int arg) {
     protocol_send_event(evt, (void*)arg);

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -44,7 +44,6 @@ void protocol_buffer_synchronize();
 void protocol_disable_steppers();
 void protocol_cancel_disable_steppers();
 
-extern volatile bool rtReset;
 extern volatile bool rtCycleStop;
 
 extern volatile bool runLimitLoop;
@@ -96,7 +95,7 @@ extern NoArgEvent cycleStartEvent;
 extern NoArgEvent cycleStopEvent;
 extern NoArgEvent motionCancelEvent;
 extern NoArgEvent sleepEvent;
-extern NoArgEvent resetEvent;
+extern NoArgEvent rtResetEvent;
 extern NoArgEvent debugEvent;
 
 // extern NoArgEvent statusReportEvent;

--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -470,6 +470,7 @@ const char* state_name() {
             return "Jog";
         case State::Homing:
             return "Home";
+        case State::Critical:
         case State::ConfigAlarm:
         case State::Alarm:
             return "Alarm";

--- a/FluidNC/src/Report.h
+++ b/FluidNC/src/Report.h
@@ -38,7 +38,7 @@ enum class Message : uint8_t {
     SleepMode       = 11,
     ConfigAlarmLock = 12,
     HardStop        = 13,
-    FileQuit        = 60,  // mc_reset was called during a file job
+    FileQuit        = 60,  // mc_critical was called during a file job
 };
 
 typedef uint8_t Counter;  // Report interval

--- a/FluidNC/src/Serial.cpp
+++ b/FluidNC/src/Serial.cpp
@@ -87,7 +87,7 @@ void execute_realtime_command(Cmd command, Channel& channel) {
     switch (command) {
         case Cmd::Reset:
             log_debug("Cmd::Reset");
-            protocol_send_event(&resetEvent);
+            protocol_send_event(&rtResetEvent);
             break;
         case Cmd::StatusReport:
             report_realtime_status(channel);  // direct call instead of setting flag

--- a/FluidNC/src/Spindles/VFDSpindle.cpp
+++ b/FluidNC/src/Spindles/VFDSpindle.cpp
@@ -244,8 +244,8 @@ namespace Spindles {
                     pollidx      = -1;
                 }
                 if (next_cmd.critical) {
-                    log_error("Critical VFD RS485 Unresponsive");
                     mc_critical(ExecAlarm::SpindleControl);
+                    log_error("Critical VFD RS485 Unresponsive");
                 }
             }
         }
@@ -364,8 +364,8 @@ namespace Spindles {
 #endif
 
             if (unchanged == limit) {
-                log_error(name() << " spindle did not reach device units " << dev_speed << ". Reported value is " << _sync_dev_speed);
                 mc_critical(ExecAlarm::SpindleControl);
+                log_error(name() << " spindle did not reach device units " << dev_speed << ". Reported value is " << _sync_dev_speed);
             }
 
             _syncing = false;
@@ -415,9 +415,9 @@ namespace Spindles {
             action.action   = actionSetSpeed;
             action.arg      = dev_speed;
             action.critical = (dev_speed == 0);
-            if (xQueueSendFromISR(vfd_cmd_queue, &action, 0) != pdTRUE) {
-                log_info("VFD Queue Full");
-            }
+            // Ignore errors because reporting is not safe from an ISR.
+            // Perhaps set a flag instead?
+            xQueueSendFromISR(vfd_cmd_queue, &action, 0);
         }
     }
 

--- a/FluidNC/src/Spindles/VFDSpindle.cpp
+++ b/FluidNC/src/Spindles/VFDSpindle.cpp
@@ -21,7 +21,7 @@
 #include "VFDSpindle.h"
 
 #include "../Machine/MachineConfig.h"
-#include "../MotionControl.h"  // mc_reset
+#include "../MotionControl.h"  // mc_critical
 #include "../Protocol.h"       // rtAlarm
 #include "../Report.h"         // hex message
 
@@ -245,8 +245,7 @@ namespace Spindles {
                 }
                 if (next_cmd.critical) {
                     log_error("Critical VFD RS485 Unresponsive");
-                    mc_reset();
-                    rtAlarm = ExecAlarm::SpindleControl;
+                    mc_critical(ExecAlarm::SpindleControl);
                 }
             }
         }
@@ -366,8 +365,7 @@ namespace Spindles {
 
             if (unchanged == limit) {
                 log_error(name() << " spindle did not reach device units " << dev_speed << ". Reported value is " << _sync_dev_speed);
-                mc_reset();
-                rtAlarm = ExecAlarm::SpindleControl;
+                mc_critical(ExecAlarm::SpindleControl);
             }
 
             _syncing = false;

--- a/FluidNC/src/Types.h
+++ b/FluidNC/src/Types.h
@@ -20,4 +20,5 @@ enum class State : uint8_t {
     SafetyDoor,   // Safety door is ajar. Feed holds and de-energizes system.
     Sleep,        // Sleep state.
     ConfigAlarm,  // You can't do anything but fix your config file.
+    Critical,     // You can't do anything but reset with CTRL-x or the reset button
 };


### PR DESCRIPTION
This is a revamp of the alarm handling code, setting the stage for finer-grained alarm states like separate spindle failure and mpos-unknown states.

At present, fine-grained states are not implemented, but the new structure should make it easier to implement them.  The new structure unwinds the previously-byzantine code in mc_reset(), separating the jobs of stopping the system and later responding to a user request to reset.  Alarm events are now queued the same as other protocol events, eliminating the old global variables rtAlarm and rtReset whose behavior and interactions were confusing.