### PR TITLE
Allow zero dwell

### DIFF
--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -266,7 +266,7 @@ void mc_arc(float*            target,
 
 // Execute dwell in seconds.
 bool mc_dwell(int32_t milliseconds) {
-    if (milliseconds <= 0 || state_is(State::CheckMode)) {
+    if (milliseconds < 0 || state_is(State::CheckMode)) {
         return false;
     }
     protocol_buffer_synchronize();


### PR DESCRIPTION
Allows a zero dwell to be used to sync the buffer. LinuxCNC says P value must be non negative. Previously 0 was not rejected, but did not do the protocol_buffer_sync()