### PR TITLE
chore(library_version): Update to latest released arduino framework

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -50,7 +50,7 @@ wifi_deps =
 platform = https://github.com/platformio/platform-espressif32.git
 framework = arduino
 platform_packages =
-    framework-arduinoespressif32@ https://github.com/espressif/arduino-esp32.git#2.0.15
+    platformio/framework-arduinoespressif32@^3.20016.0
 board_build.arduino.upstream_packages = no
 
 upload_speed = 921600


### PR DESCRIPTION
arduino-espressif32 v 2.0.16 just landed in the PIO package repository.  Seems to work, and eliminates some compile warning messages.