### PR TITLE
standarized on one delay(ms) call

### DIFF
--- a/FluidNC/src/I2SOut.cpp
+++ b/FluidNC/src/I2SOut.cpp
@@ -544,7 +544,7 @@ void i2s_out_delay() {
         // Just wait until the data now registered in the DMA descripter
         // is reflected in the I2S TX module via FIFO.
         // XXX perhaps just wait until I2SO.conf1.tx_start == 0
-        delay_ms(I2S_OUT_DELAY_MS);
+        delay(I2S_OUT_DELAY_MS);
     }
     I2S_OUT_PULSER_EXIT_CRITICAL();
 }
@@ -614,7 +614,7 @@ int i2s_out_set_stepping() {
         // Wait for complete DMAs
         for (;;) {
             I2S_OUT_PULSER_EXIT_CRITICAL();
-            delay_ms(I2S_OUT_DELAY_DMABUF_MS);
+            delay(I2S_OUT_DELAY_DMABUF_MS);
             I2S_OUT_PULSER_ENTER_CRITICAL();
             if (i2s_out_pulser_status == WAITING) {
                 continue;

--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -116,7 +116,7 @@ namespace Machine {
 
         // Advance to next cycle
         Stepper::reset();        // Stop steppers and reset step segment buffer
-        delay_ms(_settling_ms);  // Delay to allow transient dynamics to dissipate.
+        delay(_settling_ms);  // Delay to allow transient dynamics to dissipate.
 
         nextPhase();
     }
@@ -339,7 +339,7 @@ namespace Machine {
             } else {
                 // If all axes have hit their limits, this phase is complete and
                 // we can start the next one
-                delay_ms(_settling_ms);  // Delay to allow transient dynamics to dissipate.
+                delay(_settling_ms);  // Delay to allow transient dynamics to dissipate.
                 nextPhase();
             }
         }

--- a/FluidNC/src/Motors/Dynamixel2.cpp
+++ b/FluidNC/src/Motors/Dynamixel2.cpp
@@ -73,7 +73,7 @@ namespace MotorDrivers {
 
         // servos will blink in axis order for reference
         LED_on(true);
-        vTaskDelay(100);
+        delay(100);
         LED_on(false);
     }
 

--- a/FluidNC/src/Motors/RcServo.cpp
+++ b/FluidNC/src/Motors/RcServo.cpp
@@ -23,8 +23,6 @@
 #include "../Limits.h"  // limitsMaxPosition
 #include "RcServoSettings.h"
 
-#include <freertos/task.h>  // vTaskDelay
-
 namespace MotorDrivers {
     // RcServo::RcServo(Pin pwm_pin) : Servo(), _pwm_pin(pwm_pin) {}
 
@@ -92,8 +90,8 @@ namespace MotorDrivers {
             float home_time_sec = (axisConfig->_maxTravel / axisConfig->_maxRate * 60 * 1.1);  // 1.1 fudge factor for accell time.
 
             _disabled = false;
-            set_location();                    // force the PWM to update now
-            vTaskDelay(home_time_sec * 1000);  // give time to move
+            set_location();               // force the PWM to update now
+            delay(home_time_sec * 1000);  // give time to move
         }
         return false;  // Cannot be homed in the conventional way
     }

--- a/FluidNC/src/Motors/Servo.cpp
+++ b/FluidNC/src/Motors/Servo.cpp
@@ -19,7 +19,6 @@
 #include "../Machine/MachineConfig.h"
 
 #include <atomic>
-#include <freertos/task.h>  // portTICK_PERIOD_MS, vTaskDelay
 
 namespace MotorDrivers {
 

--- a/FluidNC/src/Motors/Solenoid.cpp
+++ b/FluidNC/src/Motors/Solenoid.cpp
@@ -41,8 +41,6 @@
 #include "../Pin.h"
 #include "../Limits.h"  // limitsMaxPosition
 
-#include <freertos/task.h>  // vTaskDelay
-
 namespace MotorDrivers {
 
     void Solenoid::init() {

--- a/FluidNC/src/NutsBolts.cpp
+++ b/FluidNC/src/NutsBolts.cpp
@@ -95,10 +95,6 @@ bool read_float(const char* line, size_t* pos, float& result) {
     return true;
 }
 
-void delay_ms(uint16_t ms) {
-    vTaskDelay(ms / portTICK_PERIOD_MS);
-}
-
 // Non-blocking delay function used for general operation and suspend features.
 bool delay_msec(uint32_t milliseconds, DwellMode mode) {
     while (milliseconds--) {
@@ -114,7 +110,7 @@ bool delay_msec(uint32_t milliseconds, DwellMode mode) {
         if (sys.abort) {
             return false;
         }
-        vTaskDelay(1 / portTICK_PERIOD_MS);
+        delay(1);
     }
     return true;
 }

--- a/FluidNC/src/NutsBolts.h
+++ b/FluidNC/src/NutsBolts.h
@@ -62,9 +62,6 @@ void delay_us(int32_t microseconds);
 // Delay while checking for realtime characters and other events
 bool delay_msec(uint32_t milliseconds, DwellMode mode = DwellMode::Dwell);
 
-// Delay without checking for realtime events.  Use only for short delays
-void delay_ms(uint16_t ms);
-
 // Computes hypotenuse, avoiding avr-gcc's bloated version and the extra error checking.
 float hypot_f(float x, float y);
 

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -506,7 +506,7 @@ static Error show_limits(const char* value, WebUI::AuthenticationLevel auth_leve
                             << (config->_probe->get_state() ? " P" : ""));
             limit = thisTime + interval;
         }
-        vTaskDelay(1);
+        delay(1);
         protocol_handle_events();
     } while (runLimitLoop);
     log_string(out, "");
@@ -691,14 +691,14 @@ static Error xmodem_receive(const char* value, WebUI::AuthenticationLevel auth_l
     try {
         outfile = new FileStream(value, "w");
     } catch (...) {
-        delay_ms(1000);   // Delay for FluidTerm to handle command echoing
+        delay(1000);   // Delay for FluidTerm to handle command echoing
         out.write(0x04);  // Cancel xmodem transfer with EOT
         log_info("Cannot open " << value);
         return Error::UploadFailed;
     }
     pollingPaused = true;
     bool oldCr    = out.setCr(false);
-    delay_ms(1000);
+    delay(1000);
     int size = xmodemReceive(&out, outfile);
     out.setCr(oldCr);
     pollingPaused = false;

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -94,7 +94,7 @@ xQueueHandle message_queue;
 
 void drain_messages() {
     while (uxQueueMessagesWaiting(message_queue)) {
-        vTaskDelay(1);  // Let the output task finish sending data
+        delay(1);  // Let the output task finish sending data
     }
 }
 
@@ -124,10 +124,10 @@ char activeLine[Channel::maxLine];
 bool pollingPaused = false;
 void polling_loop(void* unused) {
     // Poll the input sources waiting for a complete line to arrive
-    for (; true; /*feedLoopWDT(), */ vTaskDelay(0)) {
+    for (; true; /*feedLoopWDT(), */ delay(0)) {
         // Polling is paused when xmodem is using a channel for binary upload
         if (pollingPaused) {
-            vTaskDelay(100);
+            delay(100);
             continue;
         }
 
@@ -222,7 +222,7 @@ void start_polling() {
 static void alarm_msg(ExecAlarm alarm_code) {
     log_info_to(allChannels, "ALARM: " << alarmString(alarm_code));
     log_stream(allChannels, "ALARM:" << static_cast<int>(alarm_code));
-    delay_ms(500);  // Force delay to ensure message clears serial write buffer.
+    delay(500);  // Force delay to ensure message clears serial write buffer.
 }
 
 #if 0
@@ -274,7 +274,7 @@ void protocol_main_loop() {
     // Primary loop! Upon a system abort, this exits back to main() to reset the system.
     // This is also where the system idles while waiting for something to do.
     // ---------------------------------------------------------------------------------
-    for (;; vTaskDelay(0)) {
+    for (;; delay(0)) {
         if (activeChannel) {
             // The input polling task has collected a line of input
             if (gcode_echo->get()) {

--- a/FluidNC/src/Serial.cpp
+++ b/FluidNC/src/Serial.cpp
@@ -72,7 +72,7 @@ void heapCheckTask(void* pvParameters) {
             heapSize = newHeapSize;
             log_info("heap " << heapSize);
         }
-        vTaskDelay(3000 / portTICK_RATE_MS);  // Yield to other tasks
+        delay(3000);  // Yield to other tasks
 
         static UBaseType_t uxHighWaterMark = 0;
 #ifdef DEBUG_TASK_STACK

--- a/FluidNC/src/Spindles/VFDSpindle.cpp
+++ b/FluidNC/src/Spindles/VFDSpindle.cpp
@@ -76,7 +76,7 @@ namespace Spindles {
         uint8_t       rx_message[VFD_RS485_MAX_MSG_SIZE];
         bool          safetyPollingEnabled = instance->safety_polling();
 
-        for (; true; delay_ms(VFD_RS485_POLL_RATE)) {
+        for (; true; delay(VFD_RS485_POLL_RATE)) {
             std::atomic_thread_fence(std::memory_order::memory_order_seq_cst);  // read fence for settings
             response_parser parser = nullptr;
 
@@ -229,7 +229,7 @@ namespace Spindles {
 
                     // Wait a bit before we retry. Set the delay to poll-rate. Not sure
                     // if we should use a different value...
-                    delay_ms(VFD_RS485_POLL_RATE);
+                    delay(VFD_RS485_POLL_RATE);
 
 #ifdef DEBUG_TASK_STACK
                     static UBaseType_t uxHighWaterMark = 0;
@@ -352,7 +352,7 @@ namespace Spindles {
                 //     last      = _sync_dev_speed;
                 //     break;
                 // }
-                delay_ms(500);
+                delay(500);
 
                 // unchanged counts the number of consecutive times that we see the same speed
                 unchanged = (_sync_dev_speed == last) ? unchanged + 1 : 0;

--- a/FluidNC/src/WebUI/NotificationsService.cpp
+++ b/FluidNC/src/WebUI/NotificationsService.cpp
@@ -156,7 +156,7 @@ namespace WebUI {
                 if ((answer.find(linetrigger) != std::string::npos) || (strlen(linetrigger) == 0)) {
                     break;
                 }
-                delay_ms(10);
+                delay(10);
                 log_verbose("Received: '" << answer << "' (waiting 4 '" << expected_answer << "')");
             }
             if (strlen(expected_answer) == 0) {

--- a/FluidNC/src/WebUI/WebServer.cpp
+++ b/FluidNC/src/WebUI/WebServer.cpp
@@ -802,7 +802,7 @@ namespace WebUI {
 
         //if success restart
         if (_upload_status == UploadStatus::SUCCESSFUL) {
-            delay_ms(1000);
+            delay(1000);
             COMMANDS::restart_MCU();
         } else {
             _upload_status = UploadStatus::NONE;
@@ -860,7 +860,7 @@ namespace WebUI {
                     //Upload write
                     //**************
                 } else if (upload.status == UPLOAD_FILE_WRITE) {
-                    vTaskDelay(1 / portTICK_RATE_MS);
+                    delay(1);
                     //check if no error
                     if (_upload_status == UploadStatus::ONGOING) {
                         if (((100 * upload.totalSize) / maxSketchSpace) != last_upload_update) {
@@ -1080,7 +1080,7 @@ namespace WebUI {
     }
 
     void Web_Server::uploadWrite(uint8_t* buffer, size_t length) {
-        vTaskDelay(1 / portTICK_RATE_MS);
+        delay(1);
         if (_uploadFile && _upload_status == UploadStatus::ONGOING) {
             //no error write post data
             if (length != _uploadFile->write(buffer, length)) {

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -664,7 +664,7 @@ namespace WebUI {
                     break;
             }
             log_info(msg);
-            delay_ms(2000);  // Give it some time to connect
+            delay(2000);  // Give it some time to connect
         }
         return false;
     }

--- a/X86TestSupport/TestSupport/Arduino.cpp
+++ b/X86TestSupport/TestSupport/Arduino.cpp
@@ -2,9 +2,8 @@
 
 #include "SoftwareGPIO.h"
 #include "Capture.h"
-
+#include "freertos/task.h"
 #include <chrono>
-#include <thread>
 
 int64_t esp_timer_get_time() {
     return Capture::instance().current();
@@ -45,7 +44,7 @@ extern "C" void __digitalWrite(uint8_t pin, uint8_t val) {
 }
 
 void delay(int ms) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+    vTaskDelay(ms / portTICK_PERIOD_MS);
 }
 
 int temperatureRead(void) {


### PR DESCRIPTION
The code base currently has 3 calls to delay for X number of milliseconds.

This change standarized on the default delay(ms) call which just calls vTaskDelay() under the covers.  It also updates the x86 support to do the same.  

The custom delay_ms(ms) in the code base has the same implementation as delay(ms), so those calls have been updated to just use delay(ms).