### PR TITLE
Flow control: skip dollar commands if parser is skipping blocks

### DIFF
--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -1033,6 +1033,9 @@ Error execute_line(char* line, Channel& channel, AuthenticationLevel auth_level)
     }
     // User '$' or WebUI '[ESPxxx]' command
     if (line[0] == '$' || line[0] == '[') {
+        if (gc_state.skip_blocks) {
+            return Error::Ok;
+        }
         return settings_execute_line(line, channel, auth_level);
     }
     // Everything else is gcode. Block if in alarm or jog mode.

--- a/fixture_tests/fixtures/flow_control_alarm.nc
+++ b/fixture_tests/fixtures/flow_control_alarm.nc
@@ -1,0 +1,12 @@
+-> $X
+<~ [MSG:INFO: Caution: Unlocked]
+<- ok
+-> o100 if [1 NE 1]
+-> $Alarm/Send = 1
+-> o100 else
+-> (print, success)
+<- ok
+-> o100 endif
+<- ok
+<- ok
+<- [MSG:INFO: PRINT, success]


### PR DESCRIPTION
Fixes a bug where dollar commands such as `$Alarm/Send=1` would be executed in conditionals even if the conditional was false. Adds a test fixture.

All fixtures pass with `./fixture_tests/run_fixture /dev/cu.usbserial-31320  fixture_tests/fixtures/`.

Tested with the following:
```nc
(print, start)
o100 repeat [0]
(print, fail repeat 0)
o100 endrepeat

#<count> = 0
o200 repeat [3]
#<count> = [#<count> + 1]
o200 endrepeat
(print, pass, count=%d#<count>)

o300 if [#<count> EQ 3]
(print, pass if)
o300 else
(print, fail if)
o300 endif

```

which produces the following output: 
```
$LocalFS/Run=repeat.nc
ok
[MSG:INFO: PRINT, start]
[MSG:INFO: PRINT, pass, count=3]
[MSG:INFO: PRINT, pass if]
[MSG:DBG: /repeat.nc job sent]
```