### PR TITLE
Fix repeat of 0, O commands with larger integer values

### DIFF
--- a/FluidNC/src/Flowcontrol.cpp
+++ b/FluidNC/src/Flowcontrol.cpp
@@ -248,7 +248,7 @@ Error flowcontrol(uint32_t o_label, char* line, size_t& pos, bool& skip) {
         case Op_EndRepeat:
             if (Job::active()) {
                 if (last_op == Op_Repeat) {
-                    if (!skipping && o_label == context.top().o_label) {
+                    if (o_label == context.top().o_label) {
                         if (context.top().repeats && --context.top().repeats) {
                             context.top().file->set_position(context.top().file_pos);
                         } else {

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -288,8 +288,8 @@ Error gc_execute_line(char* line) {
     size_t     pos;
     char       letter;
     float      value;
-    uint8_t    int_value = 0;
-    uint16_t   mantissa  = 0;
+    int32_t    int_value = 0;
+    int32_t    mantissa  = 0;
     pos                  = jogMotion ? 3 : 0;  // Start parsing after `$J=` if jogging
     while ((letter = line[pos]) != '\0') {     // Loop until no more g-code words in line.
         if (letter == '#') {
@@ -327,7 +327,7 @@ Error gc_execute_line(char* line) {
         // a good enough compromise and catch most all non-integer errors. To make it compliant,
         // we would simply need to change the mantissa to int16, but this add compiled flash space.
         // Maybe update this later.
-        int_value = int8_t(truncf(value));
+        int_value = static_cast<int32_t>(truncf(value));
         mantissa  = lroundf(100 * (value - int_value));  // Compute mantissa for Gxx.x commands.
         // NOTE: Rounding must be used to catch small floating point errors.
         // Check if the g-code word is supported or errors due to modal group violations or has
@@ -757,7 +757,6 @@ Error gc_execute_line(char* line) {
                     case 'E':
                         axis_word_bit     = GCodeWord::E;
                         gc_block.values.e = int_value;
-                        //log_info("E " << gc_block.values.e);
                         break;
                     case 'F':
                         axis_word_bit     = GCodeWord::F;
@@ -794,7 +793,6 @@ Error gc_execute_line(char* line) {
                         axis_word_bit     = GCodeWord::O;
                         gc_block.values.o = int_value;
                         break;
-
                     case 'P':
                         axis_word_bit     = GCodeWord::P;
                         gc_block.values.p = value;

--- a/fixture_tests/fixtures/flow_control_large_values.nc
+++ b/fixture_tests/fixtures/flow_control_large_values.nc
@@ -1,0 +1,7 @@
+-> o1000 if [1]
+-> (print, pass if)
+-> o1000 else
+-> (print, fail if)
+-> o1000 endif
+<- ok
+<- [MSG:INFO: PRINT, pass if]


### PR DESCRIPTION
Two bugs that this fixes - 

1. `o100 repeat [0]` would fail. I think this was due to `skipping` being true by the time the parser got to the matching `endrepeat`, so it would effectively just end up skipping to the end of the file. The fix is to not check if we're skipping when we encounter an `endrepeat` I think, because we already check if the top of the stack is its matching `repeat` label.
2. `o300 if [1]` would fail because the int value of `300` is cast to an int8_t, which is too small a type to contain 300. Upgraded `int_value` to `int32_t` to avoid this.

repeat tested with the following
```
--- (gcode ----
(print, start)
o100 repeat [0]
(print, fail repeat 0)
o100 endrepeat

#<count> = 0
o200 repeat [3]
#<count> = [#<count> + 1]
o200 endrepeat
(print, pass, count=%d#<count>)

o300 if [#<count> EQ 3]
(print, pass if)
o300 else
(print, fail if)
o300 endif

--- (output) ----
$LocalFS/Run=repeat.nc
ok
[MSG:INFO: PRINT, start]
[MSG:INFO: PRINT, pass, count=3]
[MSG:INFO: PRINT, pass if]
```