### PR TITLE
Update WebUI 3 version to latest

### DIFF
--- a/build-release.py
+++ b/build-release.py
@@ -82,7 +82,7 @@ os.makedirs(manifestRelPath)
 dataRelPath = os.path.join(manifestRelPath, 'data')
 os.makedirs(dataRelPath)
 shutil.copy(os.path.join("FluidNC", "data", "index.html.gz"), os.path.join(dataRelPath, "index-webui-2.html.gz"))
-urllib.request.urlretrieve("https://github.com/michmela44/ESP3D-WEBUI/releases/download/3.0.0-5/index.html.gz", os.path.join("release", "current", "data", "index-webui-3.html.gz"))
+urllib.request.urlretrieve("https://github.com/michmela44/ESP3D-WEBUI/releases/latest/download/index.html.gz", os.path.join("release", "current", "data", "index-webui-3.html.gz"))
 
 manifest = {
         "name": "FluidNC",


### PR DESCRIPTION
Update to latest version of WebUI 3

Full changelog: [3.0.0-a81-FluidNC...3.0.0-5](https://github.com/michmela44/ESP3D-WEBUI/compare/3.0.0-a81-FluidNC...3.0.0-5)

* Fix multiple requests for extension loading
* Removed Stream controls that weren't supported to clean up the interface
* Fixed links on About page to refer to FluidNC specific documentation
* Fix autorefresh ignored in extra content
* Fix probe command to work with selected axis
* Various Formatting and Configuration Updates by @jeyeager65 in https://github.com/michmela44/ESP3D-WEBUI/pull/5