### PR TITLE
Allow multiple factory sections of the same name, e.g. laser

### DIFF
--- a/FluidNC/src/Configuration/GenericFactory.h
+++ b/FluidNC/src/Configuration/GenericFactory.h
@@ -95,13 +95,13 @@ namespace Configuration {
                     auto name = (*it)->name();
                     auto it2 =
                         std::find_if(objects.begin(), objects.end(), [&](auto& object) { return strcasecmp(object->name(), name) == 0; });
-                    if (it2 == objects.end()) {
-                        auto object = (*it)->create(name);
-                        objects.push_back(object);
-                        handler.enterFactory(name, *object);
-                    } else {
-                        handler.enterFactory(name, **it2);
-                    }
+                    // If the config file contains multiple factory sections with the same name,
+                    // for example two laser: sections or oled: sections, create a new node
+                    // for each repetition.  FluidNC can thus support multiple lasers with
+                    // different tool numbers and output pins, multiple OLED displays, etc
+                    auto object = (*it)->create(name);
+                    objects.push_back(object);
+                    handler.enterFactory(name, *object);
                 }
             } else {
                 for (auto it : objects) {

--- a/FluidNC/src/Spindles/Spindle.cpp
+++ b/FluidNC/src/Spindles/Spindle.cpp
@@ -78,6 +78,12 @@ namespace Spindles {
         _speeds[i].scale  = scaler;
     }
 
+    void Spindle::validate() {
+        for (auto s : Spindles::SpindleFactory::objects()) {
+            Assert(s == this || s->_tool != _tool, "Duplicate tool_number %d with /%s", _tool, s->name());
+        }
+    }
+
     void Spindle::afterParse() {
         if (_speeds.size() && !maxSpeed()) {
             log_error("Speed map max speed is 0. Using default");

--- a/FluidNC/src/Spindles/Spindle.h
+++ b/FluidNC/src/Spindles/Spindle.h
@@ -76,10 +76,7 @@ namespace Spindles {
         const char* name() { return _name; }
 
         // Configuration handlers:
-        void validate() override {
-            // TODO: Validate spinup/spindown delay?
-        }
-
+        void validate() override;
         void afterParse() override;
 
         void group(Configuration::HandlerBase& handler) override {


### PR DESCRIPTION
This lets you have, for example, two different lasers on the same machine, each with a different output pin and different tool numbers.  It also works for other kinds of spindles, so  you could have, say, two different PWM spindles.  And it works for things like OLED, so you could have two OLED displays with different I2C addresses.