### PR TITLE
Probe crash

### DIFF
--- a/FluidNC/src/Channel.cpp
+++ b/FluidNC/src/Channel.cpp
@@ -121,10 +121,8 @@ void Channel::autoReportGCodeState() {
 }
 void Channel::autoReport() {
     if (_reportInterval) {
-        auto thisProbeState = config->_probe->get_state();
-        report_recompute_pin_string();
         const char* stateName = state_name();
-        if (_reportOvr || _reportWco || stateName != _lastStateName || thisProbeState != _lastProbe || _lastPinString != report_pin_string ||
+        if (_reportOvr || _reportWco || stateName != _lastStateName || _lastPinString != report_pin_string ||
             (motionState() && (int32_t(xTaskGetTickCount()) - _nextReportTime) >= 0) || (_lastJobActive != Job::active())) {
             if (_reportOvr) {
                 report_ovr_counter = 0;
@@ -135,7 +133,6 @@ void Channel::autoReport() {
                 _reportWco         = false;
             }
             _lastStateName = stateName;
-            _lastProbe     = thisProbeState;
             _lastPinString = report_pin_string;
             _lastJobActive = Job::active();
 

--- a/FluidNC/src/Channel.h
+++ b/FluidNC/src/Channel.h
@@ -67,7 +67,6 @@ protected:
     float       _lastFeedRate     = 0;
     const char* _lastStateName    = "";
     MotorMask   _lastLimits       = 0;
-    bool        _lastProbe        = false;
     bool        _lastJobActive    = false;
     std::string _lastPinString    = "";
 

--- a/FluidNC/src/Probe.cpp
+++ b/FluidNC/src/Probe.cpp
@@ -12,8 +12,8 @@ const ArgEvent probeEvent { protocol_do_probe };
 Probe::ProbeEventPin::ProbeEventPin(const char* legend) : EventPin(&probeEvent, legend) {}
 
 void Probe::init() {
-    _probeEventPin.init();
-    _toolsetterEventPin.init();
+    _probePin.init();
+    _toolsetterPin.init();
 }
 
 void Probe::set_direction(bool away) {
@@ -22,7 +22,7 @@ void Probe::set_direction(bool away) {
 
 // Returns the probe pin state. Triggered = true. Called by gcode parser.
 bool Probe::get_state() {
-    return _probeEventPin.get() || _toolsetterEventPin.get();
+    return _probePin.get() || _toolsetterPin.get();
 }
 
 // Returns true if the probe pin is tripped, accounting for the direction (away or not).
@@ -33,8 +33,8 @@ bool Probe::tripped() {
 void Probe::validate() {}
 
 void Probe::group(Configuration::HandlerBase& handler) {
-    handler.item("pin", _probeEventPin);
-    handler.item("toolsetter_pin", _toolsetterEventPin);
+    handler.item("pin", _probePin);
+    handler.item("toolsetter_pin", _toolsetterPin);
     handler.item("check_mode_start", _check_mode_start);
     handler.item("hard_stop", _hard_stop);
 }

--- a/FluidNC/src/Probe.h
+++ b/FluidNC/src/Probe.h
@@ -17,16 +17,15 @@ class Probe : public Configuration::Configurable {
     public:
         ProbeEventPin(const char* legend);
 
-        // Differs from the base class version by sending the event on either edge
+        // Differs from the EventPin version by sending the event on either edge
         void trigger(bool active) override {
-            update(active);
+            InputPin::trigger(active);
             protocol_send_event(_event, this);
-            report_recompute_pin_string();
         }
     };
 
-    ProbeEventPin _probeEventPin;
-    ProbeEventPin _toolsetterEventPin;
+    ProbeEventPin _probePin;
+    ProbeEventPin _toolsetterPin;
 
 public:
     bool _hard_stop = false;
@@ -36,10 +35,10 @@ public:
     // during check mode. false sets the position to the probe target,
     // true sets the position to the start position.
 
-    Probe() : _probeEventPin("Probe"), _toolsetterEventPin("Toolsetter") {}
+    Probe() : _probePin("Probe"), _toolsetterPin("Toolsetter") {}
 
     // Configurable
-    bool exists() { return _probeEventPin.defined() || _toolsetterEventPin.defined(); }
+    bool exists() { return _probePin.defined() || _toolsetterPin.defined(); }
 
     void init();
 
@@ -51,6 +50,9 @@ public:
 
     // Returns true if the probe pin is tripped, depending on the direction (away or not)
     bool IRAM_ATTR tripped();
+
+    ProbeEventPin& probePin() { return _probePin; }
+    ProbeEventPin& toolsetterPin() { return _toolsetterPin; }
 
     // Configuration handlers.
     void validate() override;

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -500,7 +500,7 @@ static Error show_limits(const char* value, AuthenticationLevel auth_level, Chan
     log_string(out, "Send ! to exit");
     log_stream(out, "Homing Axes : " << limit_set(Machine::Axes::homingMask));
     log_stream(out, "Limit Axes : " << limit_set(Machine::Axes::limitMask));
-    log_string(out, "  PosLimitPins NegLimitPins Probe");
+    log_string(out, "  PosLimitPins NegLimitPins Probe Toolsetter");
 
     const TickType_t interval = 500;
     TickType_t       limit    = xTaskGetTickCount();
@@ -510,7 +510,7 @@ static Error show_limits(const char* value, AuthenticationLevel auth_level, Chan
         if (((long)(thisTime - limit)) > 0) {
             log_stream(out,
                        ": " << limit_set(Machine::Axes::posLimitMask) << " " << limit_set(Machine::Axes::negLimitMask)
-                            << (config->_probe->get_state() ? " P" : ""));
+                            << (config->_probe->probePin().get() ? " P" : "") << (config->_probe->toolsetterPin().get() ? " T" : ""));
             limit = thisTime + interval;
         }
         delay_ms(1);

--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -477,9 +477,12 @@ const char* state_name() {
 }
 
 void report_recompute_pin_string() {
-    report_pin_string = "";
-    if (config->_probe->get_state()) {
+    report_pin_string.clear();
+    if (config->_probe->probePin().get()) {
         report_pin_string += 'P';
+    }
+    if (config->_probe->toolsetterPin().get()) {
+        report_pin_string += 'T';
     }
 
     MotorMask lim_pin_state = limits_get_state();


### PR DESCRIPTION
1. Fixed sporadic crash while probing that was caused by reentering report_recompute_pin_string().
2. Separated the reporting of probe (with P) and toolsetter (with T) pins.