### PR TITLE
Fix problem with mDNS not registering properly for Telnet

### DIFF
--- a/FluidNC/src/WebUI/TelnetServer.cpp
+++ b/FluidNC/src/WebUI/TelnetServer.cpp
@@ -44,7 +44,7 @@ namespace WebUI {
         _wifiServer->begin();
         _setupdone = true;
 
-        Mdns::add("telnet", "tcp", _port);
+        Mdns::add("_telnet", "_tcp", _port);
     }
 
     void TelnetServer::deinit() {


### PR DESCRIPTION
The mDNS implementation changed between version 3.8.0 and 3.8.1:
https://github.com/bdring/FluidNC/compare/v3.8.0...v3.8.1

There was a typo in the service name and protocol which causes the service to not register properly.