### PR TITLE
Job tweaks

### DIFF
--- a/FluidNC/src/Machine/Macros.cpp
+++ b/FluidNC/src/Machine/Macros.cpp
@@ -131,7 +131,7 @@ Error MacroChannel::pollLine(char* line) {
             float percent_complete = (float)_position * 100.0f / _macro->get().length();
 
             std::ostringstream s;
-            s << name() << ":" << std::fixed << std::setprecision(2) << percent_complete;
+            s << "SD:" << std::fixed << std::setprecision(2) << percent_complete << "," << name();
             _progress = s.str();
         }
             return Error::Ok;

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -281,7 +281,8 @@ void protocol_main_loop() {
                 report_echo_line_received(activeLine, allChannels);
             }
 
-            Error status_code = execute_line(activeLine, *activeChannel, WebUI::AuthenticationLevel::LEVEL_GUEST);
+            Channel* out_channel = Job::leader ? Job::leader : activeChannel;
+            Error    status_code = execute_line(activeLine, *out_channel, WebUI::AuthenticationLevel::LEVEL_GUEST);
 
             // Tell the channel that the line has been processed.
             // If the line was aborted, the channel could be invalid


### PR DESCRIPTION
1. When running from a macro, report the progress with the same SD tag that is used for files.  The "filename" is e.g. Macro0.  This means that UIs can use their existing parsing for that tag, without needing additional parsing rules for a different Macro tag.
2. Fixed a bug that causes crashes when a $ command is executed in Job active state and a resulting message was being sent to the file channel.  The fix is to set the command output channel to the Job Leader in that situation.