### PR TITLE
Added a jog_acceleration_divisor config under axes to decrease acceleration when jogging

### DIFF
--- a/FluidNC/src/Machine/Axes.cpp
+++ b/FluidNC/src/Machine/Axes.cpp
@@ -24,7 +24,7 @@ namespace Machine {
     Pin Axes::_sharedStepperReset;
 
     uint32_t Axes::_homing_runs = 2;  // Number of Approach/Pulloff cycles
-
+    float Axes::_jogAccelerationDivisor = 1.0;
     int Axes::_numberAxis = 0;
 
     Axis* Axes::_axis[MAX_N_AXIS] = { nullptr };
@@ -155,6 +155,7 @@ namespace Machine {
         handler.item("shared_stepper_disable_pin", _sharedStepperDisable);
         handler.item("shared_stepper_reset_pin", _sharedStepperReset);
         handler.item("homing_runs", _homing_runs, 1, 5);
+        handler.item("jog_acceleration_divisor", _jogAccelerationDivisor, 1.0, 1000.0);
 
         // Handle axis names xyzabc.  handler.section is inferred
         // from a template.

--- a/FluidNC/src/Machine/Axes.h
+++ b/FluidNC/src/Machine/Axes.h
@@ -36,6 +36,8 @@ namespace Machine {
 
         static uint32_t _homing_runs;  // Number of Approach/Pulloff cycles
 
+        static float _jogAccelerationDivisor;
+
         static inline char axisName(int index) { return index < MAX_N_AXIS ? _names[index] : '?'; }  // returns axis letter
 
         static inline size_t    motor_bit(size_t axis, size_t motor) { return motor ? axis + 16 : axis; }

--- a/FluidNC/src/NutsBolts.cpp
+++ b/FluidNC/src/NutsBolts.cpp
@@ -159,7 +159,7 @@ float convert_delta_vector_to_unit_vector(float* v) {
 
 const float secPerMinSq = 60.0 * 60.0;  // Seconds Per Minute Squared, for acceleration conversion
 
-float limit_acceleration_by_axis_maximum(float* unit_vec) {
+float limit_acceleration_by_axis_maximum(float* unit_vec, bool is_jog) {
     float limit_value = SOME_LARGE_VALUE;
     auto  n_axis      = Axes::_numberAxis;
     for (size_t idx = 0; idx < n_axis; idx++) {
@@ -172,6 +172,9 @@ float limit_acceleration_by_axis_maximum(float* unit_vec) {
     // but used in units of mm/min^2.  It suffices to perform the conversion once on
     // exit, since the limit computation above is independent of units - it simply
     // finds the smallest value.
+    if(is_jog)
+        limit_value=limit_value/Axes::_jogAccelerationDivisor;
+
     return limit_value * secPerMinSq;
 }
 

--- a/FluidNC/src/NutsBolts.h
+++ b/FluidNC/src/NutsBolts.h
@@ -75,7 +75,7 @@ float vector_length(float* v, size_t n);
 void scale_vector(float* v, float scale, size_t n);
 
 float convert_delta_vector_to_unit_vector(float* vector);
-float limit_acceleration_by_axis_maximum(float* unit_vec);
+float limit_acceleration_by_axis_maximum(float* unit_vec, bool is_jog = false);
 float limit_rate_by_axis_maximum(float* unit_vec);
 
 const char* to_hex(uint32_t n);

--- a/FluidNC/src/Planner.cpp
+++ b/FluidNC/src/Planner.cpp
@@ -348,7 +348,7 @@ bool plan_buffer_line(float* target, plan_line_data_t* pl_data) {
     // NOTE: This calculation assumes all axes are orthogonal (Cartesian) and works with ABC-axes,
     // if they are also orthogonal/independent. Operates on the absolute value of the unit vector.
     block->millimeters  = convert_delta_vector_to_unit_vector(unit_vec);
-    block->acceleration = limit_acceleration_by_axis_maximum(unit_vec);
+    block->acceleration = limit_acceleration_by_axis_maximum(unit_vec, block->is_jog);
     block->rapid_rate   = limit_rate_by_axis_maximum(unit_vec);
     // Store programmed rate.
     if (block->motion.rapidMotion) {
@@ -403,7 +403,7 @@ bool plan_buffer_line(float* target, plan_line_data_t* pl_data) {
                 block->max_junction_speed_sqr = SOME_LARGE_VALUE;
             } else {
                 convert_delta_vector_to_unit_vector(junction_unit_vec);
-                float junction_acceleration = limit_acceleration_by_axis_maximum(junction_unit_vec);
+                float junction_acceleration = limit_acceleration_by_axis_maximum(junction_unit_vec, block->is_jog);
                 float sin_theta_d2          = sqrtf(0.5f * (1.0f - junction_cos_theta));  // Trig half angle identity. Always positive.
                 block->max_junction_speed_sqr =
                     MAX(MINIMUM_JUNCTION_SPEED * MINIMUM_JUNCTION_SPEED,


### PR DESCRIPTION
This change allow limiting accelerations when jogging.
The new config jog_acceleration_divisor can be set to a value between 1.0 and 1000.0, with a default of 1.0

Example config:
```
axes:
  jog_acceleration_divisor: 10.0
  x:
    steps_per_mm: 1000.000
    max_rate_mm_per_min: 6000.000
    acceleration_mm_per_sec2: 2000.000
    max_travel_mm: 301.000
    soft_limits: true
```

In the example above, this effectively limits the acceleration_mm_per_sec2 to 200.0 when jogging.
This allow for smoother operation when immediate speed may not be critical during jog movements.

I made the config sit at the top axes level since anyway the planner appear to only consider the maximum acceleration value of any axes, which I wasn't aware until I looked at the code.

I am not sure if there is any adverse effect to do this, it seems safe to me and works great for my use case and I thought I would share this simple change in case we want to integrate this idea to the main project.