### PR TITLE
Change log level to verbose for TMC register dump

### DIFF
--- a/FluidNC/src/Motors/TMC2209Driver.cpp
+++ b/FluidNC/src/Motors/TMC2209Driver.cpp
@@ -80,13 +80,13 @@ namespace MotorDrivers {
         }
 
         // dump the registers. This is helpful for people migrating to the Pro version
-        log_debug("CHOPCONF: 0x" << to_hex(tmc2209->CHOPCONF()));
-        log_debug("COOLCONF: 0x" << to_hex(tmc2209->COOLCONF()));
-        log_debug("TPWMTHRS: 0x" << to_hex(tmc2209->TPWMTHRS()));
-        log_debug("TCOOLTHRS: 0x" << to_hex(tmc2209->TCOOLTHRS()));
-        log_debug("GCONF: 0x" << to_hex(tmc2209->GCONF()));
-        log_debug("PWMCONF: 0x" << to_hex(tmc2209->PWMCONF()));
-        log_debug("IHOLD_IRUN: 0x" << to_hex(tmc2209->IHOLD_IRUN()));
+        log_verbose("CHOPCONF: 0x" << to_hex(tmc2209->CHOPCONF()));
+        log_verbose("COOLCONF: 0x" << to_hex(tmc2209->COOLCONF()));
+        log_verbose("TPWMTHRS: 0x" << to_hex(tmc2209->TPWMTHRS()));
+        log_verbose("TCOOLTHRS: 0x" << to_hex(tmc2209->TCOOLTHRS()));
+        log_verbose("GCONF: 0x" << to_hex(tmc2209->GCONF()));
+        log_verbose("PWMCONF: 0x" << to_hex(tmc2209->PWMCONF()));
+        log_verbose("IHOLD_IRUN: 0x" << to_hex(tmc2209->IHOLD_IRUN()));
 
         _cs_pin.synchronousWrite(false);
     }

--- a/FluidNC/src/Motors/TMC5160Driver.cpp
+++ b/FluidNC/src/Motors/TMC5160Driver.cpp
@@ -80,13 +80,13 @@ namespace MotorDrivers {
                 }
         }
         // dump the registers. This is helpful for people migrating to the Pro version
-        log_debug("CHOPCONF: 0x" << to_hex(tmc5160->CHOPCONF()));
-        log_debug("COOLCONF: 0x" << to_hex(tmc5160->COOLCONF()));
-        log_debug("THIGH: 0x" << to_hex(tmc5160->THIGH()));
-        log_debug("TCOOLTHRS: 0x" << to_hex(tmc5160->TCOOLTHRS()));
-        log_debug("GCONF: 0x" << to_hex(tmc5160->GCONF()));
-        log_debug("PWMCONF: 0x" << to_hex(tmc5160->PWMCONF()));
-        log_debug("IHOLD_IRUN: 0x" << to_hex(tmc5160->IHOLD_IRUN()));
+        log_verbose("CHOPCONF: 0x" << to_hex(tmc5160->CHOPCONF()));
+        log_verbose("COOLCONF: 0x" << to_hex(tmc5160->COOLCONF()));
+        log_verbose("THIGH: 0x" << to_hex(tmc5160->THIGH()));
+        log_verbose("TCOOLTHRS: 0x" << to_hex(tmc5160->TCOOLTHRS()));
+        log_verbose("GCONF: 0x" << to_hex(tmc5160->GCONF()));
+        log_verbose("PWMCONF: 0x" << to_hex(tmc5160->PWMCONF()));
+        log_verbose("IHOLD_IRUN: 0x" << to_hex(tmc5160->IHOLD_IRUN()));
     }
 
     // Report diagnostic and tuning info


### PR DESCRIPTION
This makes it easier to use debug level for homing.