### PR TITLE
Fix #1196 - abnormal operating speed

### DIFF
--- a/FluidNC/src/Planner.cpp
+++ b/FluidNC/src/Planner.cpp
@@ -289,6 +289,9 @@ void plan_update_velocity_profile_parameters() {
         block_index        = plan_next_block_index(block_index);
     }
     pl.previous_nominal_speed = prev_nominal_speed;  // Update prev nominal speed for next incoming block.
+    if (block_buffer_tail != block_buffer_head) {
+        plan_cycle_reinitialize();
+    }
 }
 
 bool plan_buffer_line(float* target, plan_line_data_t* pl_data) {

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -737,7 +737,6 @@ void protocol_do_cycle_stop() {
 static void update_velocities() {
     report_ovr_counter = 0;  // Set to report change immediately
     plan_update_velocity_profile_parameters();
-    plan_cycle_reinitialize();
 }
 
 // This is the final phase of the shutdown activity for a reset


### PR DESCRIPTION
The problem is that, if you issue a feedrate override when there is no motion, it calls the planner recalculate code which then incorrectly updates some planner blocks that are not in use with bogus data.  Then when you issue a jog, it uses the bogus data.

I think this is the correct fix but it hasn't been tested with a lot of different motion situations.  It certainly fixes the problem as stated, and seems to work for simple non-jog G1 commands.