### PR TITLE
Add an option to enable/disable SSDP and mDNS to save memory

### DIFF
--- a/FluidNC/src/WebUI/TelnetServer.cpp
+++ b/FluidNC/src/WebUI/TelnetServer.cpp
@@ -9,14 +9,14 @@
 #ifdef ENABLE_WIFI
 
 namespace WebUI {
-    TelnetServer telnetServer  __attribute__((init_priority(107))) ;
+    TelnetServer telnetServer __attribute__((init_priority(107)));
 }
 
 #    include "WifiServices.h"
 
 #    include "WifiConfig.h"
 #    include "../Report.h"  // report_init_message()
-#    include "Commands.h"   // COMMANDS
+#    include "Commands.h"  // COMMANDS
 
 #    include <WiFi.h>
 
@@ -50,7 +50,9 @@ namespace WebUI {
         _setupdone = true;
 
         //add mDNS
-        MDNS.addService("telnet", "tcp", _port);
+        if (WebUI::wifi_sta_ssdp->get() == SSDP_ENABLED) {
+            MDNS.addService("telnet", "tcp", _port);
+        }
 
         return no_error;
     }

--- a/FluidNC/src/WebUI/WebServer.cpp
+++ b/FluidNC/src/WebUI/WebServer.cpp
@@ -58,7 +58,7 @@ namespace WebUI {
 
     static const char LOCATION_HEADER[] = "Location";
 
-    Web_Server webServer __attribute__((init_priority(108))) ;
+    Web_Server webServer __attribute__((init_priority(108)));
     bool       Web_Server::_setupdone = false;
     uint16_t   Web_Server::_port      = 0;
 
@@ -159,7 +159,7 @@ namespace WebUI {
         }
 
         //SSDP service presentation
-        if (WiFi.getMode() == WIFI_STA) {
+        if (WiFi.getMode() == WIFI_STA && WebUI::wifi_sta_ssdp->get() == SSDP_ENABLED) {
             _webserver->on("/description.xml", HTTP_GET, handle_SSDP);
             //Add specific for SSDP
             SSDP.setSchemaURL("description.xml");
@@ -185,7 +185,7 @@ namespace WebUI {
         _webserver->begin();
 
         //add mDNS
-        if (WiFi.getMode() == WIFI_STA) {
+        if (WiFi.getMode() == WIFI_STA && WebUI::wifi_sta_ssdp->get() == SSDP_ENABLED) {
             MDNS.addService("http", "tcp", _port);
         }
 

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -141,8 +141,8 @@ namespace WebUI {
     };
 
     enum_opt_t staSsdpModeOptions = {
-        { "SSDP and mDNS Disabled", SSDP_DISABLED },
-        { "SSDP and mDNS Enabled", SSDP_ENABLED },
+        { "Enable", SSDP_ENABLED },
+        { "Disabled", SSDP_DISABLED },
     };
 
     static void print_mac(Channel& out, const char* prefix, const char* mac) { log_to(out, prefix, " (" << mac << ")"); }

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -8,17 +8,17 @@
 #include <sstream>
 #include <iomanip>
 
-WebUI::WiFiConfig wifi_config  __attribute__((init_priority(109))) ;
+WebUI::WiFiConfig wifi_config __attribute__((init_priority(109)));
 
 #ifdef ENABLE_WIFI
 #    include "../Config.h"
 #    include "../Main.h"
-#    include "Commands.h"      // COMMANDS
+#    include "Commands.h"  // COMMANDS
 #    include "WifiServices.h"  // wifi_services.start() etc.
-#    include "WebSettings.h"   // split_params(), get_params()
+#    include "WebSettings.h"  // split_params(), get_params()
 
-#    include "WebServer.h"             // webServer.port()
-#    include "TelnetServer.h"          // telnetServer
+#    include "WebServer.h"  // webServer.port()
+#    include "TelnetServer.h"  // telnetServer
 #    include "NotificationsService.h"  // notificationsservice
 
 #    include <WiFi.h>
@@ -114,6 +114,7 @@ namespace WebUI {
     IPaddrSetting* wifi_sta_ip;
     IPaddrSetting* wifi_sta_gateway;
     IPaddrSetting* wifi_sta_netmask;
+    EnumSetting*   wifi_sta_ssdp;
 
     StringSetting* wifi_ap_ssid;
     StringSetting* wifi_ap_password;
@@ -137,6 +138,11 @@ namespace WebUI {
         { "WPA2-PSK", WIFI_AUTH_WPA2_PSK },
         { "WPA-WPA2-PSK", WIFI_AUTH_WPA_WPA2_PSK },
         { "WPA2-ENTERPRISE", WIFI_AUTH_WPA2_ENTERPRISE },
+    };
+
+    enum_opt_t staSsdpModeOptions = {
+        { "SSDP and mDNS Disabled", SSDP_DISABLED },
+        { "SSDP and mDNS Enabled", SSDP_ENABLED },
     };
 
     static void print_mac(Channel& out, const char* prefix, const char* mac) { log_to(out, prefix, " (" << mac << ")"); }
@@ -339,6 +345,7 @@ namespace WebUI {
                                              (bool (*)(char*))WiFiConfig::isPasswordValid);
         wifi_ap_ssid = new StringSetting("AP SSID", WEBSET, WA, "ESP105", "AP/SSID", DEFAULT_AP_SSID, MIN_SSID_LENGTH, MAX_SSID_LENGTH, NULL);
         wifi_ap_country  = new EnumSetting("AP regulatory domain", WEBSET, WA, NULL, "AP/Country", WiFiCountry01, &wifiContryOptions, NULL);
+        wifi_sta_ssdp    = new EnumSetting("SSDP and mDNS", WEBSET, WA, NULL, "Sta/SSDP", DEFAULT_STA_SSDP_MODE, &staSsdpModeOptions, NULL);
         wifi_sta_netmask = new IPaddrSetting("Station Static Mask", WEBSET, WA, NULL, "Sta/Netmask", DEFAULT_STA_MK, NULL);
         wifi_sta_gateway = new IPaddrSetting("Station Static Gateway", WEBSET, WA, NULL, "Sta/Gateway", DEFAULT_STA_GW, NULL);
         wifi_sta_ip      = new IPaddrSetting("Station Static IP", WEBSET, WA, NULL, "Sta/IP", DEFAULT_STA_IP, NULL);

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -13,12 +13,12 @@ WebUI::WiFiConfig wifi_config __attribute__((init_priority(109)));
 #ifdef ENABLE_WIFI
 #    include "../Config.h"
 #    include "../Main.h"
-#    include "Commands.h"  // COMMANDS
-#    include "WifiServices.h"  // wifi_services.start() etc.
-#    include "WebSettings.h"  // split_params(), get_params()
+#    include "Commands.h"              // COMMANDS
+#    include "WifiServices.h"          // wifi_services.start() etc.
+#    include "WebSettings.h"           // split_params(), get_params()
 
-#    include "WebServer.h"  // webServer.port()
-#    include "TelnetServer.h"  // telnetServer
+#    include "WebServer.h"             // webServer.port()
+#    include "TelnetServer.h"          // telnetServer
 #    include "NotificationsService.h"  // notificationsservice
 
 #    include <WiFi.h>
@@ -145,7 +145,9 @@ namespace WebUI {
         { "Disabled", SSDP_DISABLED },
     };
 
-    static void print_mac(Channel& out, const char* prefix, const char* mac) { log_to(out, prefix, " (" << mac << ")"); }
+    static void print_mac(Channel& out, const char* prefix, const char* mac) {
+        log_to(out, prefix, " (" << mac << ")");
+    }
 
     static Error showIP(char* parameter, AuthenticationLevel auth_level, Channel& out) {  // ESP111
         log_to(out, parameter, IP_string(WiFi.getMode() == WIFI_STA ? WiFi.localIP() : WiFi.softAPIP()));
@@ -344,8 +346,9 @@ namespace WebUI {
                                              MAX_PASSWORD_LENGTH,
                                              (bool (*)(char*))WiFiConfig::isPasswordValid);
         wifi_ap_ssid = new StringSetting("AP SSID", WEBSET, WA, "ESP105", "AP/SSID", DEFAULT_AP_SSID, MIN_SSID_LENGTH, MAX_SSID_LENGTH, NULL);
-        wifi_ap_country  = new EnumSetting("AP regulatory domain", WEBSET, WA, NULL, "AP/Country", WiFiCountry01, &wifiContryOptions, NULL);
-        wifi_sta_ssdp    = new EnumSetting("SSDP and mDNS", WEBSET, WA, NULL, "Sta/SSDP", DEFAULT_STA_SSDP_MODE, &staSsdpModeOptions, NULL);
+        wifi_ap_country = new EnumSetting("AP regulatory domain", WEBSET, WA, NULL, "AP/Country", WiFiCountry01, &wifiContryOptions, NULL);
+        wifi_sta_ssdp =
+            new EnumSetting("SSDP and mDNS enable", WEBSET, WA, NULL, "Sta/SSDP/Enable", DEFAULT_STA_SSDP_MODE, &onoffOptions, NULL);
         wifi_sta_netmask = new IPaddrSetting("Station Static Mask", WEBSET, WA, NULL, "Sta/Netmask", DEFAULT_STA_MK, NULL);
         wifi_sta_gateway = new IPaddrSetting("Station Static Gateway", WEBSET, WA, NULL, "Sta/Gateway", DEFAULT_STA_GW, NULL);
         wifi_sta_ip      = new IPaddrSetting("Station Static IP", WEBSET, WA, NULL, "Sta/IP", DEFAULT_STA_IP, NULL);
@@ -784,7 +787,9 @@ namespace WebUI {
     /**
      * End WiFi
      */
-    void WiFiConfig::end() { StopWiFi(); }
+    void WiFiConfig::end() {
+        StopWiFi();
+    }
 
     /**
      * Reset ESP
@@ -804,12 +809,16 @@ namespace WebUI {
         }
         log_info("WiFi reset done");
     }
-    bool WiFiConfig::isOn() { return !(WiFi.getMode() == WIFI_MODE_NULL); }
+    bool WiFiConfig::isOn() {
+        return !(WiFi.getMode() == WIFI_MODE_NULL);
+    }
 
     /**
      * Handle not critical actions that must be done in sync environment
      */
-    void WiFiConfig::handle() { wifi_services.handle(); }
+    void WiFiConfig::handle() {
+        wifi_services.handle();
+    }
 
     // Used by js/scanwifidlg.js
     Error WiFiConfig::listAPs(char* parameter, AuthenticationLevel auth_level, Channel& out) {  // ESP410
@@ -823,7 +832,7 @@ namespace WebUI {
             case -2:                      // Scan not triggered
                 WiFi.scanNetworks(true);  // Begin async scan
                 break;
-            case -1:  // Scan in progress
+            case -1:                      // Scan in progress
                 break;
             default:
                 for (int i = 0; i < n; ++i) {
@@ -848,6 +857,8 @@ namespace WebUI {
         return Error::Ok;
     }
 
-    WiFiConfig::~WiFiConfig() { end(); }
+    WiFiConfig::~WiFiConfig() {
+        end();
+    }
 }
 #endif

--- a/FluidNC/src/WebUI/WifiConfig.h
+++ b/FluidNC/src/WebUI/WifiConfig.h
@@ -41,6 +41,9 @@ namespace WebUI {
     static const int DHCP_MODE   = 0;
     static const int STATIC_MODE = 1;
 
+    static const int SSDP_DISABLED = 0;
+    static const int SSDP_ENABLED  = 1;
+
     //defaults values
     static const char* DEFAULT_HOSTNAME   = "fluidnc";
     static const char* DEFAULT_STA_SSID   = "";
@@ -56,6 +59,7 @@ namespace WebUI {
 
     static const int   DEFAULT_STA_MIN_SECURITY = WIFI_AUTH_WPA2_PSK;
     static const int   DEFAULT_STA_IP_MODE      = DHCP_MODE;
+    static const int   DEFAULT_STA_SSDP_MODE    = SSDP_ENABLED;
     static const char* HIDDEN_PASSWORD          = "********";
 
     //boundaries
@@ -124,6 +128,7 @@ namespace WebUI {
     extern IPaddrSetting* wifi_sta_ip;
     extern IPaddrSetting* wifi_sta_gateway;
     extern IPaddrSetting* wifi_sta_netmask;
+    extern EnumSetting*   wifi_sta_ssdp;
 
     extern StringSetting* wifi_ap_ssid;
     extern StringSetting* wifi_ap_password;

--- a/FluidNC/src/WebUI/WifiServices.cpp
+++ b/FluidNC/src/WebUI/WifiServices.cpp
@@ -82,7 +82,7 @@ namespace WebUI {
             });
         ArduinoOTA.begin();
         //no need in AP mode
-        if (WiFi.getMode() == WIFI_STA) {
+        if (WiFi.getMode() == WIFI_STA && WebUI::wifi_sta_ssdp->get() == SSDP_ENABLED) {
             //start mDns
             const char* h = wifi_hostname->get();
             if (!MDNS.begin(h)) {


### PR DESCRIPTION
SSDP can momentarily use a considerable amount (11k at least) of heap.

This change adds an option (enabled by default, so no change to default behavior) to allow disabling of SSDP and mDNS for those who want to save memory and go by IP address only.