### PR TITLE
$gs grbl/show implementation for CNCjs initiliazation without soft reset

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -47,18 +47,18 @@ jobs:
           release/*.zip
           release/*.elf
         draft: True
-    - name: Deploy to fluidnc-releases
-      uses: datalbry/copy_folder_to_another_repo_action@1.0.0
-      env:
-        API_TOKEN_GITHUB: ${{ secrets.RELEASE_COPY_TOKEN }}
-      with:
-        source_folder: 'release/current'
-        destination_repo: 'bdring/fluidnc-releases'
-        destination_branch: 'main'
-        destination_folder: releases/${{ github.event.inputs.tag }}
-        user_email: bdring@buildlog.net
-        user_name: 'Bart Dring'
-        commit_msg: Release ${{ github.event.inputs.tag }}
+    # - name: Deploy to fluidnc-releases
+    #   uses: datalbry/copy_folder_to_another_repo_action@1.0.0
+    #   env:
+    #     API_TOKEN_GITHUB: ${{ secrets.RELEASE_COPY_TOKEN }}
+    #   with:
+    #     source_folder: 'release/current'
+    #     destination_repo: 'bdring/fluidnc-releases'
+    #     destination_branch: 'main'
+    #     destination_folder: releases/${{ github.event.inputs.tag }}
+    #     user_email: bdring@buildlog.net
+    #     user_name: 'Bart Dring'
+    #     commit_msg: Release ${{ github.event.inputs.tag }}
     # - name: Upload mac bundle
     #   uses: actions/upload-artifact@v2
     #   with:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -47,18 +47,18 @@ jobs:
           release/*.zip
           release/*.elf
         draft: True
-    # - name: Deploy to fluidnc-releases
-    #   uses: datalbry/copy_folder_to_another_repo_action@1.0.0
-    #   env:
-    #     API_TOKEN_GITHUB: ${{ secrets.RELEASE_COPY_TOKEN }}
-    #   with:
-    #     source_folder: 'release/current'
-    #     destination_repo: 'bdring/fluidnc-releases'
-    #     destination_branch: 'main'
-    #     destination_folder: releases/${{ github.event.inputs.tag }}
-    #     user_email: bdring@buildlog.net
-    #     user_name: 'Bart Dring'
-    #     commit_msg: Release ${{ github.event.inputs.tag }}
+    - name: Deploy to fluidnc-releases
+      uses: datalbry/copy_folder_to_another_repo_action@1.0.0
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.RELEASE_COPY_TOKEN }}
+      with:
+        source_folder: 'release/current'
+        destination_repo: 'bdring/fluidnc-releases'
+        destination_branch: 'main'
+        destination_folder: releases/${{ github.event.inputs.tag }}
+        user_email: bdring@buildlog.net
+        user_name: 'Bart Dring'
+        commit_msg: Release ${{ github.event.inputs.tag }}
     # - name: Upload mac bundle
     #   uses: actions/upload-artifact@v2
     #   with:

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -36,6 +36,9 @@
 
 static Error fakeMaxSpindleSpeed(const char* value, AuthenticationLevel auth_level, Channel& out);
 
+static Error report_init_message_cmd(const char* value, AuthenticationLevel auth_level, Channel& out);
+
+void report_init_message(
 // If authentication is disabled, auth_level will be LEVEL_ADMIN
 static bool auth_failed(Word* w, const char* value, AuthenticationLevel auth_level) {
     permissions_t permissions = w->getPermissions();
@@ -705,6 +708,10 @@ static Error dump_config(const char* value, AuthenticationLevel auth_level, Chan
     return Error::Ok;
 }
 
+static Error report_init_message_cmd(const char* value, AuthenticationLevel auth_level, Channel& out) {
+    report_init_message(out);
+}
+
 static Error fakeMaxSpindleSpeed(const char* value, AuthenticationLevel auth_level, Channel& out) {
     if (!value) {
         log_stream(out, "$30=" << spindle->maxSpeed());
@@ -839,6 +846,8 @@ void make_user_commands() {
 
     new UserCommand("30", "FakeMaxSpindleSpeed", fakeMaxSpindleSpeed, notIdleOrAlarm);
     new UserCommand("32", "FakeLaserMode", fakeLaserMode, notIdleOrAlarm);
+
+    new UserCommand("GS", "GRBL/Show", report_init_message_cmd, notIdleOrAlarm);
 
     new AsyncUserCommand("J", "Jog", doJog, notIdleOrJog);
     new AsyncUserCommand("G", "GCode/Modes", report_gcode, anyState);

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -709,6 +709,8 @@ static Error dump_config(const char* value, AuthenticationLevel auth_level, Chan
 
 static Error report_init_message_cmd(const char* value, AuthenticationLevel auth_level, Channel& out) {
     report_init_message(out);
+
+    return Error::Ok;
 }
 
 static Error fakeMaxSpindleSpeed(const char* value, AuthenticationLevel auth_level, Channel& out) {

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -38,7 +38,6 @@ static Error fakeMaxSpindleSpeed(const char* value, AuthenticationLevel auth_lev
 
 static Error report_init_message_cmd(const char* value, AuthenticationLevel auth_level, Channel& out);
 
-void report_init_message(
 // If authentication is disabled, auth_level will be LEVEL_ADMIN
 static bool auth_failed(Word* w, const char* value, AuthenticationLevel auth_level) {
     permissions_t permissions = w->getPermissions();


### PR DESCRIPTION
Added "$GS" or "$GRBL/Show" user commands that echo the init message. CNCjs is expecting a line starting with "Grbl x.y". CNCjs will now consider itself initialized if sending "$GS" or "$GRBL/Show" in the console and avoid a soft reset. Init string is only sent to the channel that issued the user command. This pull request should implement [Feature: Get GRBL version printout #1300](https://github.com/bdring/FluidNC/issues/1300)