### PR TITLE
support developers having custom builds in platform_override.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ FluidNC.vcxproj.filters
 *.suo
 packages/
 pio_machine.h
+platformio_override.ini
 project.checksum
 version.cpp
 esptool*.zip

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,9 @@ include_dir = FluidNC/include
 test_dir = FluidNC/tests
 data_dir = FluidNC/data
 default_envs = wifi
-;extra_configs=debug.ini
+extra_configs=
+    platformio_override.ini
+    ;debug.ini
 
 [common_env_data]
 lib_deps_builtin = 


### PR DESCRIPTION
... and prevent the override from being commited to the project.

This follows other platformio conventions so the developers may have their own custom builds without having to regularly deal with conficts in platformio.ini