### PR TITLE
Basic automated ATC implementations (Draft/WIP)

### DIFF
--- a/FluidNC/src/ToolChangers/atc_basic.cpp
+++ b/FluidNC/src/ToolChangers/atc_basic.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) 2024 -	Bart Dring
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#include "atc_basic.h"
+#include "../Machine/MachineConfig.h"
+#include <cstdio>
+#include <iostream>
+
+namespace ATCs {
+    void Basic_ATC::init() {
+        log_info("ATC:" << name());
+    }
+
+    void Basic_ATC::probe_notification() {}
+
+    bool Basic_ATC::tool_change(uint8_t new_tool, bool pre_select, bool set_tool) {
+        bool spindle_was_on = false;  // used to restore the spindle state
+        bool was_inch_mode  = false;  // allows use to restore inch mode if req'd
+
+        protocol_buffer_synchronize();  // wait for all motion to complete
+        _macro.erase();             // clear previous gcode
+
+        // M6T0 is used to reset this ATC and allow us to start a new job
+        if (new_tool == 0 || set_tool) {
+            _prev_tool = new_tool;
+            move_to_safe_z();
+            move_to_change_location();
+            reset();
+            _macro.run(nullptr);
+            return true;
+        }
+
+        was_inch_mode = (gc_state.modal.units == Units::Inches);
+
+        if (was_inch_mode) {
+            _macro.addf("G21");
+        }
+
+        try {
+            if (_prev_tool == 0) {  // M6T<anything> from T0 is used for a manual change before zero'ing
+                move_to_change_location();
+                _macro.addf("G4P0 0.1");
+                _macro.addf("G43.1Z0");
+                _macro.addf("(MSG : Install tool #%d)", new_tool);
+                if (was_inch_mode) {
+                    _macro.addf("G20");
+                }
+                _macro.run(nullptr);
+                _prev_tool = new_tool;
+                return true;
+            }
+
+            _prev_tool = new_tool;
+
+            // save current location, so we can return after the tool change.
+            _macro.addf("#<start_x >= #<_x>");
+            _macro.addf("#<start_y >= #<_y>");
+            _macro.addf("#<start_z >= #<_z>");
+
+            move_to_safe_z();
+
+            // turn off the spindle
+            if (gc_state.modal.spindle != SpindleState::Disable) {
+                spindle_was_on = true;
+                _macro.addf("M5");
+            }
+
+            // if we have not determined the tool setter offset yet, we need to do that.
+            if (!_have_tool_setter_offset) {
+                move_over_toolsetter();
+                ets_probe();
+                _macro.addf("#<_ets_tool1_z>=[#5063]");  // save the value of the tool1 ETS Z
+                _have_tool_setter_offset = true;
+            }
+
+            move_to_change_location();
+
+            _macro.addf("G4P0 0.1");
+            _macro.addf("(MSG: Install tool #%d then resume to continue)", new_tool);
+            _macro.addf("M0");
+
+            // probe the new tool
+            move_to_safe_z();
+            move_over_toolsetter();
+            ets_probe();
+
+            // TLO is simply the difference between the tool1 probe and the new tool probe.
+            _macro.addf("#<_my_tlo_z >=[#5063 - #<_ets_tool1_z>]");
+            _macro.addf("G43.1Z#<_my_tlo_z>");
+
+            move_to_safe_z();
+
+            // return to location before the tool change
+            _macro.addf("G0X#<start_x>Y#<start_y>");
+            _macro.addf("G0Z#<start_z>");
+
+            if (spindle_was_on) {
+                _macro.addf("M3");  // spindle should handle spinup delay
+            }
+
+            if (was_inch_mode) {
+                _macro.addf("G20");
+            }
+
+            _macro.run(nullptr);
+
+            return true;
+        } catch (...) { log_info("Exception caught"); }
+
+        return false;
+    }
+
+    void Basic_ATC::reset() {
+        _is_OK                   = true;
+        _have_tool_setter_offset = false;
+        _prev_tool               = gc_state.tool;  // Double check this
+        _macro.addf("G4P0 0.1");                   // reset the TLO to 0
+        _macro.addf("(MSG: TLO Z reset to 0)");    //
+    }
+
+    void Basic_ATC::move_to_change_location() {
+        move_to_safe_z();
+        _macro.addf("G53G0X%0.3fY%0.3fZ%0.3f", _change_mpos[0], _change_mpos[1], _change_mpos[2]);
+    }
+
+    void Basic_ATC::move_to_safe_z() {
+        _macro.addf("G53G0Z%0.3f", _safe_z);
+    }
+
+    void Basic_ATC::move_over_toolsetter() {
+        move_to_safe_z();
+        _macro.addf("G53G0X%0.3fY%0.3f", _ets_mpos[0], _ets_mpos[1]);
+    }
+
+    void Basic_ATC::ets_probe() {
+        _macro.addf("G53G0Z #</ atc_manual / ets_rapid_z_mpos_mm>");  // rapid down
+
+        // do a fast probe if there is a seek that is faster than feed
+        if (_probe_seek_rate > _probe_feed_rate) {
+            _macro.addf("G53 G38.2 Z%0.3f F%0.3f", _ets_mpos[2], _probe_seek_rate);
+            _macro.addf("G0Z[#<_z> + 5]");  // retract befor next probe
+        }
+
+        // do the feed rate probe
+        _macro.addf("G53 G38.2 Z%0.3f F%0.3f", _ets_mpos[2], _probe_feed_rate);
+    }
+
+    namespace {
+        ATCFactory::InstanceBuilder<Basic_ATC> registration("atc_basic");
+    }
+}

