### PR TITLE
define Events as constant 

### DIFF
--- a/FluidNC/src/Control.cpp
+++ b/FluidNC/src/Control.cpp
@@ -28,7 +28,7 @@ void Control::init() {
 
 void Control::group(Configuration::HandlerBase& handler) {
     for (auto pin : _pins) {
-        handler.item(pin->_legend.c_str(), pin->_pin);
+        handler.item(pin->legend().c_str(), pin->pin());
     }
 }
 
@@ -55,7 +55,7 @@ bool Control::startup_check() {
     bool ret = false;
     for (auto pin : _pins) {
         if (pin->get()) {
-            log_error(pin->_legend << " is active at startup");
+            log_error(pin->legend() << " is active at startup");
             ret = true;
         }
     }

--- a/FluidNC/src/ControlPin.h
+++ b/FluidNC/src/ControlPin.h
@@ -5,16 +5,17 @@
 namespace Machine {
     class ControlPin : public EventPin {
     private:
-        const char _letter;  // The name that appears in init() messages and the name of the configuration item
+        char _letter;  // The name that appears in init() messages and the name of the configuration item
+        Pin  _pin;
 
     public:
-        ControlPin(Event* event, const char* legend, char letter) : EventPin(event, legend), _letter(letter) {}
+        ControlPin(const Event* event, const char* legend, char letter) : EventPin(event, legend), _letter(letter) {}
 
         void init();
 
-        Pin _pin;
-
         bool get() { return _pin.read(); }
+
+        Pin& pin() { return _pin; }
 
         char letter() { return _letter; };
 

--- a/FluidNC/src/Event.h
+++ b/FluidNC/src/Event.h
@@ -8,7 +8,7 @@
 class Event {
 public:
     Event() {}
-    virtual void run(void* arg) = 0;
+    virtual void run(void* arg) const = 0;
 };
 
 class NoArgEvent : public Event {
@@ -16,7 +16,7 @@ class NoArgEvent : public Event {
 
 public:
     NoArgEvent(void (*function)()) : _function(function) {}
-    void run(void* arg) override {
+    void run(void* arg) const override {
         if (_function) {
             _function();
         }
@@ -28,7 +28,7 @@ class ArgEvent : public Event {
 
 public:
     ArgEvent(void (*function)(void*)) : _function(function) {}
-    void run(void* arg) override {
+    void run(void* arg) const override {
         if (_function) {
             _function(arg);
         }

--- a/FluidNC/src/Machine/EventPin.cpp
+++ b/FluidNC/src/Machine/EventPin.cpp
@@ -3,8 +3,6 @@
 
 #include "src/Protocol.h"  // protocol_send_event
 
-EventPin::EventPin(Event* event, const char* legend) : _event(event), _legend(legend) {}
-
 void EventPin::trigger(bool active) {
     update(active);
     log_debug(_legend << " " << active);

--- a/FluidNC/src/Machine/EventPin.h
+++ b/FluidNC/src/Machine/EventPin.h
@@ -5,16 +5,18 @@
 
 class EventPin {
 protected:
-    Event* _event = nullptr;  // Subordinate event that is called conditionally
+    const Event* _event;  
+    std::string  _legend;  // The name that appears in init() messages and the name of the configuration item
 
 public:
-    std::string _legend;  // The name that appears in init() messages and the name of the configuration item
 
-    EventPin(Event* event, const char* legend);
+    EventPin(const Event* event, const char* legend) : _event(event), _legend(legend) {};
 
     virtual void update(bool state) {};
 
     virtual void trigger(bool active);
+
+    const std::string& legend() { return _legend; }
 
     ~EventPin() {}
 };

--- a/FluidNC/src/Machine/Macros.cpp
+++ b/FluidNC/src/Machine/Macros.cpp
@@ -6,9 +6,7 @@
 #include "src/System.h"                 // sys
 #include "src/Machine/MachineConfig.h"  // config
 
-Macro::Macro(const char* name) : _name(name) {}
-
-void MacroEvent::run(void* arg) {
+void MacroEvent::run(void* arg) const {
     config->_macros->_macro[_num].run();
 }
 
@@ -18,10 +16,10 @@ Macro Macros::_after_homing                  = { "after_homing" };
 Macro Macros::_after_reset                   = { "after_reset" };
 Macro Macros::_after_unlock                  = { "after_unlock" };
 
-MacroEvent macro0Event { 0 };
-MacroEvent macro1Event { 1 };
-MacroEvent macro2Event { 2 };
-MacroEvent macro3Event { 3 };
+const MacroEvent macro0Event { 0 };
+const MacroEvent macro1Event { 1 };
+const MacroEvent macro2Event { 2 };
+const MacroEvent macro3Event { 3 };
 
 // clang-format off
 const std::map<std::string, Cmd> overrideCodes = {

--- a/FluidNC/src/Machine/Macros.h
+++ b/FluidNC/src/Machine/Macros.h
@@ -15,20 +15,20 @@ class MacroEvent : public Event {
 
 public:
     MacroEvent(int num) : _num(num) {}
-    void run(void*) override;
+    void run(void*) const override;
 };
 
-extern MacroEvent macro0Event;
-extern MacroEvent macro1Event;
-extern MacroEvent macro2Event;
-extern MacroEvent macro3Event;
+extern const MacroEvent macro0Event;
+extern const MacroEvent macro1Event;
+extern const MacroEvent macro2Event;
+extern const MacroEvent macro3Event;
 
 namespace Machine {
     class Macro {
     public:
         std::string _gcode;
         const char* _name;
-        Macro(const char* name);
+        Macro(const char* name) : _name(name) {}
         bool run();
     };
 

--- a/FluidNC/src/Probe.cpp
+++ b/FluidNC/src/Probe.cpp
@@ -8,7 +8,7 @@
 #include "Machine/MachineConfig.h"
 
 extern void protocol_do_probe(void* arg);
-ArgEvent probeEvent { protocol_do_probe };
+const ArgEvent probeEvent { protocol_do_probe };
 
 class ProbeEventPin : public EventPin {
 private:

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -1004,7 +1004,7 @@ static void protocol_do_fault_pin(void* arg) {
         mc_critical(ExecAlarm::HardStop);  // Initiate system kill.
     }
     ControlPin* pin = (ControlPin*)arg;
-    log_info("Stopped by " << pin->_legend);
+    log_info("Stopped by " << pin->legend());
 }
 void protocol_do_rt_reset() {
     if (state_is(State::Homing)) {
@@ -1025,30 +1025,30 @@ void protocol_do_rt_reset() {
     protocol_send_event(&restartEvent);
 }
 
-ArgEvent feedOverrideEvent { protocol_do_feed_override };
-ArgEvent rapidOverrideEvent { protocol_do_rapid_override };
-ArgEvent spindleOverrideEvent { protocol_do_spindle_override };
-ArgEvent accessoryOverrideEvent { protocol_do_accessory_override };
-ArgEvent limitEvent { protocol_do_limit };
-ArgEvent faultPinEvent { protocol_do_fault_pin };
-ArgEvent reportStatusEvent { (void (*)(void*))report_realtime_status };
+const ArgEvent feedOverrideEvent { protocol_do_feed_override };
+const ArgEvent rapidOverrideEvent { protocol_do_rapid_override };
+const ArgEvent spindleOverrideEvent { protocol_do_spindle_override };
+const ArgEvent accessoryOverrideEvent { protocol_do_accessory_override };
+const ArgEvent limitEvent { protocol_do_limit };
+const ArgEvent faultPinEvent { protocol_do_fault_pin };
+const ArgEvent reportStatusEvent { (void (*)(void*))report_realtime_status };
 
-NoArgEvent safetyDoorEvent { request_safety_door };
-NoArgEvent feedHoldEvent { protocol_do_feedhold };
-NoArgEvent cycleStartEvent { protocol_do_cycle_start };
-NoArgEvent cycleStopEvent { protocol_do_cycle_stop };
-NoArgEvent motionCancelEvent { protocol_do_motion_cancel };
-NoArgEvent sleepEvent { protocol_do_sleep };
-NoArgEvent debugEvent { report_realtime_debug };
-NoArgEvent startEvent { protocol_do_start };
-NoArgEvent restartEvent { protocol_do_restart };
-NoArgEvent runStartupLinesEvent { protocol_run_startup_lines };
+const NoArgEvent safetyDoorEvent { request_safety_door };
+const NoArgEvent feedHoldEvent { protocol_do_feedhold };
+const NoArgEvent cycleStartEvent { protocol_do_cycle_start };
+const NoArgEvent cycleStopEvent { protocol_do_cycle_stop };
+const NoArgEvent motionCancelEvent { protocol_do_motion_cancel };
+const NoArgEvent sleepEvent { protocol_do_sleep };
+const NoArgEvent debugEvent { report_realtime_debug };
+const NoArgEvent startEvent { protocol_do_start };
+const NoArgEvent restartEvent { protocol_do_restart };
+const NoArgEvent runStartupLinesEvent { protocol_run_startup_lines };
 
-NoArgEvent rtResetEvent { protocol_do_rt_reset };
+const NoArgEvent rtResetEvent { protocol_do_rt_reset };
 
 // The problem is that report_realtime_status needs a channel argument
 // Event statusReportEvent { protocol_do_status_report(XXX) };
-ArgEvent alarmEvent { (void (*)(void*))protocol_do_alarm };
+const ArgEvent alarmEvent { (void (*)(void*))protocol_do_alarm };
 
 xQueueHandle event_queue;
 
@@ -1057,11 +1057,11 @@ void protocol_init() {
     message_queue = xQueueCreate(10, sizeof(LogMessage));
 }
 
-void IRAM_ATTR protocol_send_event_from_ISR(Event* evt, void* arg) {
+void IRAM_ATTR protocol_send_event_from_ISR(const Event* evt, void* arg) {
     EventItem item { evt, arg };
     xQueueSendFromISR(event_queue, &item, NULL);
 }
-void protocol_send_event(Event* evt, void* arg) {
+void protocol_send_event(const Event* evt, void* arg) {
     EventItem item { evt, arg };
     xQueueSend(event_queue, &item, 0);
 }

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -84,51 +84,51 @@ enum AccessoryOverride {
     MistToggle     = 3,
 };
 
-extern ArgEvent feedOverrideEvent;
-extern ArgEvent rapidOverrideEvent;
-extern ArgEvent spindleOverrideEvent;
-extern ArgEvent accessoryOverrideEvent;
-extern ArgEvent limitEvent;
-extern ArgEvent faultPinEvent;
+extern const ArgEvent feedOverrideEvent;
+extern const ArgEvent rapidOverrideEvent;
+extern const ArgEvent spindleOverrideEvent;
+extern const ArgEvent accessoryOverrideEvent;
+extern const ArgEvent limitEvent;
+extern const ArgEvent faultPinEvent;
 
-extern ArgEvent reportStatusEvent;
+extern const ArgEvent reportStatusEvent;
 
-extern NoArgEvent safetyDoorEvent;
-extern NoArgEvent feedHoldEvent;
-extern NoArgEvent cycleStartEvent;
-extern NoArgEvent cycleStopEvent;
-extern NoArgEvent motionCancelEvent;
-extern NoArgEvent sleepEvent;
-extern NoArgEvent rtResetEvent;
-extern NoArgEvent debugEvent;
-extern NoArgEvent unhomedEvent;
-extern NoArgEvent startEvent;
-extern NoArgEvent restartEvent;
+extern const NoArgEvent safetyDoorEvent;
+extern const NoArgEvent feedHoldEvent;
+extern const NoArgEvent cycleStartEvent;
+extern const NoArgEvent cycleStopEvent;
+extern const NoArgEvent motionCancelEvent;
+extern const NoArgEvent sleepEvent;
+extern const NoArgEvent rtResetEvent;
+extern const NoArgEvent debugEvent;
+extern const NoArgEvent unhomedEvent;
+extern const NoArgEvent startEvent;
+extern const NoArgEvent restartEvent;
 
-extern NoArgEvent runStartupLinesEvent;
+extern const NoArgEvent runStartupLinesEvent;
 
-// extern NoArgEvent statusReportEvent;
+// extern const NoArgEvent statusReportEvent;
 
 extern xQueueHandle event_queue;
 
 extern bool pollingPaused;
 
 struct EventItem {
-    Event* event;
+    const Event* event;
     void*  arg;
 };
 
-void protocol_send_event(Event*, void* arg = 0);
+void protocol_send_event(const Event*,  void* arg = 0);
 void protocol_handle_events();
 
 void send_alarm(ExecAlarm alarm);
 void send_alarm_from_ISR(ExecAlarm alarm);
 
-inline void protocol_send_event(Event* evt, int arg) {
+inline void protocol_send_event(const Event* evt, int arg) {
     protocol_send_event(evt, (void*)arg);
 }
 
-void protocol_send_event_from_ISR(Event* evt, void* arg = 0);
+void protocol_send_event_from_ISR(const Event* evt, void* arg = 0);
 
 void drain_messages();
 


### PR DESCRIPTION
- Well-known Events are defined as constant reducing some use of RAM
- Various xxxPin and Macro classes are update to support the constant Event pointers
- Pin classes are more objected-orientated by providing accessors to values now made private or protected
- Simple Pin assignment constructors are moved to the header files so the compiler can optimize and inline the assignments

[env:wifi]
RAM:   [===       ]  27.3% (used 89400 bytes from 327680 bytes)
Flash: [========= ]  91.1% (used 1791125 bytes from 1966080 bytes)