### PR TITLE
Trinamic Diag0 output on 2130 and 5160 drivers

### DIFF
--- a/FluidNC/src/Motors/TMC2130Driver.cpp
+++ b/FluidNC/src/Motors/TMC2130Driver.cpp
@@ -53,6 +53,10 @@ namespace MotorDrivers {
         int usteps = _microsteps == 1 ? 0 : _microsteps;
         tmc2130->microsteps(usteps);
 
+        tmc2130->diag0_error(_diag0_error);
+        tmc2130->diag0_otpw(_diag0_otpw);
+        tmc2130->diag0_int_pushpull(_diag0_int_pushpull);
+
         switch (_mode) {
             case TrinamicMode ::StealthChop:
                 log_debug(axisName() << " StealthChop");

--- a/FluidNC/src/Motors/TMC5160Driver.cpp
+++ b/FluidNC/src/Motors/TMC5160Driver.cpp
@@ -54,6 +54,10 @@ namespace MotorDrivers {
 
         tmc5160->tpfd(_tpfd);
 
+        tmc5160->diag0_error(_diag0_error);
+        tmc5160->diag0_otpw(_diag0_otpw);
+        tmc5160->diag0_int_pushpull(_diag0_int_pushpull);
+
         switch (_mode) {
             case TrinamicMode ::StealthChop:
                 log_debug(axisName() << " StealthChop");

--- a/FluidNC/src/Motors/TMC5160Driver.h
+++ b/FluidNC/src/Motors/TMC5160Driver.h
@@ -23,17 +23,9 @@ namespace MotorDrivers {
         void debug_message() override;
         void validate() override { StandardStepper::validate(); }
 
-        bool _diag0_error = false;
-        bool _diag0_otpw = false;
-        bool _diag0_int_pushpull = false;
-
         void group(Configuration::HandlerBase& handler) override {
             TrinamicSpiDriver::group(handler);
             handler.item("tpfd", _tpfd, 0, 15);
-
-            handler.item("diag0_error", _diag0_error);
-            handler.item("diag0_otpw", _diag0_otpw);
-            handler.item("diag0_int_pushpull", _diag0_int_pushpull);
         }
 
     private:

--- a/FluidNC/src/Motors/TMC5160Driver.h
+++ b/FluidNC/src/Motors/TMC5160Driver.h
@@ -23,9 +23,17 @@ namespace MotorDrivers {
         void debug_message() override;
         void validate() override { StandardStepper::validate(); }
 
+        bool _diag0_error = false;
+        bool _diag0_otpw = false;
+        bool _diag0_int_pushpull = false;
+
         void group(Configuration::HandlerBase& handler) override {
             TrinamicSpiDriver::group(handler);
             handler.item("tpfd", _tpfd, 0, 15);
+
+            handler.item("diag0_error", _diag0_error);
+            handler.item("diag0_otpw", _diag0_otpw);
+            handler.item("diag0_int_pushpull", _diag0_int_pushpull);
         }
 
     private:

--- a/FluidNC/src/Motors/TrinamicSpiDriver.h
+++ b/FluidNC/src/Motors/TrinamicSpiDriver.h
@@ -63,6 +63,9 @@ namespace MotorDrivers {
             handler.item("stallguard", _stallguard, -64, 63);
             handler.item("stallguard_debug", _stallguardDebugMode);
             handler.item("toff_coolstep", _toff_coolstep, 2, 15);
+
+
+            
         }
 
     protected:

--- a/FluidNC/src/Motors/TrinamicSpiDriver.h
+++ b/FluidNC/src/Motors/TrinamicSpiDriver.h
@@ -64,14 +64,19 @@ namespace MotorDrivers {
             handler.item("stallguard_debug", _stallguardDebugMode);
             handler.item("toff_coolstep", _toff_coolstep, 2, 15);
 
-
-            
+            handler.item("diag0_error", _diag0_error);
+            handler.item("diag0_otpw", _diag0_otpw);
+            handler.item("diag0_int_pushpull", _diag0_int_pushpull);
         }
 
     protected:
         Pin     _cs_pin;  // The chip select pin (can be the same for daisy chain)
         int32_t _spi_index      = -1;
         bool    _spi_setup_done = false;
+
+        bool _diag0_error        = false;
+        bool _diag0_otpw         = false;
+        bool _diag0_int_pushpull = false;
 
         static constexpr int _spi_freq = 100000;
 


### PR DESCRIPTION
This allows diag0 to be used for driver error reporting.