### PR TITLE
Pin OLED lib version to eliminate global Serial object

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@ build_flags =
 	-Wno-unused-function
 lib_deps =
 	TMCStepper@>=0.7.0,<1.0.0
-	thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.2.1
+	thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@4.4.1
 bt_deps =
 	BluetoothSerial
 wifi_deps =


### PR DESCRIPTION
This is an alternative solution to the problem addressed by #1214