### PR TITLE
Update GPIOPinDetail.cpp

### DIFF
--- a/FluidNC/src/Pins/GPIOPinDetail.cpp
+++ b/FluidNC/src/Pins/GPIOPinDetail.cpp
@@ -29,6 +29,8 @@ namespace Pins {
                        PinCapabilities::UART;
 
             case 5:
+            case 9:
+            case 10:
             case 16:
             case 17:
             case 18:
@@ -62,8 +64,6 @@ namespace Pins {
             case 6:  // SPI flash integrated
             case 7:
             case 8:
-            case 9:
-            case 10:
             case 11:
                 return PinCapabilities::Reserved;
 


### PR DESCRIPTION
Moves pins 9 and 10 to no longer be restricted due to being available on some ESP32 chips. 

Reference: #984