### PR TITLE
remove dependency on the global Serial object

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@ build_flags =
 	-Wno-unused-function
 lib_deps =
 	TMCStepper@>=0.7.0,<1.0.0
-	thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.2.1
+	ESP8266 and ESP32 OLED driver for SSD1306 displays=https://github.com/craiglink/esp8266-oled-ssd1306#NO_GLOBAL_SERIAL
 bt_deps =
 	BluetoothSerial
 wifi_deps =
@@ -64,7 +64,7 @@ monitor_flags =
 monitor_filters=esp32_exception_decoder
 board_build.f_flash = 80000000L
 build_unflags = -std=gnu++11
-build_flags = ${common.build_flags} -std=gnu++17 -D_GLIBCXX_HAVE_DIRENT_H -D__FLUIDNC
+build_flags = ${common.build_flags} -std=gnu++17 -D_GLIBCXX_HAVE_DIRENT_H -D__FLUIDNC -DNO_GLOBAL_SERIAL
 ; -lstdc++fs
 build_src_filter =
 	+<*.h> +<*.s> +<*.S> +<*.cpp> +<*.c> +<src/>


### PR DESCRIPTION
remove dependency on the global Serial object which was only used in OLEDDisplay to output a deprecated message.

PR to original OLEDDisplay repo has been requested as well: https://github.com/ThingPulse/esp8266-oled-ssd1306/pull/408/files

Reduces RAM and Memory usage

[env:wifi] // before
RAM:   [===       ]  27.3% (used 89400 bytes from 327680 bytes)
Flash: [========= ]  91.1% (used 1791125 bytes from 1966080 bytes)

[env:wifi] // after
RAM:   [===       ]  27.2% (used 89072 bytes from 327680 bytes)
Flash: [========= ]  90.9% (used 1786609 bytes from 1966080 bytes)