### PR TITLE
fixes "Toolsetter Pin" init-messages

### DIFF
--- a/FluidNC/src/Probe.cpp
+++ b/FluidNC/src/Probe.cpp
@@ -8,14 +8,13 @@
 
 // Probe pin initialization routine.
 void Probe::init() {
-    static bool show_init_msg = true;  // used to show message only once.
+    static bool show_init_msg = true;  // used to show messages only once.
 
     if (_probePin.defined()) {
         _probePin.setAttr(Pin::Attr::Input);
 
         if (show_init_msg) {
             _probePin.report("Probe Pin:");
-            show_init_msg = false;
         }
     }
 


### PR DESCRIPTION
The info [message](https://github.com/bdring/FluidNC/blob/09fd57261d65e2bf7d60834c7f3af60a2e0c569f/FluidNC/src/Probe.cpp#L28) for the toolsetter pin is never displayed if the [message](https://github.com/bdring/FluidNC/blob/09fd57261d65e2bf7d60834c7f3af60a2e0c569f/FluidNC/src/Probe.cpp#L18) for the probe pin is displayed.

The issue is caused by a redundant show_init_msg = false; in [L19](https://github.com/bdring/FluidNC/blob/09fd57261d65e2bf7d60834c7f3af60a2e0c569f/FluidNC/src/Probe.cpp#L19)

This PR removed the duplicate.