### PR TITLE
Improve web request handling

### DIFF
--- a/FluidNC/src/HashFS.cpp
+++ b/FluidNC/src/HashFS.cpp
@@ -107,14 +107,14 @@ void HashFS::hash_all() {
         }
     }
 }
-std::string HashFS::hash(const std::filesystem::path& path) {
+std::string HashFS::hash(const std::filesystem::path& path, bool useCacheOnly /*= false*/) {
     if (file_is_hashable(path)) {
         std::map<std::string, std::string>::const_iterator it;
         it = localFsHashes.find(path.filename());
         if (it != localFsHashes.end()) {
             return it->second;
         }
-    } else {
+    } else if (!useCacheOnly) {
         std::string theHash;
         hashFile(path, theHash);
         return theHash;

--- a/FluidNC/src/HashFS.h
+++ b/FluidNC/src/HashFS.h
@@ -14,7 +14,7 @@ public:
     static void hash_all();
     static void report_change();
 
-    static std::string hash(const std::filesystem::path& path);
+    static std::string hash(const std::filesystem::path& path, bool useCacheOnly = false);
 
 private:
 };

--- a/FluidNC/src/WebUI/WebServer.h
+++ b/FluidNC/src/WebUI/WebServer.h
@@ -86,7 +86,6 @@ namespace WebUI {
         static void handle_Websocket_Event(uint8_t num, uint8_t type, uint8_t* payload, size_t length);
         static void handle_Websocketv3_Event(uint8_t num, uint8_t type, uint8_t* payload, size_t length);
         static void handleReloadBlocked();
-        static void handleFeedholdBlocked();
         static void handleFeedholdReload();
         static void handleCyclestartReload();
         static void handleRestartReload();


### PR DESCRIPTION
### Hold State Requests

Pull request #1334 introduced a new screen during the Hold state that only allows you to Resume or Stop the current job. 

![image](https://github.com/user-attachments/assets/441d2391-677a-43c3-93f8-15829be6255c)

This PR reverts back to the previous behavior which will allowed it to serve up file requests when ```inMotionState()``` is false, even in Hold state.

This is in agreement to the screen that shows when in motion, that appears to say that issuing a feedhold is recommended to be able to reload the WebUI.

![image](https://github.com/user-attachments/assets/d2c83c4c-5dd4-463f-9b01-34a0eae0fae4)

### 304 responses

This PR also adds a check when in motion that will return a 304 when the correct ETag is received and the hash of the file is already cached in memory.

This should reduce the amount of times that the cut down UI is seen if the file needs to be retrieved again for some reason.