### PR TITLE
adds on_idle macro which allows chaining or looping gcode files

### DIFF
--- a/FluidNC/src/Machine/Macros.cpp
+++ b/FluidNC/src/Machine/Macros.cpp
@@ -20,6 +20,7 @@ Macro Macros::_macro[n_macros]               = { { "macro0" }, { "macro1" }, { "
 Macro Macros::_after_homing                  = { "after_homing" };
 Macro Macros::_after_reset                   = { "after_reset" };
 Macro Macros::_after_unlock                  = { "after_unlock" };
+Macro Macros::_on_idle                       = { "on_idle" };
 
 MacroEvent macro0Event { 0 };
 MacroEvent macro1Event { 1 };

--- a/FluidNC/src/Machine/Macros.h
+++ b/FluidNC/src/Machine/Macros.h
@@ -42,6 +42,7 @@ namespace Machine {
         static Macro _after_homing;
         static Macro _after_reset;
         static Macro _after_unlock;
+        static Macro _on_idle;
 
         Macros() = default;
 
@@ -59,6 +60,7 @@ namespace Machine {
             handler.item(_after_homing._name.c_str(), _after_homing._gcode);
             handler.item(_after_reset._name.c_str(), _after_reset._gcode);
             handler.item(_after_unlock._name.c_str(), _after_unlock._gcode);
+            handler.item(_on_idle._name.c_str(), _on_idle._gcode);
         }
 
         ~Macros() {}

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -779,8 +779,12 @@ void protocol_do_cycle_stop() {
                 sys.suspend.bit.holdComplete = true;
                 sys.state                    = State::SafetyDoor;
             } else {
+                State prev_state  = sys.state;
                 sys.suspend.value = 0;
                 sys.state         = State::Idle;
+                if (prev_state == State::Cycle) {
+                    config->_macros->_on_idle.run();
+                }
             }
             break;
         case State::Homing:


### PR DESCRIPTION
On transition to Idle when a job finishes, launch the on_idle macro.

A gcode file can assign the macro value to determine its successor, or set it blank if it is the last job in the chain.

This allows looping and chaining files together.