### PR TITLE
Fix reset from arc

### DIFF
--- a/FluidNC/src/Error.cpp
+++ b/FluidNC/src/Error.cpp
@@ -68,6 +68,7 @@ std::map<Error, const char*> ErrorNames = {
     { Error::AuthenticationFailed, "Authentication failed!" },
     { Error::Eol, "End of line" },
     { Error::Eof, "End of file" },
+    { Error::Reset, "System Reset" },
     { Error::AnotherInterfaceBusy, "Another interface is busy" },
     { Error::BadPinSpecification, "Bad Pin Specification" },
     { Error::JogCancelled, "Jog Cancelled" },

--- a/FluidNC/src/Error.h
+++ b/FluidNC/src/Error.h
@@ -72,6 +72,7 @@ enum class Error : uint8_t {
     AuthenticationFailed        = 110,
     Eol                         = 111,
     Eof                         = 112,  // Not necessarily an error
+    Reset                       = 113,
     AnotherInterfaceBusy        = 120,
     JogCancelled                = 130,
     BadPinSpecification         = 150,

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -1620,6 +1620,9 @@ Error gc_execute_line(char* line) {
             // As far as the parser is concerned, the position is now == target. In reality the
             // motion control system might still be processing the action and the real tool position
             // in any intermediate location.
+            if (sys.abort) {
+                return Error::Reset;
+            }
             if (gc_update_pos == GCUpdatePos::Target) {
                 copyAxes(gc_state.position, gc_block.values.xyz);
             } else if (gc_update_pos == GCUpdatePos::System) {


### PR DESCRIPTION
If an arc is in progress when a feedhold followed by a ctrl-x reset comes in, the next move after the reset is wrong.  For example:

G0 X0 Y0
G3 X0 Y0 I-100 J0 F500
!
CTRL-X
$J=G91 Z0.1 F100

Instead of the jog going only in the Z direction, there will be motion in X and Y too.  The problem is caused by incorrect synchronization of the GCode position after the aborted arc.  The code incorrectly sets the GCode position to the target of the arc, as if the arc had completed, instead of setting it to the actual position that existed at the time of the hold+reset.  (It is possible that the same problem might occur without the feedhold, only the reset.  In any case, this patch works in both scenarios.)