### PR TITLE
Fix #989 - treat empty pin specification like NO_PIN

### DIFF
--- a/FluidNC/src/Pin.cpp
+++ b/FluidNC/src/Pin.cpp
@@ -32,7 +32,7 @@ const char* Pin::parse(std::string_view pin_str, Pins::PinDetail*& pinImplementa
 
     if (pin_str.empty()) {
         // Re-use undefined pins happens in 'create':
-        pinImplementation = new Pins::VoidPinDetail();
+        pinImplementation = undefinedPin;
         return nullptr;
     }
 


### PR DESCRIPTION
An empty pin specification, e.g. "limit_all_pin: " with no arguments should be treated the same as "limit_all_pin: NO_PIN", but instead it creates a new VoidPin instead of undefinedPin.