### PR TITLE
Better m6 macros

### DIFF
--- a/FluidNC/src/Channel.h
+++ b/FluidNC/src/Channel.h
@@ -81,7 +81,8 @@ protected:
 
     UTF8 _utf8;
 
-    bool _ended = false;
+    bool _ended   = false;
+    bool _percent = false;
 
 protected:
     bool _active = true;
@@ -180,6 +181,7 @@ public:
     void push(const std::string& s) { push(reinterpret_cast<const uint8_t*>(s.c_str()), s.length()); }
 
     void end() { _ended = true; }
+    void percent() { _percent = true; }
 
     // Pin extender functions
     virtual void out(const char* s, const char* tag);

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -1631,7 +1631,7 @@ Error gc_execute_line(char* line) {
             gc_ovr_changed();
         }
     }
-    if (gc_block.modal.set_tool_number == SetToolNumber::Enable) {
+    if (gc_block.modal.set_tool_number == SetToolNumber::Enable) {  // M61
         if (gc_block.values.q < 0) {
             FAIL(Error::NegativeValue);  // https://linuxcnc.org/docs/2.8/html/gcode/m-code.html#mcode:m61
         }

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -1613,7 +1613,7 @@ Error gc_execute_line(char* line) {
             bool stopped_spindle = false;   // was spindle stopped via the change
             bool new_spindle     = false;   // was the spindle changed
             protocol_buffer_synchronize();  // wait for motion in buffer to finish
-            
+
             Spindles::Spindle::switchSpindle(
                 gc_state.selected_tool, Spindles::SpindleFactory::objects(), spindle, stopped_spindle, new_spindle);
             if (stopped_spindle) {
@@ -1901,7 +1901,6 @@ Error gc_execute_line(char* line) {
 
             if (Job::active()) {
                 Job::channel()->end();
-                break;
             }
             // Upon program complete, only a subset of g-codes reset to certain defaults, according to
             // LinuxCNC's program end descriptions and testing. Only modal groups [G-code 1,2,3,5,7,12]

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -192,12 +192,13 @@ void collapseGCode(char* line) {
                 *outPtr = '\0';
                 return;
             case '%':
-                // TODO: Install '%' feature
-                // Program start-end percent sign NOT SUPPORTED.
-                // NOTE: This may be installed to distinguish between program running vs manual input,
-                // where, during a program, the system auto-cycle start will continue to execute
-                // everything until the next '%' sign. This will help fix resuming issues with certain
-                // functions that empty the planner buffer to execute its task on-time.
+                // Per https://linuxcnc.org/docs/html/gcode/overview.html#gcode:file-requirements
+                // % only applies to "job" channels like files and macros, not to serial channels
+                // where the sequence of lines is potentially never-ending.  A sender that handles
+                // files on the host system could apply the % semantics.
+                if (Job::active()) {
+                    Job::channel()->percent();
+                }
                 break;
             case '\r':
                 // In case one sneaks in
@@ -1605,7 +1606,7 @@ Error gc_execute_line(char* line) {
     // NOTE: Pass zero spindle speed for all restricted laser motions.
     if (!disableLaser) {
         pl_data->spindle_speed = gc_state.spindle_speed;  // Record data for planner use.
-    }  // else { pl_data->spindle_speed = 0.0; } // Initialized as zero already.
+    }                                                     // else { pl_data->spindle_speed = 0.0; } // Initialized as zero already.
     // [5. Select tool ]: NOT SUPPORTED. Only tracks tool value.
     // [M6. Change tool ]:
     if (gc_block.modal.tool_change == ToolChange::Enable) {

--- a/FluidNC/src/InputFile.cpp
+++ b/FluidNC/src/InputFile.cpp
@@ -24,6 +24,9 @@ Error InputFile::readLine(char* line, int maxlen) {
         }
         if (c == '\n') {
             ++_line_number;
+            if (len == 0) {
+                ++_blank_lines;
+            }
             break;
         }
         line[len++] = c;
@@ -61,6 +64,17 @@ Error InputFile::pollLine(char* line) {
     }
     if (_pending_error != Error::Ok) {
         return _pending_error;
+    }
+    if (_percent) {
+        _percent = false;
+        // If the first non-blank line in the file is a % line, it denotes start-of-file.
+        // Otherwise a % line causes the rest of the file to be skipped, per
+        // https://linuxcnc.org/docs/html/gcode/overview.html#gcode:file-requirements
+        // The line with % is not blank, so if it is the first non-blank line
+        // _line_number will be one more than _blank_lines
+        if (_line_number != (_blank_lines + 1)) {
+            _ended = true;
+        }
     }
     if (_ended) {
         end_message();

--- a/FluidNC/src/InputFile.h
+++ b/FluidNC/src/InputFile.h
@@ -24,6 +24,8 @@ private:
     Error _pending_error = Error::Ok;
     void  end_message();
 
+    size_t _blank_lines = 0;
+
 public:
     // fsname is the default file system on which the file is located, in case the path does not specify
     // path is the full path to the file

--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -43,7 +43,7 @@ namespace Machine {
 
     uint32_t Homing::_runs;
 
-    AxisMask Homing::_unhomed_axes;  // Bitmap of axes whose position is unknown
+    AxisMask Homing::_unhomed_axes = 0;  // Bitmap of axes whose position is unknown
 
     bool Homing::axis_is_homed(size_t axis) {
         return bitnum_is_false(_unhomed_axes, axis);
@@ -55,7 +55,9 @@ namespace Machine {
         set_bitnum(_unhomed_axes, axis);
     }
     void Homing::set_all_axes_unhomed() {
-        _unhomed_axes = Machine::Axes::homingMask;
+        if (config->_start->_mustHome) {
+            _unhomed_axes = Machine::Axes::homingMask;
+        }
     }
     void Homing::set_all_axes_homed() {
         _unhomed_axes = 0;

--- a/FluidNC/src/Machine/Macros.h
+++ b/FluidNC/src/Machine/Macros.h
@@ -58,6 +58,7 @@ namespace Machine {
     private:
         Error  _pending_error = Error::Ok;
         size_t _position      = 0;
+        size_t _blank_lines   = 0;
 
         Macro* _macro;
 

--- a/FluidNC/src/Machine/Macros.h
+++ b/FluidNC/src/Machine/Macros.h
@@ -62,6 +62,7 @@ namespace Machine {
         Macro* _macro;
 
         Error readLine(char* line, int maxlen);
+        void  end_message();
 
     public:
         Error pollLine(char* line) override;

--- a/FluidNC/src/Spindles/Spindle.cpp
+++ b/FluidNC/src/Spindles/Spindle.cpp
@@ -42,10 +42,7 @@ namespace Spindles {
                 spindle->stop();      // stop the current spindle
                 stop_spindle = true;  // used to stop the next spindle
             }
-            if (candidate != spindle) {                 // we are changing spindles
-                log_info("Sel:" << gc_state.selected_tool << " Cur:" << gc_state.current_tool);
-                //gc_state.selected_tool = 0;             // we are changing the original spindle to tool 0, for use by macro or class
-                spindle->tool_change(new_tool, false, false);  // run the tool change on the exiting spindle
+            if (candidate != spindle) {  // we are changing spindles
                 gc_state.selected_tool = new_tool;
                 spindle                = candidate;
                 new_spindle            = true;
@@ -133,14 +130,11 @@ namespace Spindles {
     // pre_select is generally ignored except for machines that need to get a tool ready
     // set_tool is just used to tell the atc what is already installed.
     bool Spindle::tool_change(uint32_t tool_number, bool pre_select, bool set_tool) {
-        log_info(_name << " Spindle::tool_change Sel:" << gc_state.selected_tool << " Cur:" << gc_state.current_tool << "pre:" << pre_select << " set:" << set_tool);
-
         if (_atc != NULL) {
             log_info(_name << " spindle changed to tool:" << tool_number << " using " << _atc_name);
             return _atc->tool_change(tool_number, pre_select, set_tool);
         }
         if (!_m6_macro.get().empty()) {
-            log_info("#1 " << _name << " spindle changed to tool:" << tool_number << " using m6_macro" << _m6_macro.get());
             if (pre_select) {
                 return true;
             }
@@ -148,7 +142,6 @@ namespace Spindles {
             if (set_tool) {
                 return true;
             }
-            log_info("#2 " << _name << " spindle changed to tool:" << tool_number << " using m6_macro" << _m6_macro.get());
             _m6_macro.run(nullptr);
             _last_tool = tool_number;
             return true;

--- a/FluidNC/src/Spindles/Spindle.cpp
+++ b/FluidNC/src/Spindles/Spindle.cpp
@@ -42,9 +42,13 @@ namespace Spindles {
                 spindle->stop();      // stop the current spindle
                 stop_spindle = true;  // used to stop the next spindle
             }
-            if (candidate != spindle) {
-                spindle = candidate;
-                new_spindle = true;
+            if (candidate != spindle) {                 // we are changing spindles
+                log_info("Sel:" << gc_state.selected_tool << " Cur:" << gc_state.current_tool);
+                //gc_state.selected_tool = 0;             // we are changing the original spindle to tool 0, for use by macro or class
+                spindle->tool_change(new_tool, false, false);  // run the tool change on the exiting spindle
+                gc_state.selected_tool = new_tool;
+                spindle                = candidate;
+                new_spindle            = true;
                 log_info("Changed to spindle:" << spindle->name());
             }
         } else {
@@ -129,12 +133,14 @@ namespace Spindles {
     // pre_select is generally ignored except for machines that need to get a tool ready
     // set_tool is just used to tell the atc what is already installed.
     bool Spindle::tool_change(uint32_t tool_number, bool pre_select, bool set_tool) {
+        log_info(_name << " Spindle::tool_change Sel:" << gc_state.selected_tool << " Cur:" << gc_state.current_tool << "pre:" << pre_select << " set:" << set_tool);
+
         if (_atc != NULL) {
             log_info(_name << " spindle changed to tool:" << tool_number << " using " << _atc_name);
             return _atc->tool_change(tool_number, pre_select, set_tool);
         }
         if (!_m6_macro.get().empty()) {
-            log_info(_name << " spindle changed to tool:" << tool_number << " using m6_macro");
+            log_info("#1 " << _name << " spindle changed to tool:" << tool_number << " using m6_macro" << _m6_macro.get());
             if (pre_select) {
                 return true;
             }
@@ -142,14 +148,13 @@ namespace Spindles {
             if (set_tool) {
                 return true;
             }
-
-            //if (tool_number != _last_tool) {
-            log_info(_name << " spindle run macro: " << _m6_macro.get());
+            log_info("#2 " << _name << " spindle changed to tool:" << tool_number << " using m6_macro" << _m6_macro.get());
             _m6_macro.run(nullptr);
             _last_tool = tool_number;
             return true;
             //}
         }
+
         return true;
     }
 


### PR DESCRIPTION
### This implements the following changes

## Control of the current tool number

If you are using m6_macros, you must set the current tool after the tool change with M61Qx. This allows the macro to control what happens if there is an issue preventing a successful tool change.

If you are not using m6_macros, FluidNC will change the tool number.

## Using Multiple Spindles

If you are using multiple spindles and want to change to a new spindle, but do something to the current spindle first, send an M6Tx to the current spindle then send M6Tx to the new spindle.

For example: If you want to change from an ATC spindle (tool range 0-9) to a laser (tool range 10-255), but want to put away the current tool first. Send this via console or include in your gcode file.

```gcode
M6T0 ; put away current tool
M6T11 ; switch to laser spindle 
```

Your macros should use the selected_tool and current_tool to determine what to do. In the case of secondary spindles the tool range is not accessible to the macro. You should hard code variables for these numbers.

The tool numbers have no special significance in FluidNC other than determining the current spindle. Your macro determines if Tool 0 means no tool or if another tool has special meaning like a touch probe. 

## M2 and M30 

Fixed some issue with M2 and M30. This returns from the current job or macro. Be careful using in macro because they reset the modal values like G54, G21, etc

## % character support 

The us of % in gcode files is now compliant with LinuxCNC. We don't suggest its use though. There is no real benefit.

## Alarm/Send in macros

A race condition was fixed so alarms stop all gcode processing

