### PR TITLE
NotificationsService: add telegram

### DIFF
--- a/FluidNC/src/WebUI/NotificationsService.h
+++ b/FluidNC/src/WebUI/NotificationsService.h
@@ -41,6 +41,7 @@ namespace WebUI {
         static bool  sendPushoverMSG(const char* title, const char* message);
         static bool  sendEmailMSG(const char* title, const char* message);
         static bool  sendLineMSG(const char* title, const char* message);
+        static bool  sendTelegramMSG(const char* title, const char* message);
         static bool  getPortFromSettings();
         static bool  getServerAddressFromSettings();
         static bool  getEmailFromSettings();


### PR DESCRIPTION
#### Add support for notifications using telegram bot.

```
$Notification/T1=bot_token
$Notification/T2=chat_id
$Notification/Type=TG
$Notification/Send=Hello, World!
```

<hr>

#### Memory usage:

| Memory type | Before changes | After changes | Difference |
| ----------- | -------------- | ------------- | ---------- |
| RAM         | 69796          | 69796         | 0          |
| Flash       | 1845089        | 1845613       | ⚠️+524    |

<hr>

#### Setup:

##### *Obtain bot token*: 

* Register bot with [@BotFather](https://t.me/BotFather), and get bot token, e.g. `9999999999:ABCdefGHi-JKLmNOpQR-stuvw-xyz012345`.

##### *Obtain chat id:*

* Choose where you want to get notifications: in personal chat or in group chat.
  * *Personal chat*: if you want to get notifications to your personal chat, text `/start` to the bot 
  * *Group chat*: if you want to get notifications to group chat, invite bot to group, text to group chat `/nameOfYour_bot hello`
* Open `https://api.telegram.org/bot{bot-token}/getUpdates` in browser and get `..."chat":{"id":-1234567890` here. The number is chat id. Group chats have negative id, personal chats have positive id.

##### *Setup FluidNC* with commands:

* `$Notification/T1=bot_token`, ex, `$Notification/T1=9999999999:ABCdefGHi-JKLmNOpQR-stuvw-xyz012345`
* `$Notification/T2=chat_id`, ex, `$Notification/T2=-1234567890`
* `$Notification/Type=TG`

##### *Test notification*:

* Test notification with command `$Notification/Send=Hello, World!`

##### *Inject notifications into G-Code*:

* For example, add `$Notification/Send=Finished` to your End G-Code in LightBurn