### PR TITLE
Raising priority of i2s task prevents main task time-slicing in

### DIFF
--- a/FluidNC/src/I2SOut.cpp
+++ b/FluidNC/src/I2SOut.cpp
@@ -887,7 +887,7 @@ int i2s_out_init(i2s_out_init_t& init_param) {
                             "I2SOutTask",
                             4096,
                             NULL,
-                            1,
+                            2,
                             nullptr,
                             CONFIG_ARDUINO_RUNNING_CORE  // must run the task on same core
     );


### PR DESCRIPTION
Maybe too "inconsequential" but through instrumentation I determined that the main task can interrupt the i2sout task while it is running.  This happens about once per minute while motion is happening, or perhaps more.

I think this interruption is extremely unlikely to produce an observable effect, but in the worst case if the main task doesn't yield or block for a while, the i2sout task could stall by up to the timeslice interval, which I think is 1 ms.

I did an experiment where I raised the priority by one, and the interruptions never happened after that, and I saw no other effects.