### PR TITLE
Drive strength

### DIFF
--- a/FluidNC/esp32/GPIOCapabilities.cpp
+++ b/FluidNC/esp32/GPIOCapabilities.cpp
@@ -1,0 +1,71 @@
+#include "src/Pins/GPIOPinDetail.h"
+
+namespace Pins {
+    PinCapabilities GPIOPinDetail::GetDefaultCapabilities(pinnum_t index) {
+        // See https://randomnerdtutorials.com/esp32-pinout-reference-gpios/ for an overview:
+        switch (index) {
+            case 0:  // Outputs PWM signal at boot
+                return PinCapabilities::Native | PinCapabilities::Input | PinCapabilities::Output | PinCapabilities::PullUp |
+                       PinCapabilities::PullDown | PinCapabilities::ADC | PinCapabilities::PWM | PinCapabilities::ISR |
+                       PinCapabilities::UART;
+
+            case 1:  // TX pin of Serial0. Note that Serial0 also runs through the Pins framework!
+                return PinCapabilities::Native | PinCapabilities::Output | PinCapabilities::Input | PinCapabilities::UART;
+
+            case 3:  // RX pin of Serial0. Note that Serial0 also runs through the Pins framework!
+                return PinCapabilities::Native | PinCapabilities::Output | PinCapabilities::Input | PinCapabilities::ISR |
+                       PinCapabilities::UART;
+
+            case 5:
+            case 9:
+            case 10:
+            case 16:
+            case 17:
+            case 18:
+            case 19:
+            case 21:
+            case 22:
+            case 23:
+            case 29:
+                return PinCapabilities::Native | PinCapabilities::Input | PinCapabilities::Output | PinCapabilities::PullUp |
+                       PinCapabilities::PullDown | PinCapabilities::PWM | PinCapabilities::ISR | PinCapabilities::UART;
+
+            case 2:  // Normal pins
+            case 4:
+            case 12:  // Boot fail if pulled high
+            case 13:
+            case 14:  // Outputs PWM signal at boot
+            case 15:  // Outputs PWM signal at boot
+            case 27:
+            case 32:
+            case 33:
+                return PinCapabilities::Native | PinCapabilities::Input | PinCapabilities::Output | PinCapabilities::PullUp |
+                       PinCapabilities::PullDown | PinCapabilities::ADC | PinCapabilities::PWM | PinCapabilities::ISR |
+                       PinCapabilities::UART;
+
+            case 25:
+            case 26:
+                return PinCapabilities::Native | PinCapabilities::Input | PinCapabilities::Output | PinCapabilities::PullUp |
+                       PinCapabilities::PullDown | PinCapabilities::ADC | PinCapabilities::DAC | PinCapabilities::PWM |
+                       PinCapabilities::ISR | PinCapabilities::UART;
+
+            case 6:  // SPI flash integrated
+            case 7:
+            case 8:
+            case 11:
+                return PinCapabilities::Reserved;
+
+            case 34:  // Input only pins
+            case 35:
+            case 36:
+            case 37:
+            case 38:
+            case 39:
+                return PinCapabilities::Native | PinCapabilities::Input | PinCapabilities::ADC | PinCapabilities::ISR | PinCapabilities::UART;
+                break;
+
+            default:  // Not mapped to actual GPIO pins
+                return PinCapabilities::None;
+        }
+    }
+}

--- a/FluidNC/esp32/gpio.cpp
+++ b/FluidNC/esp32/gpio.cpp
@@ -37,6 +37,9 @@ void gpio_mode(pinnum_t pin, int input, int output, int pullup, int pulldown, in
     }
     gpio_config(&conf);
 }
