### PR TITLE
Fixed bluetooth not initializing

### DIFF
--- a/FluidNC/src/BTConfig.cpp
+++ b/FluidNC/src/BTConfig.cpp
@@ -114,7 +114,6 @@ namespace WebUI {
 
     void BTConfig::init() {
         log_debug("Begin Bluetooth setup");
-        return;
         //stop active services
         deinit();
 


### PR DESCRIPTION
Bluetooth was not initializing due to a retrun statement in init function.

related to https://github.com/bdring/FluidNC/issues/1289