### PR TITLE
Report Run while delaying during a job; prevents UI glitches

### DIFF
--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -462,10 +462,12 @@ void mpos_to_wpos(float* position) {
     }
 }
 
-const char* state_name() {
+const char* state_name(bool actual) {
     switch (sys.state) {
         case State::Idle:
             return "Idle";
+        case State::Delay:
+            return actual ? "Delay" : "Run";
         case State::Cycle:
             return "Run";
         case State::Hold:
@@ -477,7 +479,9 @@ const char* state_name() {
         case State::Homing:
             return "Home";
         case State::Critical:
+            return actual ? "Critical" : "Alarm";
         case State::ConfigAlarm:
+            return actual ? "ConfigAlarm" : "Alarm";
         case State::Alarm:
             return "Alarm";
         case State::CheckMode:
@@ -530,7 +534,7 @@ void report_realtime_debug() {}
 // especially during g-code programs with fast, short line segments and high frequency reports (5-20Hz).
 void report_realtime_status(Channel& channel) {
     LogStream msg(channel, "<");
-    msg << state_name();
+    msg << state_name(false);
 
     // Report position
     float* print_position = get_mpos();

--- a/FluidNC/src/Report.h
+++ b/FluidNC/src/Report.h
@@ -88,7 +88,7 @@ void addPinReport(char* status, char pinLetter);
 #include "MyIOStream.h"
 
 void        mpos_to_wpos(float* position);
-const char* state_name();
+const char* state_name(bool actual = false);
 
 extern const char* grbl_version;
 extern const char* git_info;

--- a/FluidNC/src/Types.h
+++ b/FluidNC/src/Types.h
@@ -21,6 +21,7 @@ enum class State : uint8_t {
     Sleep,        // Sleep state.
     ConfigAlarm,  // You can't do anything but fix your config file.
     Critical,     // You can't do anything but reset with CTRL-x or the reset button
+    Delay,        // Delaying when a job is active, as with a dwell or spinup delay
 };
 
 void set_state(State s);


### PR DESCRIPTION
The code also sets the stage for a possible per-channel setting to control whether state names are Grbl-compatible, vs reporting the new states with new names.  For example, instead of Delay state being reported as Run, with the proposed new setting it would say Delay.  Similarly for ConfigAlarm and Critical.  This would let UIs describe the situation more precisely.