### PR TITLE
Cycle 0 and Macro Fixes

### DIFF
--- a/FluidNC/src/Machine/Axis.cpp
+++ b/FluidNC/src/Machine/Axis.cpp
@@ -45,7 +45,7 @@ namespace Machine {
                 m->init();
             }
         }
-        if (_homing->_cycle) {
+        if (_homing && _homing->_cycle != Machine::Homing::set_mpos_only) {
             _homing->init();
             set_bitnum(Axes::homingMask, _axis);
         }

--- a/FluidNC/src/Machine/Macros.cpp
+++ b/FluidNC/src/Machine/Macros.cpp
@@ -50,15 +50,15 @@ Cmd findOverride(std::string name) {
     return it == overrideCodes.end() ? Cmd::None : it->second;
 }
 
-bool Macro::run() {
-    if (sys.state != State::Idle) {
-        log_error("Macro can only be used in idle state");
+bool Macro::run() {  // return true if the macro was run
+    const std::string& s = _gcode;
+    if (_gcode == "") {
         return false;
     }
 
-    const std::string& s = _gcode;
-    if (_gcode == "") {
-        return true;
+    if (sys.state != State::Idle) {
+        log_error("Macro can only be used in idle state");
+        return false;
     }
 
     log_info("Running macro " << _name << ": " << _gcode);


### PR DESCRIPTION
- Homing cycle 0 was incorrectly running like -1 when run with $H<axis>
- Eliminated a needless macro error when the macro was empty.