### PR TITLE
define EnumItem data types as const

### DIFF
--- a/FluidNC/esp32/gpio.cpp
+++ b/FluidNC/esp32/gpio.cpp
@@ -205,7 +205,7 @@ struct pin_mux {
     int         pinnum;
     const char* pinname;
     const char* functions[6];
-} pins[] = {
+} const pins[] = {
     { 0, "GPIO0", { "GPIO0", "CLK_OUT1", "GPIO0", "-", "-", "EMAC_TX_CLK" } },
     { 1, "U0TXD", { "U0TXD", "CLK_OUT3", "GPIO1", "-", "-", "EMAC_RXD2" } },
     { 2, "GPIO2", { "GPIO2", "HSPIWP", "GPIO2", "HS2_DATA0", "SD_DATA0", "-" } },
@@ -243,7 +243,7 @@ struct pin_mux {
     { -1, "", { "" } },
 };
 const char* pin_function_name(gpio_num_t gpio, int function) {
-    pin_mux* p;
+    const pin_mux* p;
     for (p = pins; p->pinnum != -1; ++p) {
         if (p->pinnum == gpio) {
             return p->functions[function];
@@ -257,7 +257,7 @@ struct gpio_matrix_t {
     const char* in;
     const char* out;
     bool        iomux;
-} gpio_matrix[] = { { 0, "SPICLK_in", "SPICLK_out", true },
+} const gpio_matrix[] = { { 0, "SPICLK_in", "SPICLK_out", true },
                     { 1, "SPIQ_in", "SPIQ_out", true },
                     { 2, "SPID_in", "SPID_out", true },
                     { 3, "SPIHD_in", "SPIHD_out", true },
@@ -459,7 +459,7 @@ struct gpio_matrix_t {
                     { -1, "", "", false } };
 
 static const char* out_sel_name(int function) {
-    gpio_matrix_t* p;
+    const gpio_matrix_t* p;
     for (p = gpio_matrix; p->num != -1; ++p) {
         if (p->num == function) {
             return p->out;
@@ -469,7 +469,7 @@ static const char* out_sel_name(int function) {
 }
 
 static void show_matrix(Print& out) {
-    gpio_matrix_t* p;
+    const gpio_matrix_t* p;
     for (p = gpio_matrix; p->num != -1; ++p) {
         uint32_t in_sel = gpio_in_sel(p->num);
         if (in_sel & 0x80) {

--- a/FluidNC/src/Configuration/AfterParse.h
+++ b/FluidNC/src/Configuration/AfterParse.h
@@ -26,14 +26,14 @@ namespace Configuration {
         AfterParse() = default;
 
         void item(const char* name, bool& value) override {}
-        void item(const char* name, int32_t& value, int32_t minValue, int32_t maxValue) override {}
-        void item(const char* name, uint32_t& value, uint32_t minValue, uint32_t maxValue) override {}
-        void item(const char* name, float& value, float minValue, float maxValue) override {}
+        void item(const char* name, int32_t& value, const int32_t minValue, const int32_t maxValue) override {}
+        void item(const char* name, uint32_t& value, const uint32_t minValue, const uint32_t maxValue) override {}
+        void item(const char* name, float& value, const float minValue, const float maxValue) override {}
         void item(const char* name, std::vector<speedEntry>& value) override {}
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override {}
-        void item(const char* name, std::string& value, int minLength, int maxLength) override {}
+        void item(const char* name, std::string& value, const int minLength, const int maxLength) override {}
         void item(const char* name, Pin& value) override {}
         void item(const char* name, IPAddress& value) override {}
-        void item(const char* name, int& value, EnumItem* e) override {}
+        void item(const char* name, int& value, const EnumItem* e) override {}
     };
 }

--- a/FluidNC/src/Configuration/Completer.h
+++ b/FluidNC/src/Configuration/Completer.h
@@ -27,15 +27,15 @@ namespace Configuration {
 
         void item(const char* name);
         void item(const char* name, bool& value) override { item(name); }
-        void item(const char* name, int32_t& value, int32_t minValue, int32_t maxValue) override { item(name); }
-        void item(const char* name, uint32_t& value, uint32_t minValue, uint32_t maxValue) override { item(name); }
-        void item(const char* name, float& value, float minValue, float maxValue) override { item(name); }
+        void item(const char* name, int32_t& value, const int32_t minValue, const int32_t maxValue) override { item(name); }
+        void item(const char* name, uint32_t& value, const uint32_t minValue, const uint32_t maxValue) override { item(name); }
+        void item(const char* name, float& value, const float minValue, const float maxValue) override { item(name); }
         void item(const char* name, std::vector<speedEntry>& value) override { item(name); }
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override { item(name); }
-        void item(const char* name, std::string& value, int minLength, int maxLength) override { item(name); }
+        void item(const char* name, std::string& value, const int minLength, const int maxLength) override { item(name); }
         void item(const char* name, Pin& value) { item(name); }
         void item(const char* name, IPAddress& value) override { item(name); }
-        void item(const char* name, int& value, EnumItem* e) override { item(name); }
+        void item(const char* name, int& value, const EnumItem* e) override { item(name); }
 
         HandlerType handlerType() override { return HandlerType::Completer; }
 

--- a/FluidNC/src/Configuration/Generator.h
+++ b/FluidNC/src/Configuration/Generator.h
@@ -45,13 +45,13 @@ namespace Configuration {
             s << value;
         }
 
-        void item(const char* name, int& value, int32_t minValue, int32_t maxValue) override { send_item(name, std::to_string(value)); }
+        void item(const char* name, int& value, const int32_t minValue, const int32_t maxValue) override { send_item(name, std::to_string(value)); }
 
-        void item(const char* name, uint32_t& value, uint32_t minValue, uint32_t maxValue) override {
+        void item(const char* name, uint32_t& value, const uint32_t minValue, const uint32_t maxValue) override {
             send_item(name, std::to_string(value));
         }
 
-        void item(const char* name, float& value, float minValue, float maxValue) override { send_item(name, std::to_string(value)); }
+        void item(const char* name, float& value, const float minValue, const float maxValue) override { send_item(name, std::to_string(value)); }
 
         void item(const char* name, std::vector<speedEntry>& value) {
             if (value.size() == 0) {
@@ -96,14 +96,14 @@ namespace Configuration {
             send_item(name, s);
         }
 
-        void item(const char* name, std::string& value, int minLength, int maxLength) override { send_item(name, value); }
+        void item(const char* name, std::string& value, const int minLength, const int maxLength) override { send_item(name, value); }
 
         void item(const char* name, bool& value) override { send_item(name, value ? "true" : "false"); }
 
         void item(const char* name, Pin& value) override { send_item(name, value.name()); }
 
         void item(const char* name, IPAddress& value) override { send_item(name, IP_string(value)); }
-        void item(const char* name, int& value, EnumItem* e) override {
+        void item(const char* name, int& value, const EnumItem* e) override {
             const char* str = "unknown";
             for (; e->name; ++e) {
                 if (value == e->value) {

--- a/FluidNC/src/Configuration/HandlerBase.h
+++ b/FluidNC/src/Configuration/HandlerBase.h
@@ -35,25 +35,25 @@ namespace Configuration {
 
     public:
         virtual void item(const char* name, bool& value)                                                            = 0;
-        virtual void item(const char* name, int32_t& value, int32_t minValue = 0, int32_t maxValue = INT32_MAX)     = 0;
-        virtual void item(const char* name, uint32_t& value, uint32_t minValue = 0, uint32_t maxValue = UINT32_MAX) = 0;
+        virtual void item(const char* name, int32_t& value, const int32_t minValue = 0, const int32_t maxValue = INT32_MAX)     = 0;
+        virtual void item(const char* name, uint32_t& value, const uint32_t minValue = 0, uint32_t const maxValue = UINT32_MAX) = 0;
 
-        void item(const char* name, uint8_t& value, uint8_t minValue = 0, uint8_t maxValue = UINT8_MAX) {
+        void item(const char* name, uint8_t& value, const uint8_t minValue = 0, const uint8_t maxValue = UINT8_MAX) {
             int32_t v = int32_t(value);
             item(name, v, int32_t(minValue), int32_t(maxValue));
             value = uint8_t(v);
         }
 
-        virtual void item(const char* name, float& value, float minValue = -3e38, float maxValue = 3e38)  = 0;
+        virtual void item(const char* name, float& value, const float minValue = -3e38, const float maxValue = 3e38)  = 0;
         virtual void item(const char* name, std::vector<speedEntry>& value)                               = 0;
         virtual void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) = 0;
 
         virtual void item(const char* name, Pin& value)       = 0;
         virtual void item(const char* name, IPAddress& value) = 0;
 
-        virtual void item(const char* name, int& value, EnumItem* e) = 0;
+        virtual void item(const char* name, int& value, const EnumItem* e) = 0;
 
-        virtual void item(const char* name, std::string& value, int minLength = 0, int maxLength = 255) = 0;
+        virtual void item(const char* name, std::string& value, const int minLength = 0, const int maxLength = 255) = 0;
 
         virtual HandlerType handlerType() = 0;
 

--- a/FluidNC/src/Configuration/JsonGenerator.cpp
+++ b/FluidNC/src/Configuration/JsonGenerator.cpp
@@ -68,7 +68,7 @@ namespace Configuration {
         leave();
     }
 
-    void JsonGenerator::item(const char* name, int& value, int32_t minValue, int32_t maxValue) {
+    void JsonGenerator::item(const char* name, int& value, const int32_t minValue, const int32_t maxValue) {
         enter(name);
         char buf[32];
         itoa(value, buf, 10);
@@ -77,7 +77,7 @@ namespace Configuration {
         leave();
     }
 
-    void JsonGenerator::item(const char* name, uint32_t& value, uint32_t minValue, uint32_t maxValue) {
+    void JsonGenerator::item(const char* name, uint32_t& value, const uint32_t minValue, const uint32_t maxValue) {
         enter(name);
         char buf[32];
         itoa(value, buf, 10);
@@ -86,7 +86,7 @@ namespace Configuration {
         leave();
     }
 
-    void JsonGenerator::item(const char* name, float& value, float minValue, float maxValue) {
+    void JsonGenerator::item(const char* name, float& value, const float minValue, const float maxValue) {
         enter(name);
         // WebUI does not explicitly recognize the R type, but nevertheless handles it correctly.
         if (value > 999999.999f) {
@@ -106,7 +106,7 @@ namespace Configuration {
         // Not sure if I should comment this out or not. The implementation is similar to the one in Generator.h.
     }
 
-    void JsonGenerator::item(const char* name, std::string& value, int minLength, int maxLength) {
+    void JsonGenerator::item(const char* name, std::string& value, const int minLength, const int maxLength) {
         enter(name);
         _encoder.begin_webui(_currentPath, _currentPath, "S", value.c_str(), minLength, maxLength);
         _encoder.end_object();
@@ -132,7 +132,7 @@ namespace Configuration {
         leave();
     }
 
-    void JsonGenerator::item(const char* name, int& value, EnumItem* e) {
+    void JsonGenerator::item(const char* name, int& value, const EnumItem* e) {
         enter(name);
         int selected_val = 0;
         //const char* str          = "unknown";

--- a/FluidNC/src/Configuration/JsonGenerator.h
+++ b/FluidNC/src/Configuration/JsonGenerator.h
@@ -35,14 +35,14 @@ namespace Configuration {
         JsonGenerator(WebUI::JSONencoder& encoder);
 
         void item(const char* name, bool& value) override;
-        void item(const char* name, int& value, int32_t minValue, int32_t maxValue) override;
-        void item(const char* name, uint32_t& value, uint32_t minValue, uint32_t maxValue) override;
-        void item(const char* name, float& value, float minValue, float maxValue) override;
+        void item(const char* name, int& value, const int32_t minValue, const int32_t maxValue) override;
+        void item(const char* name, uint32_t& value, const uint32_t minValue, const uint32_t maxValue) override;
+        void item(const char* name, float& value, const float minValue, const float maxValue) override;
         void item(const char* name, std::vector<speedEntry>& value) override;
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override;
-        void item(const char* name, std::string& value, int minLength, int maxLength) override;
+        void item(const char* name, std::string& value, const int minLength, const int maxLength) override;
         void item(const char* name, Pin& value) override;
         void item(const char* name, IPAddress& value) override;
-        void item(const char* name, int& value, EnumItem* e) override;
+        void item(const char* name, int& value, const EnumItem* e) override;
     };
 }

--- a/FluidNC/src/Configuration/ParseException.h
+++ b/FluidNC/src/Configuration/ParseException.h
@@ -5,8 +5,8 @@
 
 namespace Configuration {
     class ParseException {
-        int         _linenum;
-        std::string _description;
+        int               _linenum;
+        const std::string _description;
 
     public:
         ParseException()                      = default;

--- a/FluidNC/src/Configuration/Parser.cpp
+++ b/FluidNC/src/Configuration/Parser.cpp
@@ -142,7 +142,7 @@ namespace Configuration {
         return ip;
     }
 
-    int Parser::enumValue(EnumItem* e) const {
+    int Parser::enumValue(const EnumItem* e) const {
         auto token = string_util::trim(_token._value);
         for (; e->name; ++e) {
             if (string_util::equal_ignore_case(token, e->name)) {

--- a/FluidNC/src/Configuration/Parser.h
+++ b/FluidNC/src/Configuration/Parser.h
@@ -30,7 +30,7 @@ namespace Configuration {
         std::vector<speedEntry> speedEntryValue() const;
         float                   floatValue() const;
         Pin                     pinValue() const;
-        int                     enumValue(EnumItem* e) const;
+        int                     enumValue(const EnumItem* e) const;
         IPAddress               ipValue() const;
         void                    uartMode(UartData& wordLength, UartParity& parity, UartStop& stopBits) const;
     };

--- a/FluidNC/src/Configuration/ParserHandler.h
+++ b/FluidNC/src/Configuration/ParserHandler.h
@@ -87,14 +87,14 @@ namespace Configuration {
             }
         }
 
-        void item(const char* name, uint32_t& value, uint32_t minValue, uint32_t maxValue) override {
+        void item(const char* name, uint32_t& value, const uint32_t minValue, const uint32_t maxValue) override {
             if (_parser.is(name)) {
                 value = _parser.uintValue();
                 constrain_with_message(value, minValue, maxValue, name);
             }
         }
 
-        void item(const char* name, int& value, EnumItem* e) override {
+        void item(const char* name, int& value, const EnumItem* e) override {
             if (_parser.is(name)) {
                 value = _parser.enumValue(e);
             }
@@ -106,7 +106,7 @@ namespace Configuration {
             }
         }
 
-        void item(const char* name, float& value, float minValue, float maxValue) override {
+        void item(const char* name, float& value, const float minValue, const float maxValue) override {
             if (_parser.is(name)) {
                 value = _parser.floatValue();
                 constrain_with_message(value, minValue, maxValue, name);
@@ -125,7 +125,7 @@ namespace Configuration {
             }
         }
 
-        void item(const char* name, std::string& value, int minLength, int maxLength) override {
+        void item(const char* name, std::string& value, const int minLength, const int maxLength) override {
             if (_parser.is(name)) {
                 value = _parser.stringValue();
             }

--- a/FluidNC/src/Configuration/RuntimeSetting.cpp
+++ b/FluidNC/src/Configuration/RuntimeSetting.cpp
@@ -69,7 +69,7 @@ namespace Configuration {
         }
     }
 
-    void RuntimeSetting::item(const char* name, int32_t& value, int32_t minValue, int32_t maxValue) {
+    void RuntimeSetting::item(const char* name, int32_t& value, const int32_t minValue, const int32_t maxValue) {
         if (is(name)) {
             isHandled_ = true;
             if (newValue_ == nullptr) {
@@ -80,7 +80,7 @@ namespace Configuration {
         }
     }
 
-    void RuntimeSetting::item(const char* name, uint32_t& value, uint32_t minValue, uint32_t maxValue) {
+    void RuntimeSetting::item(const char* name, uint32_t& value, const uint32_t minValue, const uint32_t maxValue) {
         if (is(name)) {
             isHandled_ = true;
             if (newValue_ == nullptr) {
@@ -96,7 +96,7 @@ namespace Configuration {
         }
     }
 
-    void RuntimeSetting::item(const char* name, float& value, float minValue, float maxValue) {
+    void RuntimeSetting::item(const char* name, float& value, const float minValue, const float maxValue) {
         if (is(name)) {
             isHandled_ = true;
             if (newValue_ == nullptr) {
@@ -109,7 +109,7 @@ namespace Configuration {
         }
     }
 
-    void RuntimeSetting::item(const char* name, std::string& value, int minLength, int maxLength) {
+    void RuntimeSetting::item(const char* name, std::string& value, const int minLength, const int maxLength) {
         if (is(name)) {
             isHandled_ = true;
             if (newValue_ == nullptr) {
@@ -120,7 +120,7 @@ namespace Configuration {
         }
     }
 
-    void RuntimeSetting::item(const char* name, int& value, EnumItem* e) {
+    void RuntimeSetting::item(const char* name, int& value, const EnumItem* e) {
         if (is(name)) {
             isHandled_ = true;
             if (newValue_ == nullptr) {

--- a/FluidNC/src/Configuration/RuntimeSetting.h
+++ b/FluidNC/src/Configuration/RuntimeSetting.h
@@ -34,15 +34,15 @@ namespace Configuration {
         RuntimeSetting(const char* key, const char* value, Channel& out);
 
         void item(const char* name, bool& value) override;
-        void item(const char* name, int32_t& value, int32_t minValue, int32_t maxValue) override;
-        void item(const char* name, uint32_t& value, uint32_t minValue, uint32_t maxValue) override;
-        void item(const char* name, float& value, float minValue, float maxValue) override;
+        void item(const char* name, int32_t& value, const int32_t minValue, const int32_t maxValue) override;
+        void item(const char* name, uint32_t& value, const uint32_t minValue, const uint32_t maxValue) override;
+        void item(const char* name, float& value, const float minValue, const float maxValue) override;
         void item(const char* name, std::vector<speedEntry>& value) override;
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override {}
-        void item(const char* name, std::string& value, int minLength, int maxLength) override;
+        void item(const char* name, std::string& value, const int minLength, const int maxLength) override;
         void item(const char* name, Pin& value) override;
         void item(const char* name, IPAddress& value) override;
-        void item(const char* name, int& value, EnumItem* e) override;
+        void item(const char* name, int& value, const EnumItem* e) override;
 
         std::string setting_prefix();
 

--- a/FluidNC/src/Configuration/Validator.h
+++ b/FluidNC/src/Configuration/Validator.h
@@ -26,14 +26,14 @@ namespace Configuration {
         Validator();
 
         void item(const char* name, bool& value) override {}
-        void item(const char* name, int32_t& value, int32_t minValue, int32_t maxValue) override {}
-        void item(const char* name, uint32_t& value, uint32_t minValue, uint32_t maxValue) override {}
-        void item(const char* name, float& value, float minValue, float maxValue) override {}
+        void item(const char* name, int32_t& value, const int32_t minValue, const int32_t maxValue) override {}
+        void item(const char* name, uint32_t& value, const uint32_t minValue, const uint32_t maxValue) override {}
+        void item(const char* name, float& value, const float minValue, const float maxValue) override {}
         void item(const char* name, std::vector<speedEntry>& value) override {}
         void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) override {}
-        void item(const char* name, std::string& value, int minLength, int maxLength) override {}
+        void item(const char* name, std::string& value, const int minLength, const int maxLength) override {}
         void item(const char* name, Pin& value) override {}
         void item(const char* name, IPAddress& value) override {}
-        void item(const char* name, int& value, EnumItem* e) override {}
+        void item(const char* name, int& value, const EnumItem* e) override {}
     };
 }

--- a/FluidNC/src/HashFS.cpp
+++ b/FluidNC/src/HashFS.cpp
@@ -109,7 +109,7 @@ void HashFS::hash_all() {
 }
 std::string HashFS::hash(const std::filesystem::path& path) {
     if (file_is_hashed(path)) {
-        std::map<std::string, std::string>::iterator it;
+        std::map<std::string, std::string>::const_iterator it;
         it = localFsHashes.find(path.filename());
         if (it != localFsHashes.end()) {
             return it->second;

--- a/FluidNC/src/Logging.cpp
+++ b/FluidNC/src/Logging.cpp
@@ -7,9 +7,9 @@
 #include "SettingsDefinitions.h"
 #include "Channel.h"
 
-EnumItem messageLevels2[] = { { MsgLevelNone, "None" }, { MsgLevelError, "Error" }, { MsgLevelWarning, "Warn" },
-                              { MsgLevelInfo, "Info" }, { MsgLevelDebug, "Debug" }, { MsgLevelVerbose, "Verbose" },
-                              EnumItem(MsgLevelNone) };
+const EnumItem messageLevels2[] = { { MsgLevelNone, "None" }, { MsgLevelError, "Error" }, { MsgLevelWarning, "Warn" },
+                                    { MsgLevelInfo, "Info" }, { MsgLevelDebug, "Debug" }, { MsgLevelVerbose, "Verbose" },
+                                    EnumItem(MsgLevelNone) };
 
 bool atMsgLevel(MsgLevel level) {
     return message_level == nullptr || message_level->get() >= level;

--- a/FluidNC/src/Logging.h
+++ b/FluidNC/src/Logging.h
@@ -31,7 +31,7 @@ extern TaskHandle_t outputTask;
 
 extern xQueueHandle message_queue;
 
-extern EnumItem messageLevels2[];
+extern const EnumItem messageLevels2[];
 
 // How to use logging? Well, the basics are pretty simple:
 //

--- a/FluidNC/src/Machine/Axes.cpp
+++ b/FluidNC/src/Machine/Axes.cpp
@@ -8,7 +8,7 @@
 #include "MachineConfig.h"  // config->
 #include "../Limits.h"
 
-EnumItem axisType[] = { { 0, "X" }, { 1, "Y" }, { 2, "Z" }, { 3, "A" }, { 4, "B" }, { 5, "C" }, EnumItem(0) };
+const EnumItem axisType[] = { { 0, "X" }, { 1, "Y" }, { 2, "Z" }, { 3, "A" }, { 4, "B" }, { 5, "C" }, EnumItem(0) };
 
 namespace Machine {
     MotorMask Axes::posLimitMask = 0;

--- a/FluidNC/src/Machine/Axes.h
+++ b/FluidNC/src/Machine/Axes.h
@@ -91,4 +91,4 @@ namespace Machine {
         ~Axes();
     };
 }
-extern EnumItem axisType[];
+extern const EnumItem axisType[];

--- a/FluidNC/src/Motors/TrinamicBase.cpp
+++ b/FluidNC/src/Motors/TrinamicBase.cpp
@@ -7,10 +7,10 @@
 #include <atomic>
 
 namespace MotorDrivers {
-    EnumItem trinamicModes[] = { { TrinamicMode::StealthChop, "StealthChop" },
-                                 { TrinamicMode::CoolStep, "CoolStep" },
-                                 { TrinamicMode::StallGuard, "StallGuard" },
-                                 EnumItem(TrinamicMode::StealthChop) };
+    const EnumItem trinamicModes[] = { { TrinamicMode::StealthChop, "StealthChop" },
+                                       { TrinamicMode::CoolStep, "CoolStep" },
+                                       { TrinamicMode::StallGuard, "StallGuard" },
+                                       EnumItem(TrinamicMode::StealthChop) };
 
     std::vector<TrinamicBase*> TrinamicBase::_instances;  // static list of all drivers for stallguard reporting
 

--- a/FluidNC/src/Motors/TrinamicBase.h
+++ b/FluidNC/src/Motors/TrinamicBase.h
@@ -16,7 +16,7 @@ namespace MotorDrivers {
         StallGuard  = 2,  // coolstep plus stall indication
     };
 
-    extern EnumItem trinamicModes[];
+    extern const EnumItem trinamicModes[];
 
     class TrinamicBase : public StandardStepper {
     private:

--- a/FluidNC/src/NutsBolts.h
+++ b/FluidNC/src/NutsBolts.h
@@ -88,12 +88,12 @@ char* trim(char* value);
 void  trim(std::string_view& sv);
 
 template <typename T>
-T myMap(T x, T in_min, T in_max, T out_min, T out_max) {  // DrawBot_Badge
+T myMap(T x, const T in_min, const T in_max, T out_min, T out_max) {  // DrawBot_Badge
     return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
 template <typename T>
-T myConstrain(T in, T min, T max) {
+T myConstrain(T in, const T min, const T max) {
     if (in < min) {
         return min;
     }
@@ -104,14 +104,14 @@ T myConstrain(T in, T min, T max) {
 }
 
 template <typename T>
-T mapConstrain(T x, T in_min, T in_max, T out_min, T out_max) {
+T mapConstrain(T x, const T in_min, const T in_max, T out_min, T out_max) {
     x = myConstrain(x, in_min, in_max);
     return myMap(x, in_min, in_max, out_min, out_max);
 }
 
 // constrain a value and issue a message. Returns true is the value was OK
 template <typename T>
-bool constrain_with_message(T& value, T min, T max, const char* name = "") {
+bool constrain_with_message(T& value, const T min, const T max, const char* name = "") {
     if (value < min || value > max) {
         log_warn(name << " value " << value << " constrained to range (" << min << "," << max << ")");
         value = myConstrain(value, min, max);

--- a/FluidNC/src/Settings.cpp
+++ b/FluidNC/src/Settings.cpp
@@ -269,7 +269,7 @@ void StringSetting::addWebui(WebUI::JSONencoder* j) {
 // typedef std::map<const char*, int8_t, std::less<>> enum_opt_t;
 
 EnumSetting::EnumSetting(
-    const char* description, type_t type, permissions_t permissions, const char* grblName, const char* name, int8_t defVal, enum_opt_t* opts) :
+    const char* description, type_t type, permissions_t permissions, const char* grblName, const char* name, int8_t defVal, const enum_opt_t* opts) :
     Setting(description, type, permissions, grblName, name),
     _defaultValue(defVal), _options(opts) {}
 
@@ -301,7 +301,7 @@ Error EnumSetting::setStringValue(std::string_view s) {
     }
     trim(s);
     std::string          str(s);
-    enum_opt_t::iterator it = _options->find(str.c_str());
+    enum_opt_t::const_iterator it = _options->find(str.c_str());
     if (it == _options->end()) {
         // If we don't find the value in keys, look for it in the numeric values
 
@@ -342,7 +342,7 @@ Error EnumSetting::setStringValue(std::string_view s) {
 }
 
 const char* EnumSetting::enumToString(int8_t value) {
-    for (enum_opt_t::iterator it = _options->begin(); it != _options->end(); it++) {
+    for (enum_opt_t::const_iterator it = _options->begin(); it != _options->end(); it++) {
         if (it->second == value) {
             return it->first;
         }
@@ -359,7 +359,7 @@ const char* EnumSetting::getStringValue() {
 
 void EnumSetting::showList() {
     std::string optList = "";
-    for (enum_opt_t::iterator it = _options->begin(); it != _options->end(); it++) {
+    for (enum_opt_t::const_iterator it = _options->begin(); it != _options->end(); it++) {
         optList = optList + " " + it->first;
     }
     log_info("Valid options:" << optList);
@@ -371,7 +371,7 @@ void EnumSetting::addWebui(WebUI::JSONencoder* j) {
     }
     j->begin_webui(getName(), getName(), "B", get());
     j->begin_array("O");
-    for (enum_opt_t::iterator it = _options->begin(); it != _options->end(); it++) {
+    for (enum_opt_t:: const_iterator it = _options->begin(); it != _options->end(); it++) {
         j->begin_object();
         j->member(it->first, it->second);
         j->end_object();

--- a/FluidNC/src/Settings.h
+++ b/FluidNC/src/Settings.h
@@ -278,22 +278,22 @@ typedef std::map<const char*, int8_t, cmp_str> enum_opt_t;
 
 class EnumSetting : public Setting {
 private:
-    int8_t                                  _defaultValue;
-    int8_t                                  _storedValue;
-    int8_t                                  _currentValue;
-    std::map<const char*, int8_t, cmp_str>* _options;
-    const char*                             enumToString(int8_t value);
+    int8_t                                        _defaultValue;
+    int8_t                                        _storedValue;
+    int8_t                                        _currentValue;
+    const std::map<const char*, int8_t, cmp_str>* _options;
+    const char*                                   enumToString(int8_t value);
 
 public:
-    EnumSetting(const char*   description,
-                type_t        type,
-                permissions_t permissions,
-                const char*   grblName,
-                const char*   name,
-                int8_t        defVal,
-                enum_opt_t*   opts);
+    EnumSetting(const char*       description,
+                type_t            type,
+                permissions_t     permissions,
+                const char*       grblName,
+                const char*       name,
+                int8_t            defVal,
+                const enum_opt_t* opts);
 
-    EnumSetting(type_t type, permissions_t permissions, const char* grblName, const char* name, int8_t defVal, enum_opt_t* opts) :
+    EnumSetting(type_t type, permissions_t permissions, const char* grblName, const char* name, int8_t defVal, const enum_opt_t* opts) :
         EnumSetting(NULL, type, permissions, grblName, name, defVal, opts) {}
 
     void        load();
@@ -374,4 +374,4 @@ Error settings_execute_line(char* line, Channel& out, WebUI::AuthenticationLevel
 Error do_command_or_setting(const char* key, const char* value, WebUI::AuthenticationLevel auth_level, Channel&);
 Error execute_line(char* line, Channel& channel, WebUI::AuthenticationLevel auth_level);
 
-extern enum_opt_t onoffOptions;
+extern const enum_opt_t onoffOptions;

--- a/FluidNC/src/SettingsDefinitions.cpp
+++ b/FluidNC/src/SettingsDefinitions.cpp
@@ -21,7 +21,7 @@ EnumSetting* message_level;
 std::vector<std::unique_ptr<MachineConfigProxySetting<float>>>   float_proxies;
 std::vector<std::unique_ptr<MachineConfigProxySetting<int32_t>>> int_proxies;
 
-enum_opt_t messageLevels = {
+const enum_opt_t messageLevels = {
     // clang-format off
     { "None", MsgLevelNone },
     { "Error", MsgLevelError },
@@ -32,7 +32,7 @@ enum_opt_t messageLevels = {
     // clang-format on
 };
 
-enum_opt_t onoffOptions = { { "OFF", 0 }, { "ON", 1 } };
+const enum_opt_t onoffOptions = { { "OFF", 0 }, { "ON", 1 } };
 
 void make_coordinate(CoordIndex index, const char* name) {
     float coord_data[MAX_N_AXIS] = { 0.0 };

--- a/FluidNC/src/Stepping.cpp
+++ b/FluidNC/src/Stepping.cpp
@@ -10,11 +10,11 @@ namespace Machine {
 
     int Stepping::_engine = RMT;
 
-    EnumItem stepTypes[] = { { Stepping::TIMED, "Timed" },
-                             { Stepping::RMT, "RMT" },
-                             { Stepping::I2S_STATIC, "I2S_static" },
-                             { Stepping::I2S_STREAM, "I2S_stream" },
-                             EnumItem(Stepping::RMT) };
+    const EnumItem stepTypes[] = { { Stepping::TIMED, "Timed" },
+                                   { Stepping::RMT, "RMT" },
+                                   { Stepping::I2S_STATIC, "I2S_static" },
+                                   { Stepping::I2S_STREAM, "I2S_stream" },
+                                   EnumItem(Stepping::RMT) };
 
     void Stepping::init() {
         log_info("Stepping:" << stepTypes[_engine].name << " Pulse:" << _pulseUsecs << "us Dsbl Delay:" << _disableDelayUsecs

--- a/FluidNC/src/Stepping.h
+++ b/FluidNC/src/Stepping.h
@@ -71,4 +71,4 @@ namespace Machine {
         void afterParse() override;
     };
 }
-extern EnumItem stepTypes[];
+extern const EnumItem stepTypes[];

--- a/FluidNC/src/WebUI/NotificationsService.cpp
+++ b/FluidNC/src/WebUI/NotificationsService.cpp
@@ -50,7 +50,7 @@ namespace WebUI {
 
     static const int EMAILTIMEOUT = 5000;
 
-    enum_opt_t notificationOptions = {
+    const enum_opt_t notificationOptions = {
         { "NONE", 0 },
         { "LINE", 3 },
         { "PUSHOVER", 1 },

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -36,7 +36,7 @@ namespace WebUI {
         WiFiFallback,  // Try STA and fall back to AP if STA fails
     };
 
-    enum_opt_t wifiModeOptions = {
+    const enum_opt_t wifiModeOptions = {
         { "Off", WiFiOff },
         { "STA", WiFiSTA },
         { "AP", WiFiAP },
@@ -91,7 +91,7 @@ namespace WebUI {
         WiFiCountryUS,
     };
 
-    enum_opt_t wifiContryOptions = {
+    const enum_opt_t wifiContryOptions = {
         { "01", WiFiCountry01 }, { "AT", WiFiCountryAT }, { "AU", WiFiCountryAU }, { "BE", WiFiCountryBE }, { "BG", WiFiCountryBG },
         { "BR", WiFiCountryBR }, { "CA", WiFiCountryCA }, { "CH", WiFiCountryCH }, { "CN", WiFiCountryCN }, { "CY", WiFiCountryCY },
         { "CZ", WiFiCountryCZ }, { "DE", WiFiCountryDE }, { "DK", WiFiCountryDK }, { "EE", WiFiCountryEE }, { "ES", WiFiCountryES },
@@ -126,12 +126,12 @@ namespace WebUI {
 
     HostnameSetting* wifi_hostname;
 
-    enum_opt_t staModeOptions = {
+    const enum_opt_t staModeOptions = {
         { "DHCP", DHCP_MODE },
         { "Static", STATIC_MODE },
     };
 
-    enum_opt_t staSecurityOptions = {
+    const enum_opt_t staSecurityOptions = {
         { "OPEN", WIFI_AUTH_OPEN },
         { "WEP", WIFI_AUTH_WEP },
         { "WPA-PSK", WIFI_AUTH_WPA_PSK },

--- a/FluidNC/test/Configuration/YamlTreeBuilder.cpp
+++ b/FluidNC/test/Configuration/YamlTreeBuilder.cpp
@@ -41,7 +41,7 @@ namespace Configuration {
         ST_I2S_STATIC,
     };
 
-    EnumItem stepTypes[] = {
+    const EnumItem stepTypes[] = {
         { ST_TIMED, "Timed" }, { ST_RMT, "RMT" }, { ST_I2S_STATIC, "I2S_static" }, { ST_I2S_STREAM, "I2S_stream" }, EnumItem(ST_RMT)
     };
 


### PR DESCRIPTION
Allows compiler / linker to optimize code and RAM/Flash usage 

- Reduces RAM usage by 4320 bytes
- Increases Flash usage   16 bytes

[env:wifi] ; before
RAM:   [===       ]  28.7% (used 93956 bytes from 327680 bytes)
Flash: [========= ]  91.1% (used 1791793 bytes from 1966080 bytes

[env:wifi] ; after
RAM:   [===       ]  27.4% (used 89636 bytes from 327680 bytes)
Flash: [========= ]  91.1% (used 1791809 bytes from 1966080 bytes)