### PR TITLE
Fix #1051 - bad VFD UART validation and generation logic

### DIFF
--- a/FluidNC/src/Spindles/VFDSpindle.h
+++ b/FluidNC/src/Spindles/VFDSpindle.h
@@ -94,19 +94,8 @@ namespace Spindles {
         SpindleSpeed      _slop;
 
         // Configuration handlers:
-        void validate() override {
-            Spindle::validate();
-            Assert(_uart != nullptr || _uart_num != -1, "VFD: missing UART configuration");
-            Assert(!(_uart != nullptr && _uart_num != -1), "VFD: conflicting UART configuration");
-        }
-
-        void group(Configuration::HandlerBase& handler) override {
-            handler.section("uart", _uart, 1);
-            handler.item("uart_num", _uart_num);
-            handler.item("modbus_id", _modbus_id, 0, 247);  // per https://modbus.org/docs/PI_MBUS_300.pdf
-
-            Spindle::group(handler);
-        }
+        void validate() override;
+        void group(Configuration::HandlerBase& handler) override;
 
         virtual ~VFD() {}
     };


### PR DESCRIPTION
This fixes a problem whereby a tree validation triggered by a run-time modification to the tree would cause a false validation error in a VFD node.  It is an artifact of the two different ways of specifying the VFD UART - either as a subordinate uart: node or a uart_num: reference to an external uartN: section.

Testing revealed an additional problem that this patch also fixes.  The configuration generator (e.g. $cd) would generate an invalid node that specified both a uart: subsection and also a uart_num: line.