### PR TITLE
Fix #1170 - broken fallback web page

### DIFF
--- a/FluidNC/src/WebUI/WebServer.cpp
+++ b/FluidNC/src/WebUI/WebServer.cpp
@@ -482,7 +482,14 @@ namespace WebUI {
             return;
         }
         if (_webserver->hasArg("commandText")) {
-            websocketCommand(_webserver->arg("commandText").c_str(), getPageid(), auth_level);
+            auto cmd = _webserver->arg("commandText");
+            if (cmd.startsWith("[ESP")) {
+                // [ESPXXX] commands expect data in the HTTP response
+                // Only the fallback web page uses commandText with [ESPxxx]
+                synchronousCommand(cmd.c_str(), silent, auth_level);
+            } else {
+                websocketCommand(_webserver->arg("commandText").c_str(), getPageid(), auth_level);
+            }
             return;
         }
         _webserver->send(500, "text/plain", "Invalid command");


### PR DESCRIPTION
Adds a synchronous response to "commandText=" URIs with [ESPxxx] commands, for the benefit of the fallback web page.