### PR TITLE
Uart fixes

### DIFF
--- a/FluidNC/src/Channel.h
+++ b/FluidNC/src/Channel.h
@@ -50,6 +50,11 @@ protected:
     bool       _reportWco = true;
     CoordIndex _reportNgc = CoordIndex::End;
 
+    // Set this to false to suppress messages sent to AllChannels
+    // It is useful for IO Expanders that do not want to be spammed
+    // with chitchat
+    bool _all_messages = true;
+
 public:
     Channel(const char* name, bool addCR = false) : _name(name), _linelen(0), _addCR(addCR) {}
     virtual ~Channel() = default;
@@ -103,6 +108,8 @@ public:
     int peek() override { return -1; }
     int read() override { return -1; }
     int available() override { return _queue.size(); }
+
+    bool all_messages() { return _all_messages; }
 
     uint32_t     setReportInterval(uint32_t ms);
     uint32_t     getReportInterval() { return _reportInterval; }

--- a/FluidNC/src/Serial.cpp
+++ b/FluidNC/src/Serial.cpp
@@ -233,7 +233,9 @@ void AllChannels::flushRx() {
 size_t AllChannels::write(uint8_t data) {
     _mutex_general.lock();
     for (auto channel : _channelq) {
-        channel->write(data);
+        if (channel->all_messages()) {
+            channel->write(data);
+        }
     }
     _mutex_general.unlock();
     return 1;
@@ -264,7 +266,9 @@ void AllChannels::stopJob() {
 size_t AllChannels::write(const uint8_t* buffer, size_t length) {
     _mutex_general.lock();
     for (auto channel : _channelq) {
-        channel->write(buffer, length);
+        if (channel->all_messages()) {
+            channel->write(buffer, length);
+        }
     }
     _mutex_general.unlock();
     return length;

--- a/FluidNC/src/Uart.cpp
+++ b/FluidNC/src/Uart.cpp
@@ -20,6 +20,7 @@ static void uart_driver_n_install(void* arg) {
 void Uart::begin(unsigned long baud, UartData dataBits, UartStop stopBits, UartParity parity) {
     //    uart_driver_delete(_uart_num);
     uart_config_t conf;
+    conf.source_clk          = UART_SCLK_APB;
     conf.baud_rate           = baud;
     conf.data_bits           = uart_word_length_t(_dataBits);
     conf.parity              = uart_parity_t(_parity);

--- a/FluidNC/src/UartChannel.h
+++ b/FluidNC/src/UartChannel.h
@@ -43,6 +43,7 @@ public:
     void group(Configuration::HandlerBase& handler) override {
         handler.item("uart_num", _uart_num);
         handler.item("report_interval_ms", _report_interval_ms, 0, 5000);
+        handler.item("all_messages", _all_messages);
     }
 };
 


### PR DESCRIPTION
1. Fixed baud rate inaccuracy due to uninitialized config field
2. Add all_messages: config item for uart channels, default true, to suppress chitchat on IO Expanders