### PR TITLE
define std::map's as const std::map

### DIFF
--- a/FluidNC/src/Channel.cpp
+++ b/FluidNC/src/Channel.cpp
@@ -335,7 +335,9 @@ bool Channel::is_visible(const std::string& stem, const std::string& extension, 
     if (isdir) {
         return true;
     }
-    std::string_view extensions(_gcode_extensions);
+
+    // common gcode extensions
+    std::string_view extensions( ".g .gc .gco .gcode .nc .ngc .ncc .txt .cnc .tap");
     int              pos = 0;
     while (extensions.length()) {
         auto             next_pos       = extensions.find_first_of(' ', pos);

--- a/FluidNC/src/Channel.cpp
+++ b/FluidNC/src/Channel.cpp
@@ -337,7 +337,7 @@ bool Channel::is_visible(const std::string& stem, const std::string& extension, 
     }
 
     // common gcode extensions
-    std::string_view extensions( ".g .gc .gco .gcode .nc .ngc .ncc .txt .cnc .tap");
+    std::string_view extensions(".g .gc .gco .gcode .nc .ngc .ncc .txt .cnc .tap");
     int              pos = 0;
     while (extensions.length()) {
         auto             next_pos       = extensions.find_first_of(' ', pos);

--- a/FluidNC/src/Channel.h
+++ b/FluidNC/src/Channel.h
@@ -78,7 +78,6 @@ protected:
     std::map<int, bool*>     _pin_values;
 
     UTF8        _utf8;
-    std::string _gcode_extensions = ".g .gc .gco .gcode .nc .ngc .ncc .txt .cnc .tap";
 
 protected:
     bool _active = true;

--- a/FluidNC/src/Error.cpp
+++ b/FluidNC/src/Error.cpp
@@ -5,7 +5,7 @@
 
 #include "Error.h"
 
-std::map<Error, const char*> ErrorNames = {
+const std::map<Error, const char*> ErrorNames = {
     { Error::Ok, "No error" },
     { Error::ExpectedCommandLetter, "Expected GCodecommand letter" },
     { Error::BadNumberFormat, "Bad GCode number format" },

--- a/FluidNC/src/Error.h
+++ b/FluidNC/src/Error.h
@@ -85,4 +85,4 @@ enum class Error : uint8_t {
 
 const char* errorString(Error errorNumber);
 
-extern std::map<Error, const char*> ErrorNames;
+extern const std::map<Error, const char*> ErrorNames;

--- a/FluidNC/src/Machine/Macros.cpp
+++ b/FluidNC/src/Machine/Macros.cpp
@@ -24,7 +24,7 @@ MacroEvent macro2Event { 2 };
 MacroEvent macro3Event { 3 };
 
 // clang-format off
-std::map<std::string, Cmd> overrideCodes = {
+const std::map<std::string, Cmd> overrideCodes = {
     { "fr", Cmd::FeedOvrReset },
     { "f>", Cmd::FeedOvrCoarsePlus },
     { "f<", Cmd::FeedOvrCoarseMinus },

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -528,7 +528,7 @@ static Error show_startup_lines(const char* value, WebUI::AuthenticationLevel au
     return Error::Ok;
 }
 
-std::map<const char*, uint8_t, cmp_str> restoreCommands = {
+const std::map<const char*, uint8_t, cmp_str> restoreCommands = {
     { "$", SettingsRestore::Defaults },   { "settings", SettingsRestore::Defaults },
     { "#", SettingsRestore::Parameters }, { "gcode", SettingsRestore::Parameters },
     { "*", SettingsRestore::All },        { "all", SettingsRestore::All },

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -21,7 +21,7 @@
 
 volatile ExecAlarm lastAlarm;  // The most recent alarm code
 
-std::map<ExecAlarm, const char*> AlarmNames = {
+const std::map<ExecAlarm, const char*> AlarmNames = {
     { ExecAlarm::None, "None" },
     { ExecAlarm::HardLimit, "Hard Limit" },
     { ExecAlarm::SoftLimit, "Soft Limit" },

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -73,7 +73,7 @@ enum class ExecAlarm : uint8_t {
 extern volatile ExecAlarm lastAlarm;
 
 #include <map>
-extern std::map<ExecAlarm, const char*> AlarmNames;
+extern const std::map<ExecAlarm, const char*> AlarmNames;
 
 const char* alarmString(ExecAlarm alarmNumber);
 

--- a/FluidNC/src/System.cpp
+++ b/FluidNC/src/System.cpp
@@ -109,7 +109,7 @@ float* get_wco() {
     return wco;
 }
 
-std::map<State, const char*> StateName = {
+const std::map<State, const char*> StateName = {
     { State::Idle, "Idle" },
     { State::Alarm, "Alarm" },
     { State::CheckMode, "CheckMode" },

--- a/FluidNC/src/System.h
+++ b/FluidNC/src/System.h
@@ -12,7 +12,7 @@
 #include "Config.h"  // MAX_N_AXIS
 #include <map>
 
-extern std::map<State, const char*> StateName;
+extern const std::map<State, const char*> StateName;
 
 // Step segment generator state flags.
 struct StepControl {

--- a/platformio.ini
+++ b/platformio.ini
@@ -108,7 +108,7 @@ build_flags = ${common_esp32.build_flags} ${common_wifi.build_flags}
 [env:bt_s2]
 extends = common_esp32_s2
 lib_deps = ${common.lib_deps} ${common.bt_deps}
-build_flags = ${common_esp32.build_flags} ${common_bt.build_flags}\
+build_flags = ${common_esp32.build_flags} ${common_bt.build_flags}
 
 [env:wifibt_s2]
 extends = common_esp32_s2


### PR DESCRIPTION
actually define constant std::maps as const std::map

Frees up a bit of RAM and is syntactically correct for the maps' usage

[env:wifi]
RAM:   [===       ]  27.3% (used 89552 bytes from 327680 bytes)
Flash: [========= ]  91.1% (used 1791441 bytes from 1966080 bytes)

also 
- removes a trail "\" from platformio.ini
- moves the gcode extensions string to within file that it is used