### PR TITLE
Move XON/XOFF handler from Uart to UartChannel

### DIFF
--- a/FluidNC/src/Uart.cpp
+++ b/FluidNC/src/Uart.cpp
@@ -62,11 +62,6 @@ int Uart::read() {
     }
     uint8_t c;
     int     res = uart_read_bytes(uart_port_t(_uart_num), &c, 1, 0);
-    if (res == 1 && c == 0x11) {
-        // 0x11 is XON.  If we receive that, it is a request to use software flow control
-        setSwFlowControl(true, -1, -1);
-        return -1;
-    }
     return res == 1 ? c : -1;
 }
 

--- a/FluidNC/src/UartChannel.cpp
+++ b/FluidNC/src/UartChannel.cpp
@@ -92,7 +92,13 @@ bool UartChannel::lineComplete(char* line, char c) {
 }
 
 int UartChannel::read() {
-    return _uart->read();
+    int c = _uart->read();
+    if (c == 0x11) {
+        // 0x11 is XON.  If we receive that, it is a request to use software flow control
+        _uart->setSwFlowControl(true, -1, -1);
+        return -1;
+    }
+    return c;
 }
 
 void UartChannel::flushRx() {


### PR DESCRIPTION
This fixes a hang that can happen if, for example, a TMC2209 sends 0x11 which is XON, thus triggering software flow control. One way to trigger the failure is to issue $H twice on an Fysetc E4 controller.