### PR TITLE
conditional compilation / inclusion of OLED support

### DIFF
--- a/FluidNC/src/OLED.cpp
+++ b/FluidNC/src/OLED.cpp
@@ -1,3 +1,4 @@
+#ifndef NO_OLED
 #include "OLED.h"
 
 #include "Machine/MachineConfig.h"
@@ -557,3 +558,4 @@ void OLED::draw_checkbox(int16_t x, int16_t y, int16_t width, int16_t height, bo
         _oled->drawRect(x, y, width, height);  // If log.1
     }
 }
+#endif //NO_OLED

--- a/FluidNC/src/OLED.h
+++ b/FluidNC/src/OLED.h
@@ -5,12 +5,26 @@
 #include "Configuration/Configurable.h"
 
 #include "Channel.h"
+
+#ifndef NO_OLED
 #include "SSD1306_I2C.h"
 
 typedef const uint8_t* font_t;
+#else
+
+#ifdef ARDUINO
+//#include <Arduino.h>
+
+#include "esp_arduino_version.h"
+#include "esp32-hal.h"
+#endif
+
+#endif // NO_OLED
 
 class OLED : public Channel, public Configuration::Configurable {
 public:
+#ifndef NO_OLED
+
     struct Layout {
         uint8_t                    _x;
         uint8_t                    _y;
@@ -77,6 +91,7 @@ private:
     OLEDDISPLAY_GEOMETRY _geometry = GEOMETRY_64_48;
 
     bool _error = false;
+#endif
 
 public:
     OLED() : Channel("oled") {}
@@ -88,7 +103,9 @@ public:
 
     virtual ~OLED() = default;
 
+#ifndef NO_OLED
     void init();
+
 
     OLEDDisplay* _oled;
 
@@ -128,4 +145,10 @@ public:
         handler.item("mirror", _mirror);
         handler.item("radio_delay_ms", _radio_delay);
     }
+#else
+    void   init() {}
+    size_t write(uint8_t data) override { return 0; }
+    void   group(Configuration::HandlerBase& handler) override {}
+
+#endif // NO_OLED
 };


### PR DESCRIPTION
- because most boards don't have an OLED display
- the OLED module is retired
- the OLED library uses a fair amount of ROM
- and it uses the String class

... provide an option to not included it.

**build_src_filter** is not an option because of other dependencies in the source code on the OLED class existence.