### PR TITLE
standardize on IRAM version of delay_us

### DIFF
--- a/FluidNC/esp32/delay_usecs.cpp
+++ b/FluidNC/esp32/delay_usecs.cpp
@@ -25,7 +25,6 @@ void timing_init() {
     ticks_per_us = esp_clk_cpu_freq() / 1000000;
 }
 
-// cppcheck-suppress unusedFunction
 void IRAM_ATTR delay_us(int32_t us) {
     spinUntil(usToEndTicks(us));
 }

--- a/FluidNC/include/Driver/delay_usecs.h
+++ b/FluidNC/include/Driver/delay_usecs.h
@@ -4,6 +4,8 @@ extern uint32_t ticks_per_us;
 
 void timing_init();
 void spinUntil(int32_t endTicks);
+
+// Blocking delay for very short time intervals
 void delay_us(int32_t us);
 
 int32_t usToCpuTicks(int32_t us);

--- a/FluidNC/src/I2SOut.cpp
+++ b/FluidNC/src/I2SOut.cpp
@@ -335,7 +335,7 @@ static int i2s_out_start() {
 
     I2S0.conf.tx_start = 1;
     // Wait for the first FIFO data to prevent the unintentional generation of 0 data
-    ets_delay_us(20);
+    delay_us(20);
     I2S0.conf1.tx_stop_en = 0;  // BCK and WCK are generated regardless of the FIFO status
 
     I2S_OUT_EXIT_CRITICAL();

--- a/FluidNC/src/NutsBolts.h
+++ b/FluidNC/src/NutsBolts.h
@@ -56,9 +56,6 @@ const float INCH_PER_MM = (0.0393701f);
 // a pointer to the result variable. Returns true when it succeeds
 bool read_float(const char* line, size_t* pos, float& result);
 
-// Blocking delay for very short time intervals
-void delay_us(int32_t microseconds);
-
 // Delay while checking for realtime characters and other events
 bool delay_msec(uint32_t milliseconds, DwellMode mode = DwellMode::Dwell);
 


### PR DESCRIPTION
This function exists in delay_usecs.cpp in IRAM - see [details](https://github.com/bdring/FluidNC/compare/main...craiglink:FluidNC:standarize-delay_us?expand=1#diff-7902a28ce6cb91133b961c8bb949efa6af4f54768a013b352ab374aa2650e18bL53-L57) 

This MR changes the one call to the ROM based ets_delay_us to use our IRAM based version