+void gpio_drive_strength(pinnum_t pin, int strength) {
+    gpio_set_drive_capability((gpio_num_t)pin, (gpio_drive_cap_t)strength);
+}
 #if 0
 void gpio_add_interrupt(pinnum_t pin, int mode, void (*callback)(void*), void* arg) {
     gpio_install_isr_service(ESP_INTR_FLAG_IRAM);  // Will return an err if already called

--- a/FluidNC/esp32/i2s_engine.c
+++ b/FluidNC/esp32/i2s_engine.c
@@ -197,6 +197,18 @@ int i2s_out_init(i2s_out_init_t* init_param) {
 
     // Route the i2s pins to the appropriate GPIO
     i2s_out_gpio_attach(init_param->ws_pin, init_param->bck_pin, init_param->data_pin);
+    if (init_param->ws_drive_strength != -1) {
+        gpio_drive_strength(init_param->ws_pin, init_param->ws_drive_strength);
+    }
+    if (init_param->ws_drive_strength != -1) {
+        gpio_drive_strength(init_param->ws_pin, init_param->ws_drive_strength);
+    }
+    if (init_param->bck_drive_strength != -1) {
+        gpio_drive_strength(init_param->bck_pin, init_param->bck_drive_strength);
+    }
+    if (init_param->data_drive_strength != -1) {
+        gpio_drive_strength(init_param->data_pin, init_param->data_drive_strength);
+    }
 
     /**
    * Each i2s transfer will take

--- a/FluidNC/esp32/spi.cpp
+++ b/FluidNC/esp32/spi.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
 
 #include "Driver/spi.h"
+#include "Driver/fluidnc_gpio.h"
 
 #include "driver/spi_common.h"
 #include "src/Config.h"
@@ -13,7 +14,7 @@
 #endif
 
 // cppcheck-suppress unusedFunction
-bool spi_init_bus(pinnum_t sck_pin, pinnum_t miso_pin, pinnum_t mosi_pin, bool dma) {
+bool spi_init_bus(pinnum_t sck_pin, pinnum_t miso_pin, pinnum_t mosi_pin, bool dma, int8_t sck_drive_strength, int8_t mosi_drive_strength) {
     // Start the SPI bus with the pins defined here.  Once it has been started,
     // those pins "stick" and subsequent attempts to restart it with defaults
     // for the miso, mosi, and sck pins are ignored
@@ -28,7 +29,16 @@ bool spi_init_bus(pinnum_t sck_pin, pinnum_t miso_pin, pinnum_t mosi_pin, bool d
     };
 
     // Depends on the chip variant
-    return !spi_bus_initialize(HSPI_HOST, &bus_cfg, dma ? SPI_DMA_CH_AUTO : SPI_DMA_DISABLED);
+    bool ok = !spi_bus_initialize(HSPI_HOST, &bus_cfg, dma ? SPI_DMA_CH_AUTO : SPI_DMA_DISABLED);
+    if (ok) {
+        if (sck_drive_strength != -1) {
+            gpio_drive_strength(sck_pin, sck_drive_strength);
+        }
+        if (mosi_drive_strength != -1) {
+            gpio_drive_strength(mosi_pin, mosi_drive_strength);
+        }
+    }
+    return ok;
 }
 
 // cppcheck-suppress unusedFunction

--- a/FluidNC/include/Driver/fluidnc_gpio.h
+++ b/FluidNC/include/Driver/fluidnc_gpio.h
@@ -18,6 +18,7 @@ typedef uint8_t pinnum_t;
 void gpio_write(pinnum_t pin, int value);
 int  gpio_read(pinnum_t pin);
 void gpio_mode(pinnum_t pin, int input, int output, int pullup, int pulldown, int opendrain);
+void gpio_drive_strength(pinnum_t pin, int strength);
 void gpio_set_interrupt_type(pinnum_t pin, int mode);
 void gpio_add_interrupt(pinnum_t pin, int mode, void (*callback)(void*), void* arg);
 void gpio_remove_interrupt(pinnum_t pin);

--- a/FluidNC/include/Driver/fluidnc_gpio.h
+++ b/FluidNC/include/Driver/fluidnc_gpio.h
@@ -7,11 +7,8 @@
 extern "C" {
 #endif
 
-#if 0
-#    include "src/Pins/PinDetail.h"  // pinnum_t
-#else
+#include "stdint.h"
 typedef uint8_t pinnum_t;
-#endif
 
 // GPIO interface
 

--- a/FluidNC/include/Driver/i2s_out.h
+++ b/FluidNC/include/Driver/i2s_out.h
@@ -40,6 +40,9 @@ typedef struct {
     uint32_t pulse_period;  // aka step rate.
     uint32_t init_val;
     uint32_t min_pulse_us;
+    int8_t   ws_drive_strength;
+    int8_t   bck_drive_strength;
+    int8_t   data_drive_strength;
 } i2s_out_init_t;
 
 /*

--- a/FluidNC/include/Driver/spi.h
+++ b/FluidNC/include/Driver/spi.h
@@ -4,7 +4,7 @@
 #include "src/Pins/PinDetail.h"  // pinnum_t
 #include "driver/spi_master.h"
 
-bool spi_init_bus(pinnum_t sck_pin, pinnum_t miso_pin, pinnum_t mosi_pin, bool dma);
+bool spi_init_bus(pinnum_t sck_pin, pinnum_t miso_pin, pinnum_t mosi_pin, bool dma, int8_t sck_drive_strength, int8_t mosi_drive_strength);
 void spi_deinit_bus();
 
 // Returns devid or -1

--- a/FluidNC/src/Machine/I2SOBus.cpp
+++ b/FluidNC/src/Machine/I2SOBus.cpp
@@ -46,6 +46,10 @@ namespace Machine {
 
             params.min_pulse_us = _min_pulse_us;
 
+            params.ws_drive_strength   = _ws.driveStrength();
+            params.bck_drive_strength  = _bck.driveStrength();
+            params.data_drive_strength = _data.driveStrength();
+
             i2s_out_init(&params);
         }
     }

--- a/FluidNC/src/Machine/SPIBus.cpp
+++ b/FluidNC/src/Machine/SPIBus.cpp
@@ -17,9 +17,11 @@ namespace Machine {
     }
 
     void SPIBus::init() {
-        pinnum_t mosiPin = 23;
-        pinnum_t misoPin = 19;
-        pinnum_t sckPin  = 18;
+        pinnum_t mosiPin           = 23;
+        pinnum_t misoPin           = 19;
+        pinnum_t sckPin            = 18;
+        int8_t   sckDriveDtrength  = -1;
+        int8_t   mosiDriveDtrength = -1;
 
         if (_miso.defined() || _mosi.defined() || _sck.defined()) {  // validation ensures the rest is also defined.
             log_info("SPI SCK:" << _sck.name() << " MOSI:" << _mosi.name() << " MISO:" << _miso.name());
@@ -35,7 +37,7 @@ namespace Machine {
             log_info("Using default SPI pins");
         }
         // Init in DMA mode
-        if (!spi_init_bus(sckPin, misoPin, mosiPin, true)) {
+        if (!spi_init_bus(sckPin, misoPin, mosiPin, true, _sck.driveStrength(), _mosi.driveStrength())) {
             log_error("SPIBus init failed");
             return;
         }

--- a/FluidNC/src/Pin.h
+++ b/FluidNC/src/Pin.h
@@ -4,8 +4,6 @@
 #pragma once
 
 #include "Pins/PinDetail.h"
-#include "Pins/PinCapabilities.h"
-#include "Pins/PinAttributes.h"
 
 #include <esp_attr.h>  // IRAM_ATTR
 #include <cstdint>

--- a/FluidNC/src/Pin.h
+++ b/FluidNC/src/Pin.h
@@ -112,9 +112,10 @@ public:
         Assert(_detail->capabilities().has(expectedBehavior), "Requested pin %s does not have the expected behavior.", name().c_str());
         return _detail->_index;
     }
-    inline bool canStep() { return _detail->canStep(); }
-    inline int  index() { return _detail->_index; }
-    inline bool inverted() { return _detail->_inverted; }
+    inline int8_t driveStrength() const { return _detail->driveStrength(); }
+    inline bool   canStep() { return _detail->canStep(); }
+    inline int    index() { return _detail->_index; }
+    inline bool   inverted() { return _detail->_inverted; }
 
     inline void write(bool value) const { _detail->write(value); };
     inline void synchronousWrite(bool value) const { _detail->synchronousWrite(value); };

--- a/FluidNC/src/Pins/GPIOPinDetail.cpp
+++ b/FluidNC/src/Pins/GPIOPinDetail.cpp
@@ -115,9 +115,24 @@ namespace Pins {
                 _attributes = _attributes | PinAttributes::ActiveLow;
             } else if (opt.is("high")) {
                 // Default: Active HIGH.
+            } else if (opt.is("ds0")) {
+                _attributes    = _attributes | PinAttributes::DS0;
+                _driveStrength = 0;
+            } else if (opt.is("ds1")) {
+                _attributes    = _attributes | PinAttributes::DS1;
+                _driveStrength = 1;
+            } else if (opt.is("ds2")) {
+                _attributes    = _attributes | PinAttributes::DS2;
+                _driveStrength = 2;
+            } else if (opt.is("ds3")) {
+                _attributes    = _attributes | PinAttributes::DS3;
+                _driveStrength = 3;
             } else {
                 Assert(false, "Bad GPIO option passed to pin %d: %.*s", int(index), static_cast<int>(opt().length()), opt().data());
             }
+        }
+        if (_driveStrength != -1) {
+            gpio_drive_strength(index, _driveStrength);
         }
         _claimed[index] = true;
 
@@ -181,6 +196,22 @@ namespace Pins {
                   _attributes.has(PinAttributes::PullUp),
                   _attributes.has(PinAttributes::PullDown),
                   false);  // We do not have an OpenDrain attribute yet
+
+        // setAttr can be used to set the drive strength, which is normally
+        // set when the pin is created
+        if (value.has(PinAttributes::DS0)) {
+            _driveStrength = 0;
+        } else if (value.has(PinAttributes::DS1)) {
+            _driveStrength = 1;
+        } else if (value.has(PinAttributes::DS2)) {
+            _driveStrength = 2;
+        } else if (value.has(PinAttributes::DS3)) {
+            _driveStrength = 3;
+        }
+
+        if (_driveStrength != -1) {
+            gpio_drive_strength(_index, _driveStrength);
+        }
     }
 
     void IRAM_ATTR GPIOPinDetail::setDuty(uint32_t duty) {
@@ -202,6 +233,18 @@ namespace Pins {
         }
         if (_attributes.has(PinAttributes::PullDown)) {
             s += ":pd";
+        }
+        if (_attributes.has(PinAttributes::DS0)) {
+            s += ":ds0";
+        }
+        if (_attributes.has(PinAttributes::DS1)) {
+            s += ":ds1";
+        }
+        if (_attributes.has(PinAttributes::DS2)) {
+            s += ":ds2";
+        }
+        if (_attributes.has(PinAttributes::DS3)) {
+            s += ":ds3";
         }
 
         return s;

--- a/FluidNC/src/Pins/GPIOPinDetail.h
+++ b/FluidNC/src/Pins/GPIOPinDetail.h
@@ -22,6 +22,8 @@ namespace Pins {
 
         int8_t _driveStrength = -1;
 
+        void setDriveStrength(int n, PinAttributes attr);
+
     public:
         static const int nGPIOPins = 40;
 
@@ -31,7 +33,7 @@ namespace Pins {
 
         // I/O:
         void          write(int high) override;
-        int IRAM_ATTR read() override;
+        int           read() override;
         void          setAttr(PinAttributes value, uint32_t frequency) override;
         PinAttributes getAttr() const override;
 

--- a/FluidNC/src/Pins/GPIOPinDetail.h
+++ b/FluidNC/src/Pins/GPIOPinDetail.h
@@ -20,6 +20,8 @@ namespace Pins {
         static void gpioAction(int, void*, int);
         PwmPin*     _pwm;
 
+        int8_t _driveStrength = -1;
+
     public:
         static const int nGPIOPins = 40;
 
@@ -35,6 +37,8 @@ namespace Pins {
 
         void     setDuty(uint32_t duty) override;
         uint32_t maxDuty() override { return _pwm->period(); };
+
+        int8_t driveStrength() { return _driveStrength; }
 
         bool canStep() override { return true; }
 

--- a/FluidNC/src/Pins/PinAttributes.cpp
+++ b/FluidNC/src/Pins/PinAttributes.cpp
@@ -30,6 +30,11 @@ namespace Pins {
     PinAttributes PinAttributes::Exclusive(1 << (__LINE__ - START_LINE));  // \/       These are attributes
     PinAttributes PinAttributes::InitialOn(1 << (__LINE__ - START_LINE));  // \/       These are attributes
 
+    PinAttributes PinAttributes::DS0(1 << (__LINE__ - START_LINE));  // Lowest drive strength
+    PinAttributes PinAttributes::DS1(1 << (__LINE__ - START_LINE));  // Second to lowest drive strength
+    PinAttributes PinAttributes::DS2(1 << (__LINE__ - START_LINE));  // Second to highest drive strength
+    PinAttributes PinAttributes::DS3(1 << (__LINE__ - START_LINE));  // Highest drive strength
+
     // cppcheck-suppress unusedFunction
     bool PinAttributes::validateWith(PinCapabilities caps) {
         auto capMask  = (caps._value & capabilityMask);

--- a/FluidNC/src/Pins/PinAttributes.cpp
+++ b/FluidNC/src/Pins/PinAttributes.cpp
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
 
 #include "PinAttributes.h"
-#include "PinCapabilities.h"
 
 namespace Pins {
     PinAttributes PinAttributes::Undefined(0);

--- a/FluidNC/src/Pins/PinAttributes.h
+++ b/FluidNC/src/Pins/PinAttributes.h
@@ -48,6 +48,11 @@ namespace Pins {
         static PinAttributes Exclusive;
         static PinAttributes InitialOn;
 
+        static PinAttributes DS0;
+        static PinAttributes DS1;
+        static PinAttributes DS2;
+        static PinAttributes DS3;
+
         inline PinAttributes operator|(PinAttributes rhs) { return PinAttributes(_value | rhs._value); }
         inline PinAttributes operator&(PinAttributes rhs) { return PinAttributes(_value & rhs._value); }
         inline bool          operator==(PinAttributes rhs) const { return _value == rhs._value; }

--- a/FluidNC/src/Pins/PinAttributes.h
+++ b/FluidNC/src/Pins/PinAttributes.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include "Driver/fluidnc_gpio.h"
 
 #include "PinCapabilities.h"
 

--- a/FluidNC/src/Pins/PinDetail.h
+++ b/FluidNC/src/Pins/PinDetail.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "PinCapabilities.h"
 #include "PinAttributes.h"
 #include "PinOptionsParser.h"
 
@@ -11,8 +10,6 @@
 #include <cstring>
 #include <string>
 #include <vector>
-
-typedef uint8_t pinnum_t;
 
 class InputPin;
 

--- a/FluidNC/src/Pins/PinDetail.h
+++ b/FluidNC/src/Pins/PinDetail.h
@@ -42,6 +42,8 @@ namespace Pins {
         virtual void          setAttr(PinAttributes value, uint32_t frequencey = 0) = 0;
         virtual PinAttributes getAttr() const                                       = 0;
 
+        virtual int8_t driveStrength() { return -1; }
+
         virtual bool canStep() { return false; }
 
         virtual void registerEvent(InputPin* obj);


### PR DESCRIPTION
This allows gpio output pin drive strength to be set in the config file. This can be helpful to tune rise time and reflections.

See this [Discord discussion](https://discord.com/channels/780079161460916227/1367751511685464074) and this [wiki page](http://wiki.fluidnc.com/en/hardware/signal_quality).