### PR TITLE
Fixed single-axis homing fail with cycle=0.

### DIFF
--- a/FluidNC/src/Limits.cpp
+++ b/FluidNC/src/Limits.cpp
@@ -99,21 +99,19 @@ void limit_error() {
 }
 
 float limitsMaxPosition(size_t axis) {
-    auto  axisConfig = config->_axes->_axis[axis];
-    auto  homing     = axisConfig->_homing;
-    float mpos       = (homing != nullptr) ? homing->_mpos : 0;
-    auto  maxtravel  = axisConfig->_maxTravel;
+    auto axisConfig = config->_axes->_axis[axis];
+    auto homing     = axisConfig->_homing;
+    auto mpos       = homing ? homing->_mpos : 0;
+    auto maxtravel  = axisConfig->_maxTravel;
 
-    //return (homing == nullptr || homing->_positiveDirection) ? mpos + maxtravel : mpos;
-    return (homing == nullptr || homing->_positiveDirection) ? mpos : mpos + maxtravel;
+    return (!homing || homing->_positiveDirection) ? mpos : mpos + maxtravel;
 }
 
 float limitsMinPosition(size_t axis) {
-    auto  axisConfig = config->_axes->_axis[axis];
-    auto  homing     = axisConfig->_homing;
-    float mpos       = (homing != nullptr) ? homing->_mpos : 0;
-    auto  maxtravel  = axisConfig->_maxTravel;
+    auto axisConfig = config->_axes->_axis[axis];
+    auto homing     = axisConfig->_homing;
+    auto mpos       = homing ? homing->_mpos : 0;
+    auto maxtravel  = axisConfig->_maxTravel;
 
-    //return (homing == nullptr || homing->_positiveDirection) ? mpos : mpos - maxtravel;
-    return (homing == nullptr || homing->_positiveDirection) ? mpos - maxtravel : mpos;
+    return (!homing || homing->_positiveDirection) ? mpos - maxtravel : mpos;
 }

