### PR TITLE
Save ram

### DIFF
--- a/FluidNC/ld/esp32/sections.ld
+++ b/FluidNC/ld/esp32/sections.ld
@@ -558,8 +558,6 @@ SECTIONS
     *libspi_flash.a:spi_flash_chip_winbond.*(.rodata .rodata.*)
     *libspi_flash.a:spi_flash_rom_patch.*(.rodata .rodata.*)
 
-    INCLUDE vtable_in_dram.ld
-
     _data_end = ABSOLUTE(.);
     . = ALIGN(4);
   } > dram0_0_seg
@@ -776,6 +774,8 @@ SECTIONS
     _coredump_iram_start = ABSOLUTE(.);
     *(.iram2.coredump .iram2.coredump.*)
     _coredump_iram_end = ABSOLUTE(.);
+
+    INCLUDE vtable_in_dram.ld
 
     _iram_data_end = ABSOLUTE(.);
   } > iram0_0_seg

--- a/FluidNC/src/WebUI/WebServer.cpp
+++ b/FluidNC/src/WebUI/WebServer.cpp
@@ -87,7 +87,9 @@ namespace WebUI {
                                                    DEFAULT_HTTP_BLOCKED_DURING_MOTION,
                                                    &onoffOptions);
     }
-    Web_Server::~Web_Server() { end(); }
+    Web_Server::~Web_Server() {
+        end();
+    }
 
     bool Web_Server::begin() {
         bool no_error = true;
@@ -325,7 +327,9 @@ namespace WebUI {
         "interval=setInterval(function(){\ni=i+1; \nvar x = document.getElementById(\"prg\"); \nx.value=i; \nif (i>5) "
         "\n{\nclearInterval(interval);\nwindow.location.href='/';\n}\n},1000);\n</script>\n</CENTER>\n</BODY>\n</HTML>\n\n";
 
-    void Web_Server::sendCaptivePortal() { sendWithOurAddress(PAGE_CAPTIVE, 200); }
+    void Web_Server::sendCaptivePortal() {
+        sendWithOurAddress(PAGE_CAPTIVE, 200);
+    }
 
     //Default 404 page that is sent when a request cannot be satisfied
     const char PAGE_404[] =
@@ -335,7 +339,9 @@ namespace WebUI {
         "interval=setInterval(function(){\ni=i+1; \nvar x = document.getElementById(\"prg\"); \nx.value=i; \nif (i>5) "
         "\n{\nclearInterval(interval);\nwindow.location.href='/';\n}\n},1000);\n</script>\n</CENTER>\n</BODY>\n</HTML>\n\n";
 
-    void Web_Server::send404Page() { sendWithOurAddress(PAGE_404, 404); }
+    void Web_Server::send404Page() {
+        sendWithOurAddress(PAGE_404, 404);
+    }
 
     void Web_Server::handle_root() {
         log_info("WebUI: Request from " << _webserver->client().remoteIP());
@@ -393,27 +399,27 @@ namespace WebUI {
             _webserver->send(500);
             return;
         }
-        const char* templ = "<?xml version=\"1.0\"?>"
-                            "<root xmlns=\"urn:schemas-upnp-org:device-1-0\">"
-                            "<specVersion>"
-                            "<major>1</major>"
-                            "<minor>0</minor>"
-                            "</specVersion>"
-                            "<URLBase>http://%s:%u/</URLBase>"
-                            "<device>"
-                            "<deviceType>upnp:rootdevice</deviceType>"
-                            "<friendlyName>%s</friendlyName>"
-                            "<presentationURL>/</presentationURL>"
-                            "<serialNumber>%s</serialNumber>"
-                            "<modelName>ESP32</modelName>"
-                            "<modelNumber>Marlin</modelNumber>"
-                            "<modelURL>http://espressif.com/en/products/hardware/esp-wroom-32/overview</modelURL>"
-                            "<manufacturer>Espressif Systems</manufacturer>"
-                            "<manufacturerURL>http://espressif.com</manufacturerURL>"
-                            "<UDN>uuid:%s</UDN>"
-                            "</device>"
-                            "</root>\r\n"
-                            "\r\n";
+        const char*       templ = "<?xml version=\"1.0\"?>"
+                                  "<root xmlns=\"urn:schemas-upnp-org:device-1-0\">"
+                                  "<specVersion>"
+                                  "<major>1</major>"
+                                  "<minor>0</minor>"
+                                  "</specVersion>"
+                                  "<URLBase>http://%s:%u/</URLBase>"
+                                  "<device>"
+                                  "<deviceType>upnp:rootdevice</deviceType>"
+                                  "<friendlyName>%s</friendlyName>"
+                                  "<presentationURL>/</presentationURL>"
+                                  "<serialNumber>%s</serialNumber>"
+                                  "<modelName>ESP32</modelName>"
+                                  "<modelNumber>Marlin</modelNumber>"
+                                  "<modelURL>http://espressif.com/en/products/hardware/esp-wroom-32/overview</modelURL>"
+                                  "<manufacturer>Espressif Systems</manufacturer>"
+                                  "<manufacturerURL>http://espressif.com</manufacturerURL>"
+                                  "<UDN>uuid:%s</UDN>"
+                                  "</device>"
+                                  "</root>\r\n"
+                                  "\r\n";
         char              uuid[37];
         const std::string sip    = IP_string(WiFi.localIP());
         uint32_t          chipId = (uint16_t)(ESP.getEfuseMac() >> 32);
@@ -772,10 +778,16 @@ namespace WebUI {
         sendJSON(code, s);
     }
 
-    void Web_Server::sendAuthFailed() { sendStatus(401, "Authentication failed"); }
+    void Web_Server::sendAuthFailed() {
+        sendStatus(401, "Authentication failed");
+    }
 
-    void Web_Server::LocalFSFileupload() { fileUpload(localfsName); }
-    void Web_Server::SDFileUpload() { fileUpload(sdName); }
+    void Web_Server::LocalFSFileupload() {
+        fileUpload(localfsName);
+    }
+    void Web_Server::SDFileUpload() {
+        fileUpload(sdName);
+    }
 
     //Web Update handler
     void Web_Server::handleUpdate() {
@@ -1021,8 +1033,12 @@ namespace WebUI {
         sendJSON(200, s);
     }
 
-    void Web_Server::handle_direct_SDFileList() { handleFileOps(sdName); }
-    void Web_Server::handleFileList() { handleFileOps(localfsName); }
+    void Web_Server::handle_direct_SDFileList() {
+        handleFileOps(sdName);
+    }
+    void Web_Server::handleFileList() {
+        handleFileOps(localfsName);
+    }
 
     // File upload
     void Web_Server::uploadStart(const char* filename, size_t filesize, const char* fs) {

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -542,7 +542,8 @@ namespace WebUI {
     std::string WiFiConfig::station_info() {
         std::string result;
 
-        if ((WiFi.getMode() == WIFI_MODE_STA) || (WiFi.getMode() == WIFI_MODE_APSTA)) {
+        auto mode = WiFi.getMode();
+        if (mode == WIFI_MODE_STA || mode == WIFI_MODE_APSTA) {
             result += "Mode=STA:SSID=";
             result += WiFi.SSID().c_str();
             result += ":Status=";
@@ -560,7 +561,8 @@ namespace WebUI {
     std::string WiFiConfig::ap_info() {
         std::string result;
 
-        if ((WiFi.getMode() == WIFI_MODE_AP) || (WiFi.getMode() == WIFI_MODE_APSTA)) {
+        auto mode = WiFi.getMode();
+        if (mode == WIFI_MODE_AP || mode == WIFI_MODE_APSTA) {
             if (WiFi.getMode() == WIFI_MODE_APSTA) {
                 result += "]\n[MSG:";
             }
@@ -675,10 +677,12 @@ namespace WebUI {
         //stop active service
         wifi_services.end();
         //Sanity check
-        if ((WiFi.getMode() == WIFI_STA) || (WiFi.getMode() == WIFI_AP_STA)) {
+        auto mode = WiFi.getMode();
+        if (mode == WIFI_STA || mode == WIFI_AP_STA) {
             WiFi.disconnect();
         }
-        if ((WiFi.getMode() == WIFI_AP) || (WiFi.getMode() == WIFI_AP_STA)) {
+
+        if (mode == WIFI_AP || mode == WIFI_AP_STA) {
             WiFi.softAPdisconnect();
         }
 

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -140,7 +140,9 @@ namespace WebUI {
         { "WPA2-ENTERPRISE", WIFI_AUTH_WPA2_ENTERPRISE },
     };
 
-    static void print_mac(Channel& out, const char* prefix, const char* mac) { log_stream(out, prefix << " (" << mac << ")"); }
+    static void print_mac(Channel& out, const char* prefix, const char* mac) {
+        log_stream(out, prefix << " (" << mac << ")");
+    }
 
     static Error showIP(const char* parameter, AuthenticationLevel auth_level, Channel& out) {  // ESP111
         log_stream(out, parameter << IP_string(WiFi.getMode() == WIFI_STA ? WiFi.localIP() : WiFi.softAPIP()));
@@ -872,7 +874,9 @@ namespace WebUI {
     /**
      * End WiFi
      */
-    void WiFiConfig::end() { StopWiFi(); }
+    void WiFiConfig::end() {
+        StopWiFi();
+    }
 
     /**
      * Reset ESP
@@ -892,12 +896,16 @@ namespace WebUI {
         }
         log_info("WiFi reset done");
     }
-    bool WiFiConfig::isOn() { return !(WiFi.getMode() == WIFI_MODE_NULL); }
+    bool WiFiConfig::isOn() {
+        return !(WiFi.getMode() == WIFI_MODE_NULL);
+    }
 
     /**
      * Handle not critical actions that must be done in sync environment
      */
-    void WiFiConfig::handle() { wifi_services.handle(); }
+    void WiFiConfig::handle() {
+        wifi_services.handle();
+    }
 
     // Used by js/scanwifidlg.js
 
@@ -945,6 +953,8 @@ namespace WebUI {
         return Error::Ok;
     }
 
-    WiFiConfig::~WiFiConfig() { end(); }
+    WiFiConfig::~WiFiConfig() {
+        end();
+    }
 }
 #endif

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -688,18 +688,6 @@ namespace WebUI {
 
         WiFi.enableAP(false);
 
-        // Set the number of receive and transmit buffers that the
-        // WiFi stack can use.  Making these numbers too large
-        // can eat up a lot of memory at 1.6K per buffer.  It
-        // can be especially bad when there are many dynamic buffers,
-        // If there are too few Rx buffers, file upload can fail,
-        // possibly due to IP packet fragments getting lost.  The limit
-        // for what works seems to be 4 static, 4 dynamic.
-        // allowing external network traffic to use a lot of the heap.
-        // The bawin parameters are for AMPDU aggregation.
-        // rx: static dynamic bawin  tx: static dynamic bawin cache
-        WiFi.setBuffers(4, 5, 0, 4, 0, 0, 4);
-
         //SSID
         const char* SSID = wifi_sta_ssid->get();
         if (strlen(SSID) == 0) {


### PR DESCRIPTION
This frees up 25K of heap RAM by moving ISR vtables from SRAM to IRAM, and uses some of that freed-up space to allow more WiFi buffers.  It appears to fix the problem of WebUI3 uploads failing on large files.