### PR TITLE
Added source URL to initial version INFO message

### DIFF
--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -49,7 +49,7 @@ void setup() {
         // Load settings from non-volatile storage
         settings_init();  // requires config
 
-        log_info("FluidNC " << git_info);
+        log_info("FluidNC " << git_info << " " << git_url);
         log_info("Compiled with ESP32 SDK:" << esp_get_idf_version());
 
         if (localfs_mount()) {

--- a/FluidNC/src/Report.h
+++ b/FluidNC/src/Report.h
@@ -92,6 +92,7 @@ const char* state_name();
 
 extern const char* grbl_version;
 extern const char* git_info;
+extern const char* git_url;
 
 // Callout to custom code
 void display_init();

--- a/git-version.py
+++ b/git-version.py
@@ -12,6 +12,7 @@ except:
 if gitFail:
     tag = "v3.0.x"
     rev = " (noGit)"
+    url = " (noGit)"
 else:
     try:
         tag = (
@@ -47,17 +48,24 @@ else:
             dirty = "-dirty"
         else:
             dirty = ""
-
         rev = " (%s-%s%s)" % (branchname, revision, dirty)
+
+    url = (
+        subprocess.check_output(["git", "config", "--get", "remote.origin.url"])
+            .strip()
+            .decode("utf-8")
+        )
 
 grbl_version = tag.replace('v','').rpartition('.')[0]
 git_info = '%s%s' % (tag, rev)
+git_url = url
 
 provisional = "FluidNC/src/version.cxx"
 final = "FluidNC/src/version.cpp"
 with open(provisional, "w") as fp:
     fp.write('const char* grbl_version = \"' + grbl_version + '\";\n')
     fp.write('const char* git_info     = \"' + git_info + '\";\n')
+    fp.write('const char* git_url      = \"' + git_url + '\";\n')
 
 if not os.path.exists(final):
     # No version.cpp so rename version.cxx to version.cpp


### PR DESCRIPTION
Now it looks like

[MSG:INFO: FluidNC v3.6.8 https://github.com/bdring/FluidNC.git]

The URL is determined from the git remote of the build tree