--- a/FluidNC/src/ToolChangers/atc_basic.h
+++ b/FluidNC/src/ToolChangers/atc_basic.h
@@ -45,6 +45,8 @@ namespace ATCs {
         void  ets_probe();
         void  get_ets_offset();
         void  move_to_tool_position(uint8_t tool_index);
+        void  move_to_start_position();
+
         Macro _macro;
         Macro _toolreturn_macro;
         Macro _toolpickup_macro;

--- a/FluidNC/src/ToolChangers/atc_basic.h
+++ b/FluidNC/src/ToolChangers/atc_basic.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2024 -	Bart Dring
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "src/Config.h"
+
+#include "src/Configuration/Configurable.h"
+
+#include "src/Channel.h"
+#include "src/Module.h"
+#include "atc.h"
+#include "../Machine/Macros.h"
+
+namespace ATCs {
+    class Basic_ATC : public ATC {
+    public:
+        Basic_ATC(const char* name) : ATC(name) {}
+
+        Basic_ATC(const Basic_ATC&)            = delete;
+        Basic_ATC(Basic_ATC&&)                 = delete;
+        Basic_ATC& operator=(const Basic_ATC&) = delete;
+        Basic_ATC& operator=(Basic_ATC&&)      = delete;
+
+        virtual ~Basic_ATC() = default;
+
+    private:
+        // config items
+        float              _safe_z           = 50.0;
+        float              _probe_seek_rate  = 200.0;
+        float              _probe_feed_rate  = 80.0;
+        std::vector<float> _ets_mpos         = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+        std::vector<float> _change_mpos      = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };  // manual tool change location
+        float              _ets_rapid_z_mpos = 0;
+
+        bool    _is_OK                   = false;
+        uint8_t _prev_tool               = 0;  // TODO This could be a NV setting
+        bool    _have_tool_setter_offset = false;
+        float   _tool_setter_offset      = 0.0;  // have we established an offset.
+        float   _tool_setter_position[MAX_N_AXIS];
+
+        void move_to_change_location();
+        void move_to_safe_z();
+        void move_over_toolsetter();
+        void ets_probe();
+        void reset();
+
+        Macro _macro;
+
+    public:
+        void init() override;
+        void probe_notification() override;
+        bool tool_change(uint8_t value, bool pre_select, bool set_tool) override;
+
+        void validate() override {}
+
+        void group(Configuration::HandlerBase& handler) override {
+            handler.item("safe_z_mpos_mm", _safe_z, -100000, 100000);
+            handler.item("probe_seek_rate_mm_per_min", _probe_seek_rate, 1, 10000);
+            handler.item("probe_feed_rate_mm_per_min", _probe_feed_rate, 1, 10000);
+            handler.item("change_mpos_mm", _change_mpos);
+            handler.item("ets_mpos_mm", _ets_mpos);
+            handler.item("ets_rapid_z_mpos_mm", _ets_rapid_z_mpos);
+        }
+    };
+}

