### PR TITLE
Change hidden password string to abide by minimum length

### DIFF
--- a/FluidNC/src/Settings.cpp
+++ b/FluidNC/src/Settings.cpp
@@ -262,10 +262,10 @@ static bool isPassword(bool (*_checker)(char*)) {
 
 const char* StringSetting::getDefaultString() {
     // If the string is a password do not display it
-    return (_checker && isPassword(_checker)) ? "******" : _defaultValue.c_str();
+    return (_checker && isPassword(_checker)) ? "********" : _defaultValue.c_str();
 }
 const char* StringSetting::getStringValue() {
-    return (_checker && isPassword(_checker)) ? "******" : get();
+    return (_checker && isPassword(_checker)) ? "********" : get();
 }
 
 void StringSetting::addWebui(WebUI::JSONencoder* j) {


### PR DESCRIPTION
For editing the WebUI, we currently send a string to hide passwords of length 6, "******".

WebUI 2 doesn't warn about min length constraints, but WebUI3 does.

![image](https://github.com/bdring/FluidNC/assets/417561/585b0195-63e2-4731-ac11-14b64718cf13)

This PR adds two asterisks to abide by the hardcoded length of 8, but in reality the better fix is to use the _minLength field and make sure the fake string meets the constraints.

I tried to do this with std::string(_minLength, '*') but I couldn't get it to end up correct on the web side, so I reverted back to hard-coded. It could just be my lack of C/C++ experience, so maybe someone can change it to something more robust using _minLength.