### PR TITLE
Fixed bug in JSONEncoder when trying to create a member whose value is an object

### DIFF
--- a/FluidNC/src/WebUI/JSONEncoder.cpp
+++ b/FluidNC/src/WebUI/JSONEncoder.cpp
@@ -149,6 +149,16 @@ namespace WebUI {
         add(']');
     }
 
+    // Begins the creation of a member whose value is an object.
+    // Call end_object() to close the member
+    void JSONencoder::begin_member_object(const char* tag) {
+        comma_line();
+        quoted(tag);
+        add(':');
+        add('{');
+        inc_level();
+    }
+
     // Starts an object with {.
     // If you need a named object you must call begin_member() first.
     void JSONencoder::begin_object() {

--- a/FluidNC/src/WebUI/JSONEncoder.h
+++ b/FluidNC/src/WebUI/JSONEncoder.h
@@ -22,6 +22,9 @@ namespace WebUI {
         void indent();
         void line();
 
+        // begin_member() starts the creation of a member.
+        void begin_member(const char* tag);
+
         std::string linebuf;
 
         std::string* _str     = nullptr;
@@ -58,10 +61,9 @@ namespace WebUI {
         // end_object() closes the object with }
         void end_object();
 
-        // begin_member() starts the creation of a member.
-        // The only case where you need to use it directly
-        // is when you want a member whose value is an object.
-        void begin_member(const char* tag);
+        // Begins the creation of a member whose value is an object.
+        // Call end_object() to close the member
+        void begin_member_object(const char* tag);
 
         // The begin_webui() methods are specific to Esp3D_WebUI
         // WebUI sends JSON objects to the UI to generate configuration


### PR DESCRIPTION
This fix addresses an issue in the JSONEncoder.

Currently, if you want to create JSON of the form:

```
{
    "data" : {
        "member" : "value"
    }
}
```

The expectation is to create it with code like this:

```
     JSONencoder j(true, &out);
     j.begin();
     j.begin_member("data");
     j.begin_object();
     j.member("member", "value");
     j.end_object();
     j.end();
```
However, this code currently creates JSON with an extra comma, making the output invalid, like this:

```
{
      "data" :, {
          "member" : "value"
      }
}
```

I added a new method called `begin_member_object()`. This method combines what `begin_member() ` and `begin_object()` did, but without the extraneous comma. The new way to create that JSON would be:

```
     JSONencoder j(true, &out);
     j.begin();
     j.begin_member_object("data");
     j.member("member", "value");
     j.end_object();
     j.end();
```

`begin_member()` was never directly called in the FluidNC code, so I made this method private as it only has use as it is used by the JSONEncoder itself. 

This also means that this has no effects on FluidNC currently, however this will come into play creating the more complex data structures required by WebUI 3.