--- a/FluidNC/src/ToolChangers/atc_basic.h
+++ b/FluidNC/src/ToolChangers/atc_basic.h
@@ -14,7 +14,7 @@
 
 namespace ATCs {
     const int TOOL_COUNT = 8;
-    
+
     class Basic_ATC : public ATC {
     public:
         Basic_ATC(const char* name) : ATC(name) {}
@@ -40,11 +40,11 @@ namespace ATCs {
         float   _tool_setter_offset      = 0.0;  // have we established an offset.
         float   _tool_setter_position[MAX_N_AXIS];
 
-        void move_to_safe_z();
-        void move_over_toolsetter();
-        void ets_probe();
-        void get_ets_offset();
-        void move_to_tool_position(uint8_t tool_index);
+        void  move_to_safe_z();
+        void  move_over_toolsetter();
+        void  ets_probe();
+        void  get_ets_offset();
+        void  move_to_tool_position(uint8_t tool_index);
         Macro _macro;
         Macro _toolreturn_macro;
         Macro _toolpickup_macro;

--- a/FluidNC/src/ToolChangers/atc_basic.h
+++ b/FluidNC/src/ToolChangers/atc_basic.h
@@ -13,6 +13,8 @@
 #include "../Machine/Macros.h"
 
 namespace ATCs {
+    const int TOOL_COUNT = 8;
+    
     class Basic_ATC : public ATC {
     public:
         Basic_ATC(const char* name) : ATC(name) {}
@@ -30,22 +32,22 @@ namespace ATCs {
         float              _probe_seek_rate  = 200.0;
         float              _probe_feed_rate  = 80.0;
         std::vector<float> _ets_mpos         = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-        std::vector<float> _change_mpos      = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };  // manual tool change location
         float              _ets_rapid_z_mpos = 0;
+        std::vector<float> _tool_mpos[TOOL_COUNT];
 
-        bool    _is_OK                   = false;
         uint8_t _prev_tool               = 0;  // TODO This could be a NV setting
         bool    _have_tool_setter_offset = false;
         float   _tool_setter_offset      = 0.0;  // have we established an offset.
         float   _tool_setter_position[MAX_N_AXIS];
 
-        void move_to_change_location();
         void move_to_safe_z();
         void move_over_toolsetter();
         void ets_probe();
-        void reset();
-
+        void get_ets_offset();
+        void move_to_tool_position(uint8_t tool_index);
         Macro _macro;
+        Macro _toolreturn_macro;
+        Macro _toolpickup_macro;
 
     public:
         void init() override;
@@ -58,9 +60,18 @@ namespace ATCs {
             handler.item("safe_z_mpos_mm", _safe_z, -100000, 100000);
             handler.item("probe_seek_rate_mm_per_min", _probe_seek_rate, 1, 10000);
             handler.item("probe_feed_rate_mm_per_min", _probe_feed_rate, 1, 10000);
-            handler.item("change_mpos_mm", _change_mpos);
             handler.item("ets_mpos_mm", _ets_mpos);
             handler.item("ets_rapid_z_mpos_mm", _ets_rapid_z_mpos);
+            handler.item("toolreturn_macro", _toolreturn_macro);
+            handler.item("toolpickup_macro", _toolpickup_macro);
+            handler.item("tool1_mpos_mm", _tool_mpos[0]);
+            handler.item("tool2_mpos_mm", _tool_mpos[1]);
+            handler.item("tool3_mpos_mm", _tool_mpos[2]);
+            handler.item("tool4_mpos_mm", _tool_mpos[3]);
+            handler.item("tool5_mpos_mm", _tool_mpos[4]);
+            handler.item("tool6_mpos_mm", _tool_mpos[5]);
+            handler.item("tool7_mpos_mm", _tool_mpos[6]);
+            handler.item("tool8_mpos_mm", _tool_mpos[7]);
         }
     };
 }


### PR DESCRIPTION
My intention is mostly to offer my implementation for review and maybe as contribution for further automated ATC implementations.
The code is untested but seems to compile, unless I am doing the compile incorrectly.
I am slightly scared in uploading it, as I don't want to brick my ATC-hardware 😉
*Since this PR is not intended to be merged, I'll just target main.*

### Description
The idea is to have the ATC to move to the tool's xy position, and then use a tool changer specific macro to perform any pickup/return moves, operating required outputs to the ATC with M62/63.
This way it should be rather compatible with different hardware only requiring yaml-cfg changes.
The only downside I see with this behaviour right now, would be exposing the ATC-I/Os to the Gcode - but I would consider this acceptable, since GCode already has millions of ways of crashing your machine anyways.

for a simple vertical ATC the pickup macro could look like this:
```gcode
G91 (or alternatively use G90 moves and the variables set up by the ATC: G0 Z#<_tc_tool_z>)
M62 P6 (Triggers air valve to open the ATC )
G4 P0 1.0 (wait for ATC to settle)
G0 Z-50.0 (go to tool-pickup location)
M63 P6 (Triggers air valve to close the ATC )
G4 P0 1.0 (wait for ATC to settle)
G0 Z50.0 (lift tool from fixture)
```
It shouldn't be difficult to adapt the macro for a fork-holder atc that is accessed from the side, or run the spindle for something like the rapidchange ATC.

P.S.
The general implementation of "using macros" is mostly guesswork since i haven't found any related documentation in the wiki, Especially for the macro variables I am not confident at all. 