### PR TITLE
enable conditional compilation to reduce image size

### DIFF
--- a/FluidNC/esp32/tmc_spi.cpp
+++ b/FluidNC/esp32/tmc_spi.cpp
@@ -1,3 +1,4 @@
+#ifndef EXTERNAL_STEPPERS_ONLY
 // Copyright (c) 2022 Mitch Bradley
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
 
@@ -92,3 +93,4 @@ uint32_t TMC2130Stepper::read(uint8_t reg) {
 
     return data;
 }
+#endif

--- a/FluidNC/src/Motors/Dynamixel2.cpp
+++ b/FluidNC/src/Motors/Dynamixel2.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2020 -	Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
-
+#ifndef EXTERNAL_STEPPERS_ONLY
 /*
     Dynamixel2.cpp
 
@@ -358,3 +358,4 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<Dynamixel2> registration("dynamixel2");
     }
 }
+#endif

--- a/FluidNC/src/Motors/RcServo.cpp
+++ b/FluidNC/src/Motors/RcServo.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 -	Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 /*
     This lets an RcServo be used like any other motor. Servos
@@ -134,3 +135,4 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<RcServo> registration("rc_servo");
     }
 }
+#endif

--- a/FluidNC/src/Motors/Servo.cpp
+++ b/FluidNC/src/Motors/Servo.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 -	Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 /*
     This is a base class for servo-type motors - ones that autonomously
@@ -46,3 +47,4 @@ namespace MotorDrivers {
         log_info("    Update timer for " << object->name() << " at " << interval << " ms");
     }
 }
+#endif

--- a/FluidNC/src/Motors/Solenoid.cpp
+++ b/FluidNC/src/Motors/Solenoid.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 -	Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 /*
     This lets an Solenoid act like an axis. It will active when the machine position of 
@@ -123,3 +124,4 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<Solenoid> registration("solenoid");
     }
 }
+#endif

--- a/FluidNC/src/Motors/StepStick.cpp
+++ b/FluidNC/src/Motors/StepStick.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2021 - Stefan de Bruijn
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 /*
     Stepstick.cpp -- stepstick type stepper drivers
@@ -47,3 +48,4 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<StepStick> registration("stepstick");
     }
 }
+#endif

--- a/FluidNC/src/Motors/TMC2130Driver.cpp
+++ b/FluidNC/src/Motors/TMC2130Driver.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 -	Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 /*
     This is used for Trinamic SPI controlled stepper motor drivers.
@@ -110,3 +111,4 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<TMC2130Driver> registration("tmc_2130");
     }
 }
+#endif

--- a/FluidNC/src/Motors/TMC2160ProDriver.cpp
+++ b/FluidNC/src/Motors/TMC2160ProDriver.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 -	Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 #include "TMC2160ProDriver.h"
 #include "../Machine/MachineConfig.h"
@@ -12,3 +13,5 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<TMC2160Driver> registration("tmc_2160Pro");
     }
 }
+
+#endif

--- a/FluidNC/src/Motors/TMC2208Driver.cpp
+++ b/FluidNC/src/Motors/TMC2208Driver.cpp
@@ -4,6 +4,7 @@
 /*
     This is used for Trinamic SPI controlled stepper motor drivers.
 */
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 #include "TMC2208Driver.h"
 #include "../Machine/MachineConfig.h"
@@ -96,3 +97,4 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<TMC2208Driver> registration("tmc_2208");
     }
 }
+#endif

--- a/FluidNC/src/Motors/TMC2209Driver.cpp
+++ b/FluidNC/src/Motors/TMC2209Driver.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 -	Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 /*
     This is used for Trinamic SPI controlled stepper motor drivers.
@@ -149,3 +150,4 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<TMC2209Driver> registration("tmc_2209");
     }
 }
+#endif

--- a/FluidNC/src/Motors/TMC5160Driver.cpp
+++ b/FluidNC/src/Motors/TMC5160Driver.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 -	Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 #include "TMC5160Driver.h"
 #include "../Machine/MachineConfig.h"
@@ -119,3 +120,4 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<TMC5160Driver> registration("tmc_5160");
     }
 }
+#endif

--- a/FluidNC/src/Motors/TMC5160ProDriver.cpp
+++ b/FluidNC/src/Motors/TMC5160ProDriver.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 -	Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 #include "TMC5160ProDriver.h"
 #include "../Machine/MachineConfig.h"
@@ -72,3 +73,4 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<TMC5160ProDriver> registration("tmc_5160Pro");
     }
 }
+#endif

--- a/FluidNC/src/Motors/TrinamicBase.cpp
+++ b/FluidNC/src/Motors/TrinamicBase.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2021 - Stefan de Bruijn
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 #include "TrinamicBase.h"
 #include "../Machine/MachineConfig.h"
@@ -167,3 +168,4 @@ namespace MotorDrivers {
         config_message();
     }
 }
+#endif

--- a/FluidNC/src/Motors/TrinamicBase.h
+++ b/FluidNC/src/Motors/TrinamicBase.h
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
 
 #pragma once
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 #include "StandardStepper.h"
 #include "../EnumItem.h"
@@ -86,3 +87,4 @@ namespace MotorDrivers {
     };
 
 }
+#endif

--- a/FluidNC/src/Motors/TrinamicSpiDriver.cpp
+++ b/FluidNC/src/Motors/TrinamicSpiDriver.cpp
@@ -4,6 +4,7 @@
 /*
     This is used for Trinamic SPI controlled stepper motor drivers.
 */
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 #include "TrinamicSpiDriver.h"
 #include "../Machine/MachineConfig.h"
