### PR TITLE
custom esp32 WebServer library which allows for conditional compilation of Auth code

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,6 +35,8 @@ bt_deps =
 wifi_deps =
 	arduinoWebSockets=https://github.com/MitchBradley/arduinoWebSockets#canSend
 	WiFi=https://github.com/MitchBradley/WiFi#canWrite
+	WebServer=https://github.com/craiglink/arduino-esp32-libraries-WebServer#no-auth
+
         ; If we include the following explicit dependencies when we get the
         ; Arduino framework code from github, platformio picks up different
         ; and incompatible versions of these libraries from who knows where, 
@@ -42,7 +44,6 @@ wifi_deps =
 	; DNSServer
 	; ESPmDNS
 	; Update
-	; WebServer
 	; WiFi
 	; WiFiClientSecure
 


### PR DESCRIPTION
leverage custom esp32 WebServer library which conditionally compiles out Authentication code to match our ENABLE_AUTHENTICATION preprocessor definition usage.

https://github.com/craiglink/arduino-esp32-libraries-WebServer/compare/release/v2.x...no-auth

Additionally, it fixes a const array to be static const and reduce RAM usage by 320 bytes.

PR for the static const has been submitted back to espressif : https://github.com/espressif/arduino-esp32/pull/9594

[env:wifi]
RAM:   [===       ]  27.1% (used 88944 bytes from 327680 bytes)
Flash: [========= ]  90.8% (used 1785069 bytes from 1966080 bytes)