--- a/FluidNC/src/Machine/Axes.cpp
+++ b/FluidNC/src/Machine/Axes.cpp
@@ -286,7 +286,7 @@ namespace Machine {
     }
 
     bool Axes::namesToMask(const char* names, AxisMask& mask) {
-        bool retval = true;
+        bool       retval   = true;
         const auto lenNames = strlen(names);
         for (int i = 0; i < lenNames; i++) {
             char  axisName = toupper(names[i]);

--- a/FluidNC/src/Machine/Axis.cpp
+++ b/FluidNC/src/Machine/Axis.cpp
@@ -28,9 +28,6 @@ namespace Machine {
         uint32_t stepRate = uint32_t(_stepsPerMm * _maxRate / 60.0);
         auto     maxRate  = config->_stepping->maxPulsesPerSec();
         Assert(stepRate <= maxRate, "Stepping rate %d steps/sec exceeds the maximum rate %d", stepRate, maxRate);
-        if (_homing == nullptr) {
-            _homing = new Homing();
-        }
         if (_motors[0] == nullptr) {
             _motors[0] = new Machine::Motor(_axis, 0);
         }
@@ -44,7 +41,7 @@ namespace Machine {
                 m->init();
             }
         }
-        if (_homing && _homing->_cycle != 0) {
+        if (_homing && _homing->_cycle >= 0) {
             _homing->init();
             set_bitnum(Axes::homingMask, _axis);
         }
@@ -81,7 +78,9 @@ namespace Machine {
     }
 
     // Does this axis have 2 motors?
-    bool Axis::hasDualMotor() { return _motors[0] && _motors[0]->isReal() && _motors[1] && _motors[1]->isReal(); }
+    bool Axis::hasDualMotor() {
+        return _motors[0] && _motors[0]->isReal() && _motors[1] && _motors[1]->isReal();
+    }
 
     // How many motors have switches defined?
     int Axis::motorsWithSwitches() {

--- a/FluidNC/src/Motors/Dynamixel2.cpp
+++ b/FluidNC/src/Motors/Dynamixel2.cpp
@@ -171,8 +171,10 @@ namespace MotorDrivers {
             return false;
         }
 
-        auto axis = config->_axes->_axis[_axis_index];
-        set_motor_steps(_axis_index, mpos_to_steps(axis->_homing->_mpos, _axis_index));
+        auto axisConfig = config->_axes->_axis[_axis_index];
+        auto homing     = axisConfig->_homing;
+        auto mpos       = homing ? homing->_mpos : 0;
+        set_motor_steps(_axis_index, mpos_to_steps(mpos, _axis_index));
 
         set_disable(false);
         set_location();  // force the PWM to update now

--- a/FluidNC/src/Motors/RcServo.cpp
+++ b/FluidNC/src/Motors/RcServo.cpp
@@ -84,10 +84,12 @@ namespace MotorDrivers {
             return false;
 
         if (isHoming) {
-            auto axis = config->_axes->_axis[_axis_index];
-            set_motor_steps(_axis_index, mpos_to_steps(axis->_homing->_mpos, _axis_index));
+            auto axisConfig = config->_axes->_axis[_axis_index];
+            auto homing     = axisConfig->_homing;
+            auto mpos       = homing ? homing->_mpos : 0;
+            set_motor_steps(_axis_index, mpos_to_steps(mpos, _axis_index));
 
-            float home_time_sec = (axis->_maxTravel / axis->_maxRate * 60 * 1.1);  // 1.1 fudge factor for accell time.
+            float home_time_sec = (axisConfig->_maxTravel / axisConfig->_maxRate * 60 * 1.1);  // 1.1 fudge factor for accell time.
 
             _disabled = false;
             set_location();                    // force the PWM to update now
@@ -96,7 +98,9 @@ namespace MotorDrivers {
         return false;  // Cannot be homed in the conventional way
     }
 
-    void RcServo::update() { set_location(); }
+    void RcServo::update() {
+        set_location();
+    }
 
     void RcServo::set_location() {
         if (_disabled || _has_errors) {

--- a/FluidNC/src/Motors/TMC2130Driver.cpp
+++ b/FluidNC/src/Motors/TMC2130Driver.cpp
@@ -29,7 +29,9 @@ namespace MotorDrivers {
         TrinamicBase::config_motor();
     }
 
-    bool TMC2130Driver::test() { return checkVersion(0x11, tmc2130->version()); }
+    bool TMC2130Driver::test() {
+        return checkVersion(0x11, tmc2130->version());
+    }
 
     void TMC2130Driver::set_registers(bool isHoming) {
         if (_has_errors) {
@@ -66,12 +68,10 @@ namespace MotorDrivers {
             case TrinamicMode ::StallGuard:
                 log_debug(axisName() << " Stallguard");
                 {
-                    auto feedrate = config->_axes->_axis[axis_index()]->_homing->_feedRate;
-
                     tmc2130->en_pwm_mode(false);
                     tmc2130->pwm_autoscale(false);
-                    tmc2130->TCOOLTHRS(calc_tstep(feedrate, 150.0));
-                    tmc2130->THIGH(calc_tstep(feedrate, 60.0));
+                    tmc2130->TCOOLTHRS(calc_tstep(150));
+                    tmc2130->THIGH(calc_tstep(60));
                     tmc2130->sfilt(1);
                     tmc2130->diag1_stall(true);  // stallguard i/o is on diag1
                     tmc2130->sgt(constrain(_stallguard, -64, 63));

--- a/FluidNC/src/Motors/TMC2209Driver.cpp
+++ b/FluidNC/src/Motors/TMC2209Driver.cpp
@@ -49,8 +49,10 @@ namespace MotorDrivers {
         _cs_pin.synchronousWrite(true);
 
         tmc2209->I_scale_analog(false);  // do not scale via pot
+        log_debug("sr 3'");
         tmc2209->rms_current(run_i, TrinamicBase::holdPercent());
 
+        log_debug("sr 4");
         // The TMCStepper library uses the value 0 to mean 1x microstepping
         int usteps = _microsteps == 1 ? 0 : _microsteps;
         tmc2209->microsteps(usteps);
@@ -69,12 +71,10 @@ namespace MotorDrivers {
                 break;
             case TrinamicMode ::StallGuard:  //TODO: check all configurations for stallguard
             {
-                auto axisConfig     = config->_axes->_axis[this->axis_index()];
-                auto homingFeedRate = (axisConfig->_homing != nullptr) ? axisConfig->_homing->_feedRate : 200;
                 log_debug(axisName() << " Stallguard");
                 tmc2209->en_spreadCycle(false);
                 tmc2209->pwm_autoscale(true);
-                tmc2209->TCOOLTHRS(calc_tstep(homingFeedRate, 150.0));
+                tmc2209->TCOOLTHRS(calc_tstep(150));
                 tmc2209->SGTHRS(_stallguard);
                 break;
             }

--- a/FluidNC/src/Motors/TMC5160Driver.cpp
+++ b/FluidNC/src/Motors/TMC5160Driver.cpp
@@ -29,7 +29,9 @@ namespace MotorDrivers {
         TrinamicBase::config_motor();
     }
 
-    bool TMC5160Driver::test() { return checkVersion(0x30, tmc5160->version()); }
+    bool TMC5160Driver::test() {
+        return checkVersion(0x30, tmc5160->version());
+    }
 
     void TMC5160Driver::set_registers(bool isHoming) {
         if (_has_errors) {
@@ -67,12 +69,10 @@ namespace MotorDrivers {
             case TrinamicMode ::StallGuard:
                 log_debug(axisName() << " Stallguard");
                 {
-                    auto feedrate = config->_axes->_axis[axis_index()]->_homing->_feedRate;
-
                     tmc5160->en_pwm_mode(false);
                     tmc5160->pwm_autoscale(false);
-                    tmc5160->TCOOLTHRS(calc_tstep(feedrate, 150.0));
-                    tmc5160->THIGH(calc_tstep(feedrate, 60.0));
+                    tmc5160->TCOOLTHRS(calc_tstep(150));
+                    tmc5160->THIGH(calc_tstep(60));
                     tmc5160->sfilt(1);
                     tmc5160->diag1_stall(true);  // stallguard i/o is on diag1
                     tmc5160->sgt(constrain(_stallguard, -64, 63));

--- a/FluidNC/src/Motors/TrinamicBase.cpp
+++ b/FluidNC/src/Motors/TrinamicBase.cpp
@@ -31,8 +31,12 @@ namespace MotorDrivers {
     // tstep = fclk / (time between 1/256 steps)
     // This is used to set the stallguard window from the homing speed.
     // The percent is the offset on the window
-    uint32_t TrinamicBase::calc_tstep(float speed, float percent) {
-        double tstep = speed / 60.0 * config->_axes->_axis[axis_index()]->_stepsPerMm * (256.0 / _microsteps);
+    uint32_t TrinamicBase::calc_tstep(int percent) {
+        auto axisConfig     = config->_axes->_axis[axis_index()];
+        auto homing         = axisConfig->_homing;
+        auto homingFeedrate = homing ? homing->_feedRate : 200.0;
+
+        double tstep = homingFeedrate / 60.0 * config->_axes->_axis[axis_index()]->_stepsPerMm * (256.0 / _microsteps);
         tstep        = fclk / tstep * percent / 100.0;
 
         return static_cast<uint32_t>(tstep);
@@ -113,7 +117,9 @@ namespace MotorDrivers {
         return true;
     }
 
-    void TrinamicBase::reportCommsFailure(void) { log_info(axisName() << " communications check failed"); }
+    void TrinamicBase::reportCommsFailure(void) {
+        log_info(axisName() << " communications check failed");
+    }
 
     bool TrinamicBase::startDisable(bool disable) {
         if (_has_errors) {

--- a/FluidNC/src/Motors/TrinamicBase.h
+++ b/FluidNC/src/Motors/TrinamicBase.h
@@ -25,7 +25,7 @@ namespace MotorDrivers {
         static std::vector<TrinamicBase*> _instances;
 
     protected:
-        uint32_t calc_tstep(float speed, float percent);
+        uint32_t calc_tstep(int percent);
 
         bool         _disable_state_known = false;  // we need to always set the state least once.
         bool         _has_errors;

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -385,7 +385,8 @@ static Error home(AxisMask axisMask) {
         for (int axis = 0; axis < n_axis; axis++) {
             if (bitnum_is_true(axisMask, axis)) {
                 auto axisConfig     = config->_axes->_axis[axis];
-                auto homing_allowed = axisConfig->_homing->_allow_single_axis;
+                auto homing         = axisConfig->_homing;
+                auto homing_allowed = homing && homing->_allow_single_axis;
                 if (!homing_allowed)
                     return Error::SingleAxisHoming;
             }
@@ -422,7 +423,7 @@ static Error home_all(const char* value, WebUI::AuthenticationLevel auth_level, 
     // value can be a list of cycle numbers like "21", which will run homing cycle 2 then cycle 1,
     // or a list of axis names like "XZ", which will home the X and Z axes simultaneously
     if (value) {
-        int ndigits = 0;
+        int        ndigits  = 0;
         const auto lenValue = strlen(value);
         for (int i = 0; i < lenValue; i++) {
             char cycleName = value[i];

--- a/FluidNC/test/TestFramework.h
+++ b/FluidNC/test/TestFramework.h
@@ -24,7 +24,7 @@
             static void runWrap() {                                                                                                        \
                 try {                                                                                                                      \
                     runDetail();                                                                                                           \
-                } catch (AssertionFailed ex) { TEST_FAIL_MESSAGE(ex.stackTrace.c_str()); } catch (...) {                                   \
+                } catch (AssertionFailed & ex) { TEST_FAIL_MESSAGE(ex.stackTrace.c_str()); } catch (...) {                                 \
                     TEST_FAIL_MESSAGE("Failed for unknown reason.");                                                                       \
                 }                                                                                                                          \
             }                                                                                                                              \


### PR DESCRIPTION
The fix involved adding homing/cycle=0 axes to the homing mask. The problem was introduced via a combination of automatically creating homing sections if they were not explicitly present, along with the way that the default cycle value for such sections was interpreted for the purpose of homing mask.  I eliminated the inferred sections, ensuring that code that uses homing sections is careful to check for nonexistent ones.  In the process, I factored the tstep calculation in Trinamic drivers so the homing related code is in one place.