### PR TITLE
Wrap config value as string if it contains a colon

### DIFF
--- a/FluidNC/src/Configuration/Generator.h
+++ b/FluidNC/src/Configuration/Generator.h
@@ -42,7 +42,15 @@ namespace Configuration {
             }
             s << name;
             s << ": ";
-            s << value;
+
+            // If value contains a colon, wrap text as string
+            if (value.find(':') == std::string::npos) {
+                s << value;
+            } else {
+                s << "'";
+                s << value;
+                s << "'";
+            }
         }
 
         void item(const char* name, int& value, const int32_t minValue, const int32_t maxValue) override {


### PR DESCRIPTION
This is a work-around for the issue #1270

The `$Config/Dump` command does not wrap values as a string if it contains "special characters" such as `:` which will result in an invalid YAML.

The proper way should probably be to check if the string contains a `"` which would wrap the string with `'`. If it contains a `'` it would wrap with `"`. And it should probably also check for other special characters. But this will solve the immediate problem.

