### PR TITLE
remove double include of ESP32SSDP.h

### DIFF
--- a/FluidNC/src/WebUI/WebServer.cpp
+++ b/FluidNC/src/WebUI/WebServer.cpp
@@ -16,7 +16,6 @@
 #    include <WebSocketsServer.h>
 #    include <WiFi.h>
 #    include <WebServer.h>
-#    include <ESP32SSDP.h>
 #    include <StreamString.h>
 #    include <Update.h>
 #    include <esp_wifi_types.h>


### PR DESCRIPTION
file was included twice on line 19 and line 24.
removes one include