### PR TITLE
Adjust M6 macro behaviour

### DIFF
--- a/FluidNC/src/Spindles/Spindle.cpp
+++ b/FluidNC/src/Spindles/Spindle.cpp
@@ -143,10 +143,10 @@ namespace Spindles {
                 return true;
             }
             _last_tool = tool_number;
-            if (set_tool) {}
-            if (tool_number == 0) {  // do nothing
+            if (set_tool) {
                 return true;
             }
+
             //if (tool_number != _last_tool) {
             log_info(_name << " spindle run macro: " << _m6_macro.get());
             _m6_macro.run(nullptr);


### PR DESCRIPTION
- M6 T0 is now to be handled by the m6 macro (Allows unloading of currently loaded tool)
- M61 Q<X> no longer runs the M6 macro