@@ -51,3 +52,4 @@ namespace MotorDrivers {
     }
 
 }
+#endif

--- a/FluidNC/src/Motors/TrinamicUartDriver.cpp
+++ b/FluidNC/src/Motors/TrinamicUartDriver.cpp
@@ -8,6 +8,7 @@
     TMC2209 Datasheet
     https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC2209_Datasheet_V103.pdf
 */
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 #include "TrinamicUartDriver.h"
 
@@ -44,3 +45,4 @@ namespace MotorDrivers {
     }
 
 }
+#endif

--- a/FluidNC/src/Motors/UnipolarMotor.cpp
+++ b/FluidNC/src/Motors/UnipolarMotor.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 -	Bart Dring
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+#ifndef EXTERNAL_STEPPERS_ONLY
 
 #include "UnipolarMotor.h"
 #include "../Machine/MachineConfig.h"
@@ -124,3 +125,4 @@ namespace MotorDrivers {
         MotorFactory::InstanceBuilder<UnipolarMotor> registration("unipolar");
     }
 }
+#endif

--- a/FluidNC/src/OLED.cpp
+++ b/FluidNC/src/OLED.cpp
@@ -1,3 +1,4 @@
+#ifndef NO_OLED
 #include "OLED.h"
 
 #include "Machine/MachineConfig.h"
@@ -557,3 +558,5 @@ void OLED::draw_checkbox(int16_t x, int16_t y, int16_t width, int16_t height, bo
         _oled->drawRect(x, y, width, height);  // If log.1
     }
 }
+}
+#endif //NO_OLED

--- a/FluidNC/src/OLED.cpp
+++ b/FluidNC/src/OLED.cpp
@@ -558,5 +558,4 @@ void OLED::draw_checkbox(int16_t x, int16_t y, int16_t width, int16_t height, bo
         _oled->drawRect(x, y, width, height);  // If log.1
     }
 }
-}
 #endif //NO_OLED

--- a/FluidNC/src/OLED.h
+++ b/FluidNC/src/OLED.h
@@ -5,12 +5,26 @@
 #include "Configuration/Configurable.h"
 
 #include "Channel.h"
+
+#ifndef NO_OLED
 #include "SSD1306_I2C.h"
 
 typedef const uint8_t* font_t;
+#else
+
+#ifdef ARDUINO
+//#include <Arduino.h>
+
+#include "esp_arduino_version.h"
+#include "esp32-hal.h"
+#endif
+
+#endif // NO_OLED
 
 class OLED : public Channel, public Configuration::Configurable {
 public:
+#ifndef NO_OLED
+
     struct Layout {
         uint8_t                    _x;
         uint8_t                    _y;
@@ -77,6 +91,7 @@ private:
     OLEDDISPLAY_GEOMETRY _geometry = GEOMETRY_64_48;
 
     bool _error = false;
+#endif
 
 public:
     OLED() : Channel("oled") {}
@@ -88,7 +103,9 @@ public:
 
     virtual ~OLED() = default;
 
+#ifndef NO_OLED
     void init();
+
 
     OLEDDisplay* _oled;
 
@@ -128,4 +145,10 @@ public:
         handler.item("mirror", _mirror);
         handler.item("radio_delay_ms", _radio_delay);
     }
+#else
+    void   init() {}
+    size_t write(uint8_t data) override { return 0; }
+    void   group(Configuration::HandlerBase& handler) override {}
+
+#endif // NO_OLED
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -105,6 +105,12 @@ extends = common_esp32
 lib_deps = ${common.lib_deps} ${common.wifi_deps}
 build_flags = ${common_esp32.build_flags} ${common_wifi.build_flags}
 
+[env:wifi-external]
+extends = env:wifi
+lib_deps = ${common.wifi_deps}
+build_flags = ${env:wifi.build_flags} -D EXTERNAL_STEPPERS_ONLY -D NO_OLED
+
+
 [env:bt]
 extends = common_esp32
 lib_deps = ${common.lib_deps} ${common.bt_deps}


### PR DESCRIPTION
If you are open to it, I'd like to have these conditional compilation settings merged.  For those of us with 6Pack External or 6x CNC Controllers there won't be any other stepper drivers.  Additionally there isn't an OLED display easily added.  Thus to save some space and allow room for other experimentation, I'd like to have the option to not include the supporting code and 2 external libraries in the build.

I don't see there being a need to build and share this binary for others to download, but I'll leave that decision to you :)

- enable conditional compilation for only External Drivers
- enable conditional compilation for OLED Display

The size of the wifi-external build is
RAM:   [==        ]  19.5% (used 63772 bytes from 327680 bytes)
Flash: [========= ]  86.6% (used 1703465 bytes from 1966080 bytes)

The size of the original wifi build
RAM:   [==        ]  19.7% (used 64564 bytes from 327680 bytes)
Flash: [========= ]  91.5% (used 1799137 bytes from 1966080 bytes)