### PR TITLE
Configurable and non-configurable modules to keep the config tidy

### DIFF
--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -68,7 +68,7 @@ namespace Machine {
 
         handler.section("user_outputs", _userOutputs);
 
-        ModuleFactory::factory(handler);
+        ConfigurableModuleFactory::factory(handler);
         ATCs::ATCFactory::factory(handler);
         Spindles::SpindleFactory::factory(handler);
 

--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -108,6 +108,9 @@ void setup() {
         for (auto const& module : Modules()) {
             module->init();
         }
+        for (auto const& module : ConfigurableModules()) {
+            module->init();
+        }
 
         auto atcs = ATCs::ATCFactory::objects();
         for (auto const& atc : atcs) {

--- a/FluidNC/src/OLED.cpp
+++ b/FluidNC/src/OLED.cpp
@@ -558,4 +558,4 @@ void OLED::draw_checkbox(int16_t x, int16_t y, int16_t width, int16_t height, bo
     }
 }
 
-ModuleFactory::InstanceBuilder<OLED> oled_module __attribute__((init_priority(104))) ("oled");
+ConfigurableModuleFactory::InstanceBuilder<OLED> oled_module __attribute__((init_priority(104))) ("oled");

--- a/FluidNC/src/OLED.h
+++ b/FluidNC/src/OLED.h
@@ -10,9 +10,9 @@
 
 typedef const uint8_t* font_t;
 
-class OLED : public Channel, public Module {
+class OLED : public Channel, public ConfigurableModule {
 public:
-    OLED(const char* name) : Channel(name), Module(name) {}
+    OLED(const char* name) : Channel(name), ConfigurableModule(name) {}
     struct Layout {
         uint8_t                    _x;
         uint8_t                    _y;

--- a/FluidNC/src/Status_outputs.cpp
+++ b/FluidNC/src/Status_outputs.cpp
@@ -78,5 +78,5 @@ void Status_Outputs::parse_status_report() {
 
 // Configuration registration
 namespace {
-    ModuleFactory::InstanceBuilder<Status_Outputs> registration("status_outputs");
+    ConfigurableModuleFactory::InstanceBuilder<Status_Outputs> registration("status_outputs");
 }

--- a/FluidNC/src/Status_outputs.h
+++ b/FluidNC/src/Status_outputs.h
@@ -4,7 +4,7 @@
 #include "src/Module.h"
 #include "src/Channel.h"
 
-class Status_Outputs : public Channel, public Module {
+class Status_Outputs : public Channel, public ConfigurableModule {
     Pin _Idle_pin;
     Pin _Run_pin;
     Pin _Hold_pin;
@@ -21,7 +21,7 @@ private:
     void parse_status_report();
 
 public:
-    Status_Outputs(const char* name) : Channel(name), Module(name) {}
+    Status_Outputs(const char* name) : Channel(name), ConfigurableModule(name) {}
 
     Status_Outputs(const Status_Outputs&)            = delete;
     Status_Outputs(Status_Outputs&&)                 = delete;


### PR DESCRIPTION
Fixes #1320

Needs a heck of a lot of testing

Non-configurable modules now do not appear in the configuration listing.  Configurable modules must now derive from ConfigurableModule instead of Module.