### PR TITLE
Fix Generation of JSON for boolean settings

### DIFF
--- a/FluidNC/src/Configuration/JsonGenerator.cpp
+++ b/FluidNC/src/Configuration/JsonGenerator.cpp
@@ -58,6 +58,8 @@ namespace Configuration {
         {
             _encoder.begin_object();
             _encoder.member("False", 0);
+            _encoder.end_object();
+            _encoder.begin_object();
             _encoder.member("True", 1);
             _encoder.end_object();
         }


### PR DESCRIPTION
FluidNC currently generates JSON options for boolean settings like /axes/x/homing/soft_limits such that the option values are serialized like this:

```
 {
    "F":"tree",
    "P":"/axes/x/soft_limits",
    "H":"/axes/x/soft_limits",
    "T":"B",
    "V":"0",
    "O": [
        {
            "False":"0",
            "True":"1"
        }
      ]
    },
```
WebUI 2.1 handles this fine, however, WebUI 3 requires this to be formatted correctly.

There are 2 other places in the code where "O" members are generated, and both of those other places handle this by putting each value option as a member of it's own object in JSON.

![image](https://github.com/bdring/FluidNC/assets/417561/79049827-ae4c-4b3f-97e2-97262026f7fd)

![image](https://github.com/bdring/FluidNC/assets/417561/6374910c-1697-4a94-9bc7-9d208e867f85)

This PR makes all 3 versions consistent, which makes it possible for the WebUI 3 settings page to work correctly. I tested with WebUI 2.1 and it also still works correctly. After this commit, the setting would come in as 

```
 {
    "F":"tree",
    "P":"/axes/x/soft_limits",
    "H":"/axes/x/soft_limits",
    "T":"B",
    "V":"0",
    "O": [
        {
            "False":"0"
        },
        {
            "True":"1"
        }
      ]
    },
```

I don't believe this should have an effect on the current version, but I wanted to put this in as a separate fix as I believe this may have been the original intent of the code, but it went unnoticed as the WebUI currently handles it.

I am not super familiar with the FluidNC codebase, though, so it would be good for someone else to also check this commit and make sure this doesn't affect anything outside of the WebUI.

