### PR TITLE
make class constant values also static

### DIFF
--- a/FluidNC/src/Channel.h
+++ b/FluidNC/src/Channel.h
@@ -33,18 +33,18 @@ class Channel : public Stream {
 private:
     void pin_event(uint32_t pinnum, bool active);
 
-    const int PinLowFirst  = 0x100;
-    const int PinLowLast   = 0x13f;
-    const int PinHighFirst = 0x140;
-    const int PinHighLast  = 0x17f;
+    static constexpr int PinLowFirst  = 0x100;
+    static constexpr int PinLowLast   = 0x13f;
+    static constexpr int PinHighFirst = 0x140;
+    static constexpr int PinHighLast  = 0x17f;
 
-    const int PinACK = 0xB2;
-    const int PinNAK = 0xB3;
+    static constexpr int PinACK = 0xB2;
+    static constexpr int PinNAK = 0xB3;
 
-    const int timeout = 2000;
+    static constexpr int timeout = 2000;
 
 public:
-    static const int maxLine = 255;
+    static constexpr int maxLine = 255;
 
     int _message_level = MsgLevelVerbose;
 

--- a/FluidNC/src/Motors/Solenoid.h
+++ b/FluidNC/src/Motors/Solenoid.h
@@ -10,7 +10,7 @@ namespace MotorDrivers {
         void config_message() override;
         void update() override;
 
-        const uint8_t _update_rate_ms = 50;
+        static constexpr uint8_t _update_rate_ms = 50;
 
         float    _off_percent  = 0.0;
         float    _pull_percent = 100.0;

--- a/FluidNC/src/Motors/TrinamicBase.h
+++ b/FluidNC/src/Motors/TrinamicBase.h
@@ -50,7 +50,7 @@ namespace MotorDrivers {
         uint8_t _toff_stealthchop = 5;
         uint8_t _toff_coolstep    = 3;
 
-        const double fclk = 12700000.0;  // Internal clock Approx (Hz) used to calculate TSTEP from homing rate
+        static constexpr double fclk = 12700000.0;  // Internal clock Approx (Hz) used to calculate TSTEP from homing rate
 
         float        holdPercent();
         bool         report_open_load(bool ola, bool olb);

--- a/FluidNC/src/Motors/TrinamicSpiDriver.h
+++ b/FluidNC/src/Motors/TrinamicSpiDriver.h
@@ -67,8 +67,9 @@ namespace MotorDrivers {
     protected:
         Pin       _cs_pin;  // The chip select pin (can be the same for daisy chain)
         int32_t   _spi_index      = -1;
-        const int _spi_freq       = 100000;
         bool      _spi_setup_done = false;
+
+        static constexpr int _spi_freq = 100000;
 
         void config_message() override;
 

--- a/FluidNC/src/Spindles/BESCSpindle.h
+++ b/FluidNC/src/Spindles/BESCSpindle.h
@@ -30,8 +30,8 @@ namespace Spindles {
     class BESC : public PWM {
     private:
         // Fixed
-        const uint32_t besc_pwm_min_freq = 50;    // 50 Hz
-        const uint32_t besc_pwm_max_freq = 2000;  // 50 Hz
+        static constexpr uint32_t besc_pwm_min_freq = 50;    // 50 Hz
+        static constexpr uint32_t besc_pwm_max_freq = 2000;  // 50 Hz
 
         // Calculated
         uint32_t _pulse_span_counts;  // In counts of a 32-bit counter. ESP32 uses up to 20bits

--- a/FluidNC/src/UartChannel.h
+++ b/FluidNC/src/UartChannel.h
@@ -15,7 +15,7 @@ private:
     int _uart_num           = 0;
     int _report_interval_ms = 0;
 
-    const int _ack_timeout = 2000;
+    static constexpr int _ack_timeout = 2000;
 
 public:
     UartChannel(int num, bool addCR = false);


### PR DESCRIPTION
class member variables which are constant should also be static. 
Not having them static affects compiler generated operators.

More details here:
https://www.reddit.com/r/cpp/comments/8wbeom/coding_guideline_avoid_const_member_variables/

Updated to use constexpr instead of const to be modern and declare that the values are known at compile time.