### PR TITLE
Event probe

### DIFF
--- a/FluidNC/data/taig_probe.flnc
+++ b/FluidNC/data/taig_probe.flnc
@@ -1,0 +1,93 @@
+name: "Taig Mill"
+board: "Gecko Blaster v1 M2"
+
+use_line_numbers: true
+
+stepping:
+  engine: RMT
+  idle_ms: 255
+  dir_delay_us: 4
+  pulse_us: 4
+  disable_delay_us: 0
+
+start:
+  must_home: false
+
+spi:
+  miso_pin: gpio.19
+  mosi_pin: gpio.23
+  sck_pin: gpio.18
+
+sdcard:
+  cs_pin: gpio.5
+  card_detect_pin: NO_PIN
+  frequency_hz: 4000000
+
+# uart1:
+#   txd_pin: gpio.16
+#   rxd_pin: gpio.0
+#   rts_pin: NO_PIN
+#   cts_pin: NO_PIN
+#   baud: 5000000
+#   mode: 8N1
+# 
+# uart_channel1:
+#   report_interval_ms: 200
+#   uart_num: 1
+#   message_level: 0
+
+probe:
+   pin: gpio.0:low:pu
+
+axes:
+  x:
+    # 1600 steps/rev * 20 revs/in * 1/25.4 mm/in = 1259.84252 steps/mm
+    steps_per_mm: 1259.8425
+    max_rate_mm_per_min: 1000
+    acceleration_mm_per_sec2: 100
+    max_travel_mm: 300
+    
+    motor0:
+      standard_stepper:
+        direction_pin: gpio.25
+        step_pin: gpio.27
+
+  y:
+    # 1600 steps/rev * 20 revs/in * 1/25.4 mm/in = 1259.84252 steps/mm
+    steps_per_mm: 1259.8425
+    max_rate_mm_per_min: 1000
+    acceleration_mm_per_sec2: 100
+    max_travel_mm: 127
+
+    motor0:
+      standard_stepper:
+        direction_pin: gpio.15
+        step_pin: gpio.32
+
+  z:
+    # 3200 steps/rev * 20 revs/in * 1/25.4 mm/in = 2518.g9 steps/mm
+    steps_per_mm: 2518.69
+    max_rate_mm_per_min: 600
+    acceleration_mm_per_sec2: 25
+    max_travel_mm: 100
+
+    motor0:
+      standard_stepper:
+        direction_pin: gpio.14
+        step_pin: gpio.17
+
+i2c0:
+   sda_pin: gpio.21
+   scl_pin: gpio.22
+        
+oled:
+   i2c_num: 0
+   i2c_address: 60
+   width: 64
+   height: 48
+   radio_delay_ms: 500
+
+macros:
+   startup_line0: g20
+   after_reset: g20
+   after_unlock: g20

--- a/FluidNC/src/Channel.cpp
+++ b/FluidNC/src/Channel.cpp
@@ -103,18 +103,18 @@ void Channel::autoReportGCodeState() {
 }
 void Channel::autoReport() {
     if (_reportInterval) {
-        auto probeState = config->_probe->get_state();
-        if (probeState != _lastProbe) {
+        auto thisProbeState = config->_probe->get_state();
+        if (thisProbeState != _lastProbe) {
             report_recompute_pin_string();
         }
-        if (_reportWco || sys.state != _lastState || probeState != _lastProbe || _lastPinString != report_pin_string ||
+        if (_reportWco || sys.state != _lastState || thisProbeState != _lastProbe || _lastPinString != report_pin_string ||
             (motionState() && (int32_t(xTaskGetTickCount()) - _nextReportTime) >= 0)) {
             if (_reportWco) {
                 report_wco_counter = 0;
             }
             _reportWco     = false;
             _lastState     = sys.state;
-            _lastProbe     = probeState;
+            _lastProbe     = thisProbeState;
             _lastPinString = report_pin_string;
 
             _nextReportTime = xTaskGetTickCount() + _reportInterval;

--- a/FluidNC/src/Machine/EventPin.h
+++ b/FluidNC/src/Machine/EventPin.h
@@ -14,7 +14,7 @@ public:
 
     virtual void update(bool state) {};
 
-    void trigger(bool active);
+    virtual void trigger(bool active);
 
     ~EventPin() {}
 };

--- a/FluidNC/src/Machine/ProbeEventPin.cpp
+++ b/FluidNC/src/Machine/ProbeEventPin.cpp
@@ -1,0 +1,24 @@
+#if 0
+#include "src/Machine/ProbeEventPin.h"
+#include "src/Machine/MachineConfig.h"  // config
+
+#include "src/Protocol.h"  // protocol_send_event_from_ISR()
+
+namespace Machine {
+    ProbeEventPin::ProbeEventPin(const char* legend, Pin& pin) :
+        EventPin(&probeEvent, legend), _pin(&pin) {}
+
+    void ProbeEventPin::init() {
+        if (_pin->undefined()) {
+            return;
+        }
+        _value = _pin->read();
+        _pin->report(_legend);
+        _pin->setAttr(Pin::Attr::Input);
+        _pin->registerEvent(static_cast<EventPin*>(this));
+    }
+    void ProbeEventPin::update(bool state) { _value = state; }
+    bool ProbeEventPin::get() { return _value; }
+
+}
+#endif

--- a/FluidNC/src/Machine/ProbeEventPin.cpp
+++ b/FluidNC/src/Machine/ProbeEventPin.cpp
@@ -5,20 +5,6 @@
 #include "src/Protocol.h"  // protocol_send_event_from_ISR()
 
 namespace Machine {
-    ProbeEventPin::ProbeEventPin(const char* legend, Pin& pin) :
-        EventPin(&probeEvent, legend), _pin(&pin) {}
-
-    void ProbeEventPin::init() {
-        if (_pin->undefined()) {
-            return;
-        }
-        _value = _pin->read();
-        _pin->report(_legend);
-        _pin->setAttr(Pin::Attr::Input);
-        _pin->registerEvent(static_cast<EventPin*>(this));
-    }
-    void ProbeEventPin::update(bool state) { _value = state; }
-    bool ProbeEventPin::get() { return _value; }
 
 }
 #endif

--- a/FluidNC/src/Machine/ProbeEventPin.h
+++ b/FluidNC/src/Machine/ProbeEventPin.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "EventPin.h"
+#include "../Pin.h"
+namespace Machine {
+    class ProbeEventPin : public EventPin {
+    private:
+        bool _value = 0;
+        Pin* _pin = nullptr;
+
+    public:
+        ProbeEventPin(const char* legend, Pin& pin);
+
+        void init();
+        void update(bool state) override;
+        bool get();
+    };
+}

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -328,7 +328,7 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, bool away, 
     // Set state variables and error out, if the probe failed and cycle with error is enabled.
     if (probeState == ProbeState::Active) {
         if (no_error) {
-            copyAxes(probe_steps, get_motor_steps());
+            get_motor_steps(probe_steps);
         } else {
             send_alarm(ExecAlarm::ProbeFailContact);
         }

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -274,7 +274,7 @@ bool mc_dwell(int32_t milliseconds) {
     return delay_msec(milliseconds, DwellMode::Dwell);
 }
 
-volatile ProbeState probeState;
+volatile bool probing;
 
 bool probe_succeeded = false;
 
@@ -310,8 +310,9 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, bool away, 
     }
     // Setup and queue probing motion. Auto cycle-start should not start the cycle.
     mc_linear(target, pl_data, gc_state.position);
+    printf("Target %f\n", target[2]);
     // Activate the probing state monitor in the stepper module.
-    probeState = ProbeState::Active;
+    probing = true;
     // Perform probing cycle. Wait here until probe is triggered or motion completes.
     protocol_send_event(&cycleStartEvent);
     do {
@@ -326,7 +327,7 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, bool away, 
 
     // Probing cycle complete!
     // Set state variables and error out, if the probe failed and cycle with error is enabled.
-    if (probeState == ProbeState::Active) {
+    if (probing) {
         if (no_error) {
             get_motor_steps(probe_steps);
         } else {
@@ -335,7 +336,7 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, bool away, 
     } else {
         probe_succeeded = true;  // Indicate to system the probing cycle completed successfully.
     }
-    probeState = ProbeState::Off;  // Ensure probe state monitor is disabled.
+    probing = false;  // Ensure probe state monitor is disabled.
     protocol_execute_realtime();   // Check and execute run-time commands
     // Reset the stepper and planner buffers to remove the remainder of the probe motion.
     Stepper::reset();      // Reset step segment buffer.

--- a/FluidNC/src/MotionControl.h
+++ b/FluidNC/src/MotionControl.h
@@ -12,7 +12,7 @@
 
 #include <cstdint>
 
-extern volatile ProbeState probeState;  // Probing state value.  Used to coordinate the probing cycle with stepper ISR.
+extern volatile bool probing;  // Probing state value.  Used to coordinate the probing cycle with stepper ISR.
 
 extern bool probe_succeeded;  // Tracks if last probing cycle was successful.
 

--- a/FluidNC/src/Planner.cpp
+++ b/FluidNC/src/Planner.cpp
@@ -307,7 +307,7 @@ bool plan_buffer_line(float* target, plan_line_data_t* pl_data) {
     float   unit_vec[MAX_N_AXIS], delta_mm;
     // Copy position data based on type of motion being planned.
     if (block->motion.systemMotion) {
-        copyAxes(position_steps, get_motor_steps());
+        get_motor_steps(position_steps);
     } else {
         if (!block->is_jog && Homing::unhomed_axes()) {
             log_info("Unhomed axes: " << config->_axes->maskToNames(Homing::unhomed_axes()));
@@ -426,7 +426,7 @@ void plan_sync_position() {
     // TODO: For motor configurations not in the same coordinate frame as the machine position,
     // this function needs to be updated to accomodate the difference.
     if (config->_axes) {
-        copyAxes(pl.position, get_motor_steps());
+        get_motor_steps(pl.position);
     }
 }
 

--- a/FluidNC/src/Probe.cpp
+++ b/FluidNC/src/Probe.cpp
@@ -4,72 +4,67 @@
 
 #include "Probe.h"
 #include "Pin.h"
+#include "Machine/EventPin.h"
+#include "Machine/MachineConfig.h"
+
+extern void protocol_do_probe(void* arg);
+ArgEvent probeEvent { protocol_do_probe };
+
+class ProbeEventPin : public EventPin {
+private:
+    bool _value = 0;
+    Pin* _pin = nullptr;
+
+public:
+    ProbeEventPin(const char* legend, Pin& pin) :
+        EventPin(&probeEvent, legend), _pin(&pin) {}
+
+    void init() {
+        if (_pin->undefined()) {
+            return;
+        }
+        _value = _pin->read();
+        _pin->report(_legend);
+        _pin->setAttr(Pin::Attr::Input);
+        _pin->registerEvent(static_cast<EventPin*>(this));
+    }
+    void update(bool state) { _value = state; }
+
+    // Differs from the base class version by sending the event on either edge
+    void trigger(bool active) override {
+        update(active);
+        protocol_send_event(_event, this);
+        report_recompute_pin_string();
+    }
+
+    bool get() { return _value; }
+};
 
 // Probe pin initialization routine.
 void Probe::init() {
     if (_probePin.defined()) {
-        try {
-            _probePin.getNative(Pin::Capabilities::Input | Pin::Capabilities::Native);
-            _probe_is_native = true;
-        } catch (...) { _probe_is_native = false; }
-
         _probeEventPin = new ProbeEventPin("Probe", _probePin);
         _probeEventPin->init();
     }
 
     if (_toolsetterPin.defined()) {
-        _toolsetterPin.getNative(Pin::Capabilities::Input | Pin::Capabilities::Native);
-        _toolsetter_is_native = true;
+        _toolsetterEventPin = new ProbeEventPin("Toolsetter", _toolsetterPin);
+        _toolsetterEventPin->init();
     }
-    try {
-            _toolsetterPin.getNative(Pin::Capabilities::Input | Pin::Capabilities::Native);
-            _toolsetter_is_native = true;
-        } catch (...) {
-        _toolsetter_is_native = false;
-    }
-    _toolsetterPin.getNative(Pin::Capabilities::Input | Pin::Capabilities::Native);
-
-    _toolsetterEventPin = new ProbeEventPin("Toolsetter", _toolsetterPin);
-    _toolsetterEventPin->init();
-
 }
 
-void Probe::set_direction(bool is_away) {
-    _isProbeAway = is_away;
+void Probe::set_direction(bool away) {
+    _away = away;
 }
 
 // Returns the probe pin state. Triggered = true. Called by gcode parser.
 bool Probe::get_state() {
-    // This is time-critical when called from the stepper IRQ so
-    // we go to a lot of trouble to optimize the case where we
-    // read the GPIOs directly
-    // But we might be screwed by the vtable of EventPin
-    if (_probe_is_native) {
-        if (_probePin.read()) {
-            return true;
-        }
-        if (_toolsetter_is_native) {
-            return _toolsetterPin.read();
-        }
-        // Native probe pin was inactive
-        return _toolsetterEventPin && _toolsetterEventPin->get();
-    }
-    if (_toolsetter_is_native) {
-        if (_toolsetterPin.read()) {
-            return true;
-        }
-        // Native toolsetter pin was inactive
-        return _probeEventPin && _probeEventPin->get();
-    }
-    // Neither probe nor toolsetter was native so we must use the Event pins
     return ((_probeEventPin && _probeEventPin->get()) || (_toolsetterEventPin && _toolsetterEventPin->get()));
 }
 
 // Returns true if the probe pin is tripped, accounting for the direction (away or not).
-// This function must be extremely efficient as to not bog down the stepper ISR.
-// Should be called only in situations where the probe pin is known to be defined.
-bool IRAM_ATTR Probe::tripped() {
-    return get_state() ^ _isProbeAway;
+bool Probe::tripped() {
+    return get_state() ^ _away;
 }
 
 void Probe::validate() {}
@@ -78,4 +73,19 @@ void Probe::group(Configuration::HandlerBase& handler) {
     handler.item("pin", _probePin);
     handler.item("toolsetter_pin", _toolsetterPin);
     handler.item("check_mode_start", _check_mode_start);
+    handler.item("hard_stop", _hard_stop);
+}
+void protocol_do_probe(void* arg) {
+    Probe* p =config->_probe;
+    if (p->tripped() && probing) {
+        probing = false;
+        get_motor_steps(probe_steps);
+        if (p->_hard_stop) {
+            Stepper::reset();
+            plan_reset();
+            sys.state = State::Idle;
+        } else {
+            protocol_do_motion_cancel();
+        }
+    }
 }

--- a/FluidNC/src/Probe.cpp
+++ b/FluidNC/src/Probe.cpp
@@ -12,7 +12,7 @@ ArgEvent probeEvent { protocol_do_probe };
 
 class ProbeEventPin : public EventPin {
 private:
-    bool _value = 0;
+    bool _value = false;
     Pin* _pin = nullptr;
 
 public:
@@ -27,6 +27,7 @@ public:
         _pin->report(_legend);
         _pin->setAttr(Pin::Attr::Input);
         _pin->registerEvent(static_cast<EventPin*>(this));
+        update(_pin->read());
     }
     void update(bool state) { _value = state; }
 

--- a/FluidNC/src/Probe.h
+++ b/FluidNC/src/Probe.h
@@ -6,8 +6,11 @@
 
 #include "Configuration/HandlerBase.h"
 #include "Configuration/Configurable.h"
+#include "Machine/ProbeEventPin.h"
 
 #include <cstdint>
+
+using namespace Machine;
 
 // Values that define the probing state machine.
 enum class ProbeState : uint8_t {
@@ -18,10 +21,10 @@ enum class ProbeState : uint8_t {
 class Probe : public Configuration::Configurable {
     // Inverts the probe pin state depending on user settings and probing cycle mode.
     bool _isProbeAway = false;
-
-    // Configurable
-    Pin _probePin;
-    Pin _toolsetter_Pin;
+    ProbeEventPin* _probeEventPin;
+    ProbeEventPin* _toolsetterEventPin;
+    bool _probe_is_native = false;
+    bool _toolsetter_is_native = false;
 
 public:
     // Configurable
@@ -32,7 +35,11 @@ public:
 
     Probe() = default;
 
-    bool exists() const { return _probePin.defined() || _toolsetter_Pin.defined(); }
+    // Configurable
+    Pin _probePin;
+    Pin _toolsetterPin;
+
+    bool exists() const { return _probePin.defined() || _toolsetterPin.defined(); }
     // Probe pin initialization routine.
     void init();
 

--- a/FluidNC/src/Probe.h
+++ b/FluidNC/src/Probe.h
@@ -6,27 +6,18 @@
 
 #include "Configuration/HandlerBase.h"
 #include "Configuration/Configurable.h"
-#include "Machine/ProbeEventPin.h"
 
 #include <cstdint>
-
-using namespace Machine;
-
-// Values that define the probing state machine.
-enum class ProbeState : uint8_t {
-    Off    = 0,  // Probing disabled or not in use. (Must be zero.)
-    Active = 1,  // Actively watching the input pin.
-};
+class ProbeEventPin;
 
 class Probe : public Configuration::Configurable {
     // Inverts the probe pin state depending on user settings and probing cycle mode.
-    bool _isProbeAway = false;
+    bool _away = false;
     ProbeEventPin* _probeEventPin;
     ProbeEventPin* _toolsetterEventPin;
-    bool _probe_is_native = false;
-    bool _toolsetter_is_native = false;
 
 public:
+    bool _hard_stop = false;
     // Configurable
     bool _check_mode_start = true;
     // _check_mode_start configures the position after a probing cycle
@@ -44,7 +35,7 @@ public:
     void init();
 
     // setup probing direction G38.2 vs. G38.4
-    void set_direction(bool is_away);
+    void set_direction(bool away);
 
     // Returns probe pin state. Triggered = true. Called by gcode parser and probe state monitor.
     bool get_state();

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -72,7 +72,7 @@ union SpindleStop {
 static SpindleStop spindle_stop_ovr;
 
 void protocol_reset() {
-    probeState             = ProbeState::Off;
+    probing = false;
     soft_limit             = false;
     rtSafetyDoor           = false;
     spindle_stop_ovr.value = 0;
@@ -413,7 +413,7 @@ static void protocol_hold_complete() {
     sys.suspend.bit.holdComplete = true;
 }
 
-static void protocol_do_motion_cancel() {
+void protocol_do_motion_cancel() {
     // log_debug("protocol_do_motion_cancel " << state_name());
     // Execute and flag a motion cancel with deceleration and return to idle. Used primarily by probing cycle
     // to halt and cancel the remainder of the motion.
@@ -986,14 +986,6 @@ static void protocol_do_accessory_override(void* type) {
     }
 }
 
-static void protocol_do_probe(void* arg) {
-    if (probeState == ProbeState::Active) {
-        probeState = ProbeState::Off;
-        get_motor_steps(probe_steps);
-        protocol_do_motion_cancel();
-    }
-}
-
 static void protocol_do_limit(void* arg) {
     Machine::LimitPin* limit = (Machine::LimitPin*)arg;
     if (sys.state == State::Homing) {
@@ -1040,7 +1032,6 @@ ArgEvent spindleOverrideEvent { protocol_do_spindle_override };
 ArgEvent accessoryOverrideEvent { protocol_do_accessory_override };
 ArgEvent limitEvent { protocol_do_limit };
 ArgEvent faultPinEvent { protocol_do_fault_pin };
-ArgEvent probeEvent { protocol_do_probe };
 ArgEvent reportStatusEvent { (void (*)(void*))report_realtime_status };
 
 NoArgEvent safetyDoorEvent { request_safety_door };

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -986,6 +986,14 @@ static void protocol_do_accessory_override(void* type) {
     }
 }
 
+static void protocol_do_probe(void* arg) {
+    if (probeState == ProbeState::Active) {
+        probeState = ProbeState::Off;
+        get_motor_steps(probe_steps);
+        protocol_do_motion_cancel();
+    }
+}
+
 static void protocol_do_limit(void* arg) {
     Machine::LimitPin* limit = (Machine::LimitPin*)arg;
     if (sys.state == State::Homing) {
@@ -1032,7 +1040,7 @@ ArgEvent spindleOverrideEvent { protocol_do_spindle_override };
 ArgEvent accessoryOverrideEvent { protocol_do_accessory_override };
 ArgEvent limitEvent { protocol_do_limit };
 ArgEvent faultPinEvent { protocol_do_fault_pin };
-
+ArgEvent probeEvent { protocol_do_probe };
 ArgEvent reportStatusEvent { (void (*)(void*))report_realtime_status };
 
 NoArgEvent safetyDoorEvent { request_safety_door };

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -44,6 +44,8 @@ void protocol_buffer_synchronize();
 void protocol_disable_steppers();
 void protocol_cancel_disable_steppers();
 
+void protocol_do_motion_cancel();
+
 extern volatile bool rtCycleStop;
 
 extern volatile bool runLimitLoop;
@@ -87,7 +89,6 @@ extern ArgEvent rapidOverrideEvent;
 extern ArgEvent spindleOverrideEvent;
 extern ArgEvent accessoryOverrideEvent;
 extern ArgEvent limitEvent;
-extern ArgEvent probeEvent;
 extern ArgEvent faultPinEvent;
 
 extern ArgEvent reportStatusEvent;

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -87,6 +87,7 @@ extern ArgEvent rapidOverrideEvent;
 extern ArgEvent spindleOverrideEvent;
 extern ArgEvent accessoryOverrideEvent;
 extern ArgEvent limitEvent;
+extern ArgEvent probeEvent;
 extern ArgEvent faultPinEvent;
 
 extern ArgEvent reportStatusEvent;

--- a/FluidNC/src/Stepper.cpp
+++ b/FluidNC/src/Stepper.cpp
@@ -249,8 +249,8 @@ bool IRAM_ATTR Stepper::pulse_func() {
     }
 #if 0
     // Check probing state.
-    if (probeState == ProbeState::Active && config->_probe->tripped()) {
-        probeState = ProbeState::Off;
+    if (probing && config->_probe->tripped()) {
+        probing = false;
         auto axes  = config->_axes;
         for (int axis = 0; axis < n_axis; axis++) {
             auto m            = axes->_axis[axis]->_motors[0];

--- a/FluidNC/src/Stepper.cpp
+++ b/FluidNC/src/Stepper.cpp
@@ -247,7 +247,7 @@ bool IRAM_ATTR Stepper::pulse_func() {
             return false;  // Nothing to do but exit.
         }
     }
-
+#if 0
     // Check probing state.
     if (probeState == ProbeState::Active && config->_probe->tripped()) {
         probeState = ProbeState::Off;
@@ -258,7 +258,7 @@ bool IRAM_ATTR Stepper::pulse_func() {
         }
         protocol_send_event_from_ISR(&motionCancelEvent);
     }
-
+#endif
     // Reset step out bits.
     st.step_outbits = 0;
 

--- a/FluidNC/src/System.cpp
+++ b/FluidNC/src/System.cpp
@@ -74,15 +74,19 @@ int32_t get_axis_motor_steps(size_t axis) {
     return m ? m->_steps : 0;
 }
 
-int32_t* get_motor_steps() {
-    static int32_t motor_steps[MAX_N_AXIS];
-
+void get_motor_steps(int32_t* motor_steps) {
     auto axes   = config->_axes;
     auto n_axis = axes->_numberAxis;
     for (size_t axis = 0; axis < n_axis; axis++) {
         auto m            = axes->_axis[axis]->_motors[0];
         motor_steps[axis] = m ? m->_steps : 0;
     }
+
+}
+int32_t* get_motor_steps() {
+    static int32_t motor_steps[MAX_N_AXIS];
+
+    get_motor_steps(motor_steps);
     return motor_steps;
 }
 

--- a/FluidNC/src/System.h
+++ b/FluidNC/src/System.h
@@ -65,6 +65,7 @@ int32_t  get_axis_motor_steps(size_t axis);
 void     set_motor_steps(size_t axis, int32_t steps);
 void     set_motor_steps_from_mpos(float* mpos);
 int32_t* get_motor_steps();
+void     get_motor_steps(int32_t* steps);
 
 // Updates a machine position array from a steps array
 void motor_steps_to_mpos(float* position, int32_t* steps);


### PR DESCRIPTION
Use the event mechanism for probes instead of direct gpio polling.

Also added boolean /probe/hard_stop config item, default false, to control whether to decelerate (false) or just quit stepping (true) when the probe triggers.  hard_stop is intended for rigid probes where deceleration is dodgy due to the probe preventing further motion.