### PR TITLE
Generic Modbus VFD

### DIFF
--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -628,7 +628,7 @@ void hex_msg(uint8_t* buf, const char* prefix, int len) {
     char temp[20];
     sprintf(report, "%s", prefix);
     for (int i = 0; i < len; i++) {
-        sprintf(temp, " 0x%02X", buf[i]);
+        sprintf(temp, " %02X", buf[i]);
         strcat(report, temp);
     }
 

--- a/FluidNC/src/Spindles/VFD/DanfossVLT2800Protocol.h
+++ b/FluidNC/src/Spindles/VFD/DanfossVLT2800Protocol.h
@@ -60,7 +60,9 @@ namespace Spindles {
             void direction_command(SpindleState mode, ModbusCommand& data) override;
             void set_speed_command(uint32_t rpm, ModbusCommand& data) override;
 
-            response_parser initialization_sequence(int index, ModbusCommand& data) { return get_status_ok_and_init(data, true); }
+            response_parser initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) {
+                return get_status_ok_and_init(data, true);
+            }
             response_parser get_current_speed(ModbusCommand& data) override;
             response_parser get_current_direction(ModbusCommand& data) override { return nullptr; };
             response_parser get_status_ok(ModbusCommand& data) override { return get_status_ok_and_init(data, false); }

--- a/FluidNC/src/Spindles/VFD/GenericProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/GenericProtocol.cpp
@@ -40,9 +40,14 @@ namespace Spindles {
             return true;
         }
 
-        void scale(uint32_t& n, std::string_view scale_str) {
+        void scale(uint32_t& n, std::string_view scale_str, uint32_t maxRPM) {
             if (scale_str.empty()) {
                 return;
+            }
+            if (scale_str[0] == '%') {
+                scale_str.remove_prefix(1);
+                n *= 100;
+                n /= maxRPM;
             }
             if (scale_str[0] == '*') {
                 std::string_view numerator_str;
@@ -109,7 +114,7 @@ namespace Spindles {
             if (string_util::starts_with_ignore_case(token, name)) {
                 uint32_t rval  = (response_view[0] << 8) + (response_view[1] & 0xff);
                 uint32_t orval = rval;
-                scale(rval, token.substr(strlen(name)));
+                scale(rval, token.substr(strlen(name)), 1);
                 data = rval;
                 response_view.remove_prefix(2);
                 return true;
@@ -173,7 +178,7 @@ namespace Spindles {
                 }
                 if (string_util::starts_with_ignore_case(token, "rpm")) {
                     uint32_t oout = out;
-                    scale(out, token.substr(strlen("rpm")));
+                    scale(out, token.substr(strlen("rpm")), _maxRPM);
                     data.msg[data.tx_length++] = out >> 8;
                     data.msg[data.tx_length++] = out & 0xff;
                 } else if (from_hex(token, data.msg[data.tx_length])) {

--- a/FluidNC/src/Spindles/VFD/GenericProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/GenericProtocol.cpp
@@ -1,0 +1,275 @@
+// Copyright (c) 2021 -  Marco Wagner
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#include "GenericProtocol.h"
+
+#include "../VFDSpindle.h"
+
+#include "src/string_util.h"
+#include <algorithm>
+
+namespace Spindles {
+    // cw_cmd: 06 20 00 00 12 < 06 20 00 00 12
+    // ccw_cmd: 06 20 00 00 22 < 06 20 00 00 22
+    // off_cmd: 06 20 00 00 01 < 06 20 00 00 01
+    // get_speed_cmd: 03 20 0b 00 01 < 03 02 xxxx
+    // set_speed_cmd: 03 20 01 xxxx < 06 20 01 xxxx
+    // get_min_freq_cmd: 03 03 08 00 01 < 03 02 xxxx
+    // get_max_freq_cmd: 03 00 00 00 01 < 03 02 xxxx
+    // rpm_factor: 6
+
+    namespace VFD {
+        bool split(std::string_view& input, std::string_view& token, const char* delims) {
+            if (input.size() == 0) {
+                return false;
+            }
+            auto pos = input.find_first_of(delims);
+            if (pos != std::string_view::npos) {
+                token = input.substr(0, pos);
+                input = input.substr(pos + 1);
+            } else {
+                token = input;
+                input = "";
+            }
+            return true;
+        }
+
+        bool from_decimal(std::string_view str, uint32_t& value) {
+            value = 0;
+            if (str.size() == 0) {
+                return false;
+            }
+            while (str.size()) {
+                value <<= 4;
+                if (!isdigit(str[0])) {
+                    return false;
+                }
+                value = value * 10 + str[0] - '0';
+                str   = str.substr(1);
+            }
+            return true;
+        }
+
+        void scale(uint32_t& n, std::string_view scale_str) {
+            if (scale_str.empty()) {
+                return;
+            }
+            if (scale_str[0] == '*') {
+                std::string_view numerator_str;
+                scale_str = scale_str.substr(1);
+                split(scale_str, numerator_str, "/");
+                uint32_t numerator;
+                if (from_decimal(numerator_str, numerator)) {
+                    n *= numerator;
+                } else {
+                    log_error("Bad decimal number " << numerator_str);
+                    return;
+                }
+                if (!scale_str.empty()) {
+                    uint32_t denominator;
+                    if (from_decimal(scale_str, denominator)) {
+                        n /= denominator;
+                    } else {
+                        log_error("Bad decimal number " << scale_str);
+                        return;
+                    }
+                }
+            } else if (scale_str[0] == '/') {
+                std::string_view denominator_str(scale_str.substr(1));
+                uint32_t         denominator;
+                if (from_decimal(denominator_str, denominator)) {
+                    n /= denominator;
+                } else {
+                    log_error("Bad decimal number " << scale_str);
+                    return;
+                }
+            }
+        }
+
+        bool from_xdigit(char c, uint8_t& value) {
+            if (isdigit(c)) {
+                value = c - '0';
+                return true;
+            }
+            c = tolower(c);
+            if (c >= 'a' && c <= 'f') {
+                value = 10 + c - 'a';
+                return true;
+            }
+            return false;
+        }
+
+        bool from_hex(std::string_view str, uint8_t& value) {
+            value = 0;
+            if (str.size() == 0 || str.size() > 2) {
+                return false;
+            }
+            uint8_t x;
+            while (str.size()) {
+                value <<= 4;
+                if (!from_xdigit(str[0], x)) {
+                    return false;
+                }
+                value += x;
+                str = str.substr(1);
+            }
+            return true;
+        }
+        bool set_data(std::string_view token, std::basic_string_view<uint8_t>& response_view, const char* name, uint32_t& data) {
+            if (string_util::starts_with_ignore_case(token, name)) {
+                uint32_t rval  = (response_view[0] << 8) + (response_view[1] & 0xff);
+                uint32_t orval = rval;
+                scale(rval, token.substr(strlen(name)));
+                log_debug("Input " << orval << " scaled to " << rval);
+                data = rval;
+                response_view.remove_prefix(2);
+                return true;
+            }
+            return false;
+        }
+        bool GenericProtocol::parser(const uint8_t* response, VFDSpindle* spindle, GenericProtocol* instance) {
+            // This routine does not know the actual length of the response array
+            std::basic_string_view<uint8_t> response_view(response, VFD_RS485_MAX_MSG_SIZE);
+            response_view.remove_prefix(1);  // Remove the modbus ID which has already been checked
+
+            std::string_view token;
+            std::string_view format(_response_format);
+            while (split(format, token, " ")) {
+                uint8_t val;
+                if (token == "") {
+                    // Ignore repeated blanks
+                    continue;
+                }
+                if (set_data(token, response_view, "rpm", spindle->_sync_dev_speed)) {
+                    continue;
+                }
+                if (set_data(token, response_view, "minrpm", instance->_minRPM)) {
+                    continue;
+                }
+                if (set_data(token, response_view, "maxrpm", instance->_maxRPM)) {
+                    continue;
+                }
+                if (from_hex(token, val)) {
+                    if (val != response_view[0]) {
+                        log_debug("VFD Response mismatch - expected " << to_hex(val) << " got " << to_hex(response_view[0]));
+                        return false;
+                    }
+                    response_view.remove_prefix(1);
+                    continue;
+                }
+                log_error("Bad response token " << token);
+                return false;
+            }
+            return true;
+        }
+        void GenericProtocol::send_vfd_command(const std::string cmd, ModbusCommand& data, uint32_t out) {
+            log_debug("Sending " << cmd);
+            data.tx_length = 1;
+            data.rx_length = 1;
+            if (cmd.empty()) {
+                return;
+            }
+
+            std::string_view out_view;
+            std::string_view in_view(cmd);
+            split(in_view, out_view, ">");
+            _response_format = in_view;  // Remember the response format for the parser
+
+            std::string_view token;
+            while (data.tx_length < (VFD_RS485_MAX_MSG_SIZE - 3) && split(out_view, token, " ")) {
+                if (token == "") {
+                    // Ignore repeated blanks
+                    continue;
+                }
+                if (string_util::starts_with_ignore_case(token, "rpm")) {
+                    uint32_t oout = out;
+                    scale(out, token.substr(strlen("rpm")));
+                    log_debug("Output " << oout << " scaled to " << out);
+                    data.msg[data.tx_length++] = out >> 8;
+                    data.msg[data.tx_length++] = out & 0xff;
+                } else if (from_hex(token, data.msg[data.tx_length])) {
+                    ++data.tx_length;
+                } else {
+                    log_error("Bad hex number " << token);
+                    return;
+                }
+            }
+            while (data.rx_length < (VFD_RS485_MAX_MSG_SIZE - 3) && split(in_view, token, " ")) {
+                // log_debug("<tok " << token);
+                if (token == "") {
+                    // Ignore repeated spaces
+                    continue;
+                }
+                uint8_t x;
+                if (string_util::equal_ignore_case(token, "echo")) {
+                    data.rx_length = data.tx_length;
+                    break;
+                }
+                if (string_util::starts_with_ignore_case(token, "rpm") || string_util::starts_with_ignore_case(token, "minrpm") ||
+                    string_util::starts_with_ignore_case(token, "maxrpm")) {
+                    data.rx_length += 2;
+                } else if (from_hex(token, x)) {
+                    ++data.rx_length;
+                } else {
+                    log_error("Bad hex number " << token);
+                }
+            }
+        }
+        void GenericProtocol::direction_command(SpindleState mode, ModbusCommand& data) {
+            switch (mode) {
+                case SpindleState::Cw:
+                    send_vfd_command(_cw_cmd, data, 0);
+                    break;
+                case SpindleState::Ccw:
+                    send_vfd_command(_ccw_cmd, data, 0);
+                    break;
+                default:  // SpindleState::Disable
+                    send_vfd_command(_off_cmd, data, 0);
+                    break;
+            }
+        }
+
+        void GenericProtocol::set_speed_command(uint32_t speed, ModbusCommand& data) {
+            send_vfd_command(_set_speed_cmd, data, speed);
+        }
+
+        VFDProtocol::response_parser GenericProtocol::get_current_speed(ModbusCommand& data) {
+            send_vfd_command(_get_speed_cmd, data, 0);
+            return [](const uint8_t* response, VFDSpindle* spindle, VFDProtocol* protocol) -> bool {
+                auto instance = static_cast<GenericProtocol*>(protocol);
+                return instance->parser(response, spindle, instance);
+            };
+        }
+
+        void GenericProtocol::setup_speeds(VFDSpindle* vfd) {
+            vfd->shelfSpeeds(_minRPM, _maxRPM);
+            vfd->setupSpeeds(_maxRPM);
+            vfd->_slop = 300;
+        }
+        VFDProtocol::response_parser GenericProtocol::initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) {
+            if (_minRPM == 0xffffffff && !_get_min_rpm_cmd.empty()) {
+                send_vfd_command(_get_min_rpm_cmd, data, 0);
+                return [](const uint8_t* response, VFDSpindle* spindle, VFDProtocol* protocol) -> bool {
+                    auto instance = static_cast<GenericProtocol*>(protocol);
+                    return instance->parser(response, spindle, instance);
+                };
+            }
+            if (_maxRPM == 0xffffffff && !_get_max_rpm_cmd.empty()) {
+                send_vfd_command(_get_max_rpm_cmd, data, 0);
+                return [](const uint8_t* response, VFDSpindle* spindle, VFDProtocol* protocol) -> bool {
+                    auto instance = static_cast<GenericProtocol*>(protocol);
+                    return instance->parser(response, spindle, instance);
+                };
+            }
+            if (vfd->_speeds.size() == 0) {
+                setup_speeds(vfd);
+            }
+            return nullptr;
+        }
+
+        // Configuration registration
+        namespace {
+            SpindleFactory::DependentInstanceBuilder<VFDSpindle, GenericProtocol> registration("VFD");
+        }
+    }
+}

--- a/FluidNC/src/Spindles/VFD/GenericProtocol.h
+++ b/FluidNC/src/Spindles/VFD/GenericProtocol.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 -	Mitch Bradley
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "VFDProtocol.h"
+
+namespace Spindles {
+    namespace VFD {
+        class GenericProtocol : public VFDProtocol, Configuration::Configurable {
+        protected:
+            void direction_command(SpindleState mode, ModbusCommand& data) override;
+            void set_speed_command(uint32_t dev_speed, ModbusCommand& data) override;
+
+            response_parser initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) override;
+            response_parser get_current_speed(ModbusCommand& data) override;
+            response_parser get_current_direction(ModbusCommand& data) override { return nullptr; };
+            response_parser get_status_ok(ModbusCommand& data) override { return nullptr; }
+
+            bool use_delay_settings() const override { return false; }
+            bool safety_polling() const override { return false; }
+
+            std::string _cw_cmd;
+            std::string _ccw_cmd;
+            std::string _off_cmd;
+            std::string _set_speed_cmd;
+            std::string _get_min_rpm_cmd;
+            std::string _get_max_rpm_cmd;
+            std::string _get_speed_cmd;
+
+        private:
+            std::string _model;  // VFD Model name
+            uint32_t*   _response_data;
+            uint32_t    _minRPM = 0xffffffff;
+            uint32_t    _maxRPM = 0xffffffff;
+            bool        parser(const uint8_t* response, VFDSpindle* spindle, GenericProtocol* protocol);
+            void        send_vfd_command(const std::string cmd, ModbusCommand& data, uint32_t out);
+            std::string _response_format;
+            void        setup_speeds(VFDSpindle* vfd);
+
+        public:
+            void group(Configuration::HandlerBase& handler) override {
+                handler.item("model", _model);
+                handler.item("min_RPM", _minRPM, 0xffffffff);
+                handler.item("max_RPM", _maxRPM, 0xffffffff);
+                handler.item("cw_cmd", _cw_cmd);
+                handler.item("ccw_cmd", _ccw_cmd);
+                handler.item("off_cmd", _off_cmd);
+                handler.item("set_speed_cmd", _set_speed_cmd);
+                handler.item("get_min_rpm_cmd", _get_min_rpm_cmd);
+                handler.item("get_max_rpm_cmd", _get_max_rpm_cmd);
+                handler.item("get_speed_cmd", _get_speed_cmd);
+            }
+        };
+
+    }
+}

--- a/FluidNC/src/Spindles/VFD/GenericProtocol.h
+++ b/FluidNC/src/Spindles/VFD/GenericProtocol.h
@@ -17,16 +17,16 @@ namespace Spindles {
             response_parser get_current_direction(ModbusCommand& data) override { return nullptr; };
             response_parser get_status_ok(ModbusCommand& data) override { return nullptr; }
 
-            bool use_delay_settings() const override { return true; }
-            bool safety_polling() const override { return false; }
-
             std::string _cw_cmd;
             std::string _ccw_cmd;
             std::string _off_cmd;
-            std::string _set_speed_cmd;
+            std::string _set_rpm_cmd;
             std::string _get_min_rpm_cmd;
             std::string _get_max_rpm_cmd;
-            std::string _get_speed_cmd;
+            std::string _get_rpm_cmd;
+
+            bool use_delay_settings() const override { return _get_rpm_cmd.empty(); }
+            bool safety_polling() const override { return false; }
 
         private:
             std::string _model;  // VFD Model name
@@ -46,10 +46,10 @@ namespace Spindles {
                 handler.item("cw_cmd", _cw_cmd);
                 handler.item("ccw_cmd", _ccw_cmd);
                 handler.item("off_cmd", _off_cmd);
-                handler.item("set_speed_cmd", _set_speed_cmd);
+                handler.item("set_rpm_cmd", _set_rpm_cmd);
                 handler.item("get_min_rpm_cmd", _get_min_rpm_cmd);
                 handler.item("get_max_rpm_cmd", _get_max_rpm_cmd);
-                handler.item("get_speed_cmd", _get_speed_cmd);
+                handler.item("get_rpm_cmd", _get_rpm_cmd);
             }
         };
 

--- a/FluidNC/src/Spindles/VFD/GenericProtocol.h
+++ b/FluidNC/src/Spindles/VFD/GenericProtocol.h
@@ -17,7 +17,7 @@ namespace Spindles {
             response_parser get_current_direction(ModbusCommand& data) override { return nullptr; };
             response_parser get_status_ok(ModbusCommand& data) override { return nullptr; }
 
-            bool use_delay_settings() const override { return false; }
+            bool use_delay_settings() const override { return true; }
             bool safety_polling() const override { return false; }
 
             std::string _cw_cmd;

--- a/FluidNC/src/Spindles/VFD/H100Protocol.cpp
+++ b/FluidNC/src/Spindles/VFD/H100Protocol.cpp
@@ -70,7 +70,7 @@ namespace Spindles {
         }
 
         // This gets data from the VFD. It does not set any values
-        VFDProtocol::response_parser H100Protocol::initialization_sequence(int index, ModbusCommand& data) {
+        VFDProtocol::response_parser H100Protocol::initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) {
             // NOTE: data length is excluding the CRC16 checksum.
             data.tx_length = 6;
             data.rx_length = 5;

--- a/FluidNC/src/Spindles/VFD/H100Protocol.h
+++ b/FluidNC/src/Spindles/VFD/H100Protocol.h
@@ -20,7 +20,7 @@ namespace Spindles {
             void direction_command(SpindleState mode, ModbusCommand& data) override;
             void set_speed_command(uint32_t rpm, ModbusCommand& data) override;
 
-            response_parser initialization_sequence(int index, ModbusCommand& data) override;
+            response_parser initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) override;
             response_parser get_status_ok(ModbusCommand& data) override { return nullptr; }
             response_parser get_current_speed(ModbusCommand& data) override;
 

--- a/FluidNC/src/Spindles/VFD/H2AProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/H2AProtocol.cpp
@@ -56,7 +56,7 @@ namespace Spindles {
             data.msg[5] = speed & 0xFF;
         }
 
-        VFDProtocol::response_parser H2AProtocol::initialization_sequence(int index, ModbusCommand& data) {
+        VFDProtocol::response_parser H2AProtocol::initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) {
             if (index == -1) {
                 data.tx_length = 6;
                 data.rx_length = 8;

--- a/FluidNC/src/Spindles/VFD/H2AProtocol.h
+++ b/FluidNC/src/Spindles/VFD/H2AProtocol.h
@@ -12,7 +12,7 @@ namespace Spindles {
             void direction_command(SpindleState mode, ModbusCommand& data) override;
             void set_speed_command(uint32_t dev_speed, ModbusCommand& data) override;
 
-            response_parser initialization_sequence(int index, ModbusCommand& data) override;
+            response_parser initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) override;
             response_parser get_current_speed(ModbusCommand& data) override;
             response_parser get_current_direction(ModbusCommand& data) override;
             response_parser get_status_ok(ModbusCommand& data) override { return nullptr; }

--- a/FluidNC/src/Spindles/VFD/HuanyangProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/HuanyangProtocol.cpp
@@ -210,7 +210,7 @@ namespace Spindles {
         }
 
         // This gets data from the VFS. It does not set any values
-        VFDProtocol::response_parser HuanyangProtocol::initialization_sequence(int index, ModbusCommand& data) {
+        VFDProtocol::response_parser HuanyangProtocol::initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) {
             // NOTE: data length is excluding the CRC16 checksum.
             data.tx_length = 6;
             data.rx_length = 6;

--- a/FluidNC/src/Spindles/VFD/HuanyangProtocol.h
+++ b/FluidNC/src/Spindles/VFD/HuanyangProtocol.h
@@ -23,7 +23,7 @@ namespace Spindles {
             void direction_command(SpindleState mode, ModbusCommand& data) override;
             void set_speed_command(uint32_t rpm, ModbusCommand& data) override;
 
-            response_parser initialization_sequence(int index, ModbusCommand& data) override;
+            response_parser initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) override;
             response_parser get_status_ok(ModbusCommand& data) override;
             response_parser get_current_speed(ModbusCommand& data) override;
         };

--- a/FluidNC/src/Spindles/VFD/NowForeverProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/NowForeverProtocol.cpp
@@ -69,7 +69,7 @@ namespace Spindles {
             log_debug("VFD: Set speed: " << hz / 100 << "hz or" << (hz * 60 / 100) << "rpm");
         }
 
-        VFDProtocol::response_parser NowForeverProtocol::initialization_sequence(int index, ModbusCommand& data) {
+        VFDProtocol::response_parser NowForeverProtocol::initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) {
             if (index == -1) {
                 data.tx_length = 6;
                 data.rx_length = 7;

--- a/FluidNC/src/Spindles/VFD/NowForeverProtocol.h
+++ b/FluidNC/src/Spindles/VFD/NowForeverProtocol.h
@@ -14,7 +14,7 @@ namespace Spindles {
             void direction_command(SpindleState mode, ModbusCommand& data) override;
             void set_speed_command(uint32_t hz, ModbusCommand& data) override;
 
-            response_parser initialization_sequence(int index, ModbusCommand& data) override;
+            response_parser initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) override;
             response_parser get_current_speed(ModbusCommand& data) override;
             response_parser get_current_direction(ModbusCommand& data) override;
             response_parser get_status_ok(ModbusCommand& data) override;

--- a/FluidNC/src/Spindles/VFD/SiemensV20Protocol.cpp
+++ b/FluidNC/src/Spindles/VFD/SiemensV20Protocol.cpp
@@ -169,7 +169,7 @@ namespace Spindles {
             data.msg[5] = ScaledFreq & 0xFF;
         }
 
-        VFDProtocol::response_parser SiemensV20Protocol::initialization_sequence(int index, ModbusCommand& data) {
+        VFDProtocol::response_parser SiemensV20Protocol::initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) {
             // NOTE: data length is excluding the CRC16 checksum.
             data.tx_length = 6;
             data.rx_length = 5;

--- a/FluidNC/src/Spindles/VFD/SiemensV20Protocol.h
+++ b/FluidNC/src/Spindles/VFD/SiemensV20Protocol.h
@@ -21,7 +21,7 @@ namespace Spindles {
 
             void            direction_command(SpindleState mode, ModbusCommand& data) override;
             void            set_speed_command(uint32_t rpm, ModbusCommand& data) override;
-            response_parser initialization_sequence(int index, ModbusCommand& data) override;
+            response_parser initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) override;
             response_parser get_current_speed(ModbusCommand& data) override;
             response_parser get_status_ok(ModbusCommand& data) override { return nullptr; }
 

--- a/FluidNC/src/Spindles/VFD/VFDProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/VFDProtocol.cpp
@@ -145,7 +145,7 @@ namespace Spindles {
 
                 // Assume for the worst, and retry...
                 int retry_count = 0;
-                for (; retry_count < MAX_RETRIES; ++retry_count) {
+                for (; retry_count < instance->_retries; ++retry_count) {
                     // Flush the UART and write the data:
                     uart.flush();
                     uart.write(next_cmd.msg, next_cmd.tx_length);
@@ -179,7 +179,7 @@ namespace Spindles {
 
                         // Success
                         unresponsive = false;
-                        retry_count  = MAX_RETRIES + 1;  // stop retry'ing
+                        retry_count  = instance->_retries + 1;  // stop retry'ing
                         if (instance->_debug > 2) {
                             hex_msg(rx_message, "RS485 Rx: ", read_length);
                         }
@@ -217,7 +217,7 @@ namespace Spindles {
                     }
                 }
 
-                if (retry_count == MAX_RETRIES) {
+                if (retry_count == instance->_retries) {
                     if (!unresponsive) {
                         log_info("VFD RS485 Unresponsive");
                         unresponsive = true;
@@ -246,7 +246,6 @@ namespace Spindles {
         }
 
         bool VFDProtocol::prepareSetSpeedCommand(uint32_t speed, ModbusCommand& data, VFDSpindle* spindle) {
-            log_debug("prep speed " << speed << " curr " << spindle->_current_dev_speed);
             if (speed == spindle->_current_dev_speed) {  // prevent setting same speed twice
                 return false;
             }

--- a/FluidNC/src/Spindles/VFD/VFDProtocol.h
+++ b/FluidNC/src/Spindles/VFD/VFDProtocol.h
@@ -14,7 +14,6 @@ namespace Spindles {
             using response_parser = bool (*)(const uint8_t* response, VFDSpindle* spindle, VFDProtocol* detail);
 
             static const int VFD_RS485_MAX_MSG_SIZE = 16;  // more than enough for a modbus message
-            static const int MAX_RETRIES            = 5;   // otherwise the spindle is marked 'unresponsive'
 
             struct ModbusCommand {
                 bool critical;  // TODO SdB: change into `uint8_t critical : 1;`: We want more flags...

--- a/FluidNC/src/Spindles/VFD/VFDProtocol.h
+++ b/FluidNC/src/Spindles/VFD/VFDProtocol.h
@@ -5,7 +5,7 @@
 
 namespace Spindles {
     class VFDSpindle;
-    
+
     namespace VFD {
         // VFDProtocol resides in a separate class because it doesn't need to be in IRAM. This contains all the
         // VFD specific code, which is called from a separate task.
@@ -23,6 +23,7 @@ namespace Spindles {
                 uint8_t rx_length;
                 uint8_t msg[VFD_RS485_MAX_MSG_SIZE];
             };
+            virtual void group(Configuration::HandlerBase& handler) {};
 
         protected:
             // Enable spindown / spinup settings:
@@ -34,7 +35,7 @@ namespace Spindles {
 
             // Commands that return the status. Returns nullptr if unavailable by this VFD (default):
 
-            virtual response_parser initialization_sequence(int index, ModbusCommand& data) { return nullptr; }
+            virtual response_parser initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) { return nullptr; }
             virtual response_parser get_current_speed(ModbusCommand& data) { return nullptr; }
             virtual response_parser get_current_direction(ModbusCommand& data) { return nullptr; }
             virtual response_parser get_status_ok(ModbusCommand& data) = 0;
@@ -51,11 +52,11 @@ namespace Spindles {
                 uint32_t      arg;
             };
 
-            // Careful observers will notice that these *shouldn't* be static, but they are. The reason is 
-            // hard to track down. In the spindle class, you can find: 
+            // Careful observers will notice that these *shouldn't* be static, but they are. The reason is
+            // hard to track down. In the spindle class, you can find:
             //
             // 'virtual void init() = 0;  // not in constructor because this also gets called when $$ settings change'
-            // 
+            //
             // With init being called multiple times, static suddenly makes more sense - especially since there is
             // no de-init. Oh well...
 
@@ -72,10 +73,10 @@ namespace Spindles {
 
         public:
             VFDProtocol() {}
-            VFDProtocol(const VFDProtocol&) = delete;
-            VFDProtocol(VFDProtocol&&)      = delete;
+            VFDProtocol(const VFDProtocol&)            = delete;
+            VFDProtocol(VFDProtocol&&)                 = delete;
             VFDProtocol& operator=(const VFDProtocol&) = delete;
-            VFDProtocol& operator=(VFDProtocol&&) = delete;
+            VFDProtocol& operator=(VFDProtocol&&)      = delete;
         };
     }
 }

--- a/FluidNC/src/Spindles/VFD/YL620Protocol.cpp
+++ b/FluidNC/src/Spindles/VFD/YL620Protocol.cpp
@@ -115,7 +115,7 @@ namespace Spindles {
             data.msg[5] = speed & 0xFF;
         }
 
-        VFDProtocol::response_parser YL620Protocol::initialization_sequence(int index, ModbusCommand& data) {
+        VFDProtocol::response_parser YL620Protocol::initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) {
             if (index == -1) {
                 data.tx_length = 6;
                 data.rx_length = 5;

--- a/FluidNC/src/Spindles/VFD/YL620Protocol.h
+++ b/FluidNC/src/Spindles/VFD/YL620Protocol.h
@@ -15,7 +15,7 @@ namespace Spindles {
             void direction_command(SpindleState mode, ModbusCommand& data) override;
             void set_speed_command(uint32_t rpm, ModbusCommand& data) override;
 
-            response_parser initialization_sequence(int index, ModbusCommand& data) override;
+            response_parser initialization_sequence(int index, ModbusCommand& data, VFDSpindle* vfd) override;
             response_parser get_current_speed(ModbusCommand& data) override;
             response_parser get_current_direction(ModbusCommand& data) override;
             response_parser get_status_ok(ModbusCommand& data) override { return nullptr; }

--- a/FluidNC/src/Spindles/VFDSpindle.h
+++ b/FluidNC/src/Spindles/VFDSpindle.h
@@ -38,6 +38,7 @@ namespace Spindles {
         uint8_t  _modbus_id = 1;
         uint8_t  _debug     = 0;
         uint32_t _poll_ms   = 250;
+        uint32_t _retries   = 5;
 
         void setSpeed(uint32_t dev_speed);
 

--- a/FluidNC/src/Spindles/VFDSpindle.h
+++ b/FluidNC/src/Spindles/VFDSpindle.h
@@ -9,13 +9,9 @@
 
 #include "../Uart.h"
 
-// #define DEBUG_VFD
-// #define DEBUG_VFD_ALL
-
 namespace Spindles {
     extern Uart _uart;
-    
-    
+
     namespace VFD {
         // VFDProtocol resides in a separate class because it doesn't need to be in IRAM. This contains all the
         // VFD specific code, which is called from a separate task.
@@ -37,9 +33,11 @@ namespace Spindles {
 
     protected:
         // The constructor sets these
-        int     _uart_num  = -1;
-        Uart*   _uart      = nullptr;
-        uint8_t _modbus_id = 1;
+        int      _uart_num  = -1;
+        Uart*    _uart      = nullptr;
+        uint8_t  _modbus_id = 1;
+        uint8_t  _debug     = 0;
+        uint32_t _poll_ms   = 250;
 
         void setSpeed(uint32_t dev_speed);
 
@@ -47,18 +45,19 @@ namespace Spindles {
 
     public:
         VFDSpindle(const char* name, VFD::VFDProtocol* detail) : Spindle(name), detail_(detail) {}
-        VFDSpindle(const VFDSpindle&) = delete;
-        VFDSpindle(VFDSpindle&&)      = delete;
+        VFDSpindle(const VFDSpindle&)            = delete;
+        VFDSpindle(VFDSpindle&&)                 = delete;
         VFDSpindle& operator=(const VFDSpindle&) = delete;
-        VFDSpindle& operator=(VFDSpindle&&) = delete;
+        VFDSpindle& operator=(VFDSpindle&&)      = delete;
 
         void init();
         void config_message();
         void setState(SpindleState state, SpindleSpeed speed);
         void setSpeedfromISR(uint32_t dev_speed) override;
 
-        volatile uint32_t _sync_dev_speed;
-        SpindleSpeed      _slop;
+        // volatile uint32_t _sync_dev_speed;
+        uint32_t     _sync_dev_speed;
+        SpindleSpeed _slop;
 
         // Configuration handlers:
         void validate() override;


### PR DESCRIPTION
Creates a new "ModbusVFD" spindle type that can be used with most (any?) RS485/Modbus VFD by defining a few Modbus message templates in config items.
There is documentation at http://wiki.fluidnc.com/en/config/config_spindles#generic-modbusvfd-rs485