### PR TITLE
Added oled flip and mirror config parameters

### DIFF
--- a/FluidNC/src/OLED.cpp
+++ b/FluidNC/src/OLED.cpp
@@ -71,7 +71,12 @@ void OLED::init() {
     _oled = new SSD1306_I2C(_address, _geometry, config->_i2c[_i2c_num], 400000);
     _oled->init();
 
-    _oled->flipScreenVertically();
+    if (_flip) {
+        _oled->flipScreenVertically();
+    }
+    if (_mirror) {
+        _oled->mirrorScreen();
+    }
     _oled->setTextAlignment(TEXT_ALIGN_LEFT);
 
     _oled->clear();

--- a/FluidNC/src/OLED.h
+++ b/FluidNC/src/OLED.h
@@ -97,8 +97,8 @@ public:
     uint8_t _address = 0x3c;
     int     _width   = 64;
     int     _height  = 48;
-    int     _flip    = 1;
-    int     _mirror  = 0;
+    bool     _flip    = true;
+    bool     _mirror  = false;
 
     // Channel method overrides
 

--- a/FluidNC/src/OLED.h
+++ b/FluidNC/src/OLED.h
@@ -97,6 +97,8 @@ public:
     uint8_t _address = 0x3c;
     int     _width   = 64;
     int     _height  = 48;
+    int     _flip    = 1;
+    int     _mirror  = 0;
 
     // Channel method overrides
 
@@ -122,6 +124,8 @@ public:
         handler.item("i2c_address", _address);
         handler.item("width", _width);
         handler.item("height", _height);
+        handler.item("flip", _flip);
+        handler.item("mirror", _mirror);
         handler.item("radio_delay_ms", _radio_delay);
     }
 };


### PR DESCRIPTION
I built my own OLED shield on perfboard, and sure enough, it was the wrong orientation for my enclosure.  So I added config options to expose the OLED's flip and mirror methods.  Works on my 6 pack external driver system.