### PR TITLE
Fix typos

### DIFF
--- a/CodingStyle.md
+++ b/CodingStyle.md
@@ -32,7 +32,7 @@ clang-format:
    problems, you should be fixing your includes, instead of disabling
    clang-format.
 2. Preprocessor commands are not formatted nicely in some cases.
-   This can hurt readibility in rare cases, in which case it's 
+   This can hurt readability in rare cases, in which case it's 
    okay to disable clang-format temporarily with 
    `// clang-format off` and `// clang-format on`. Most notably, 
    machine definitions should have clang-format off.

--- a/FluidNC/esp32/fnc_idf_uart.h
+++ b/FluidNC/esp32/fnc_idf_uart.h
@@ -859,7 +859,7 @@ esp_err_t fnc_uart_wait_tx_idle_polling(uart_port_t uart_num);
   * @brief Configure TX signal loop back to RX module, just for the test usage.
   *
   * @param uart_num UART number
-  * @param loop_back_en Set ture to enable the loop back function, else set it false.
+  * @param loop_back_en Set true to enable the loop back function, else set it false.
   *
   * * @return
   *      - ESP_OK on success

--- a/FluidNC/esp32/i2s_engine.c
+++ b/FluidNC/esp32/i2s_engine.c
@@ -445,7 +445,7 @@ static IRAM_ATTR void set_dir_pin(int pin, int level) {
 // For direction changes, we push one sample to the FIFO
 // and busy-wait for the delay.  If the delay is short enough,
 // it might be possible to use the same multiple-sample trick
-// that we use for step pulses, but the optimizaton might not
+// that we use for step pulses, but the optimization might not
 // be worthwhile since direction changes are infrequent.
 static IRAM_ATTR void finish_dir() {
     I2S0.fifo_wr = i2s_out_port_data;

--- a/FluidNC/esp32/tmc_spi.cpp
+++ b/FluidNC/esp32/tmc_spi.cpp
@@ -12,7 +12,7 @@
 // work properly for TMC devices that have a 5-byte input packet length;
 // The last few bytes get stuck somewhere and do not make it into the
 // input buffer.  I tried to switch back and forth between DMA mode
-// and non-DMA mode, but that turned out to be extraordinarly difficult
+// and non-DMA mode, but that turned out to be extraordinarily difficult
 // since the mode is applied at the very top level of SPI bus driver setup.
 // In order to switch modes, it was necessary to completely tear down
 // the various levels of the SD-on-SPI driver, reinit everything, then

--- a/FluidNC/ld/esp32/README.md
+++ b/FluidNC/ld/esp32/README.md
@@ -25,7 +25,7 @@ One solution would be to stop calling virtual methods from ISR code,
 but that would require some tedious recoding.  Instead, we choose,
 for now, to force the compilation toolchain to place vtables in RAM.
 
-Changing the vtable placment requires modifications to the linker
+Changing the vtable placement requires modifications to the linker
 scripts (.ld files) that control where things are placed in memory.
 The linker scripts reside in the Arduino framework code where they
 cannot easily be changed, but we can take advantage of some PlatformIO

--- a/FluidNC/ld/esp32/bt/sections.ld
+++ b/FluidNC/ld/esp32/bt/sections.ld
@@ -177,7 +177,7 @@ SECTIONS
 
   .iram0.text :
   {
-    /* Code marked as runnning out of IRAM */
+    /* Code marked as running out of IRAM */
     _iram_text_start = ABSOLUTE(.);
 
     *(.iram1 .iram1.*)

--- a/FluidNC/ld/esp32/noradio/sections.ld
+++ b/FluidNC/ld/esp32/noradio/sections.ld
@@ -177,7 +177,7 @@ SECTIONS
 
   .iram0.text :
   {
-    /* Code marked as runnning out of IRAM */
+    /* Code marked as running out of IRAM */
     _iram_text_start = ABSOLUTE(.);
 
     *(.iram1 .iram1.*)

--- a/FluidNC/ld/esp32/wifi/sections.ld
+++ b/FluidNC/ld/esp32/wifi/sections.ld
@@ -177,7 +177,7 @@ SECTIONS
 
   .iram0.text :
   {
-    /* Code marked as runnning out of IRAM */
+    /* Code marked as running out of IRAM */
     _iram_text_start = ABSOLUTE(.);
 
     *(.iram1 .iram1.*)

--- a/FluidNC/src/Channel.cpp
+++ b/FluidNC/src/Channel.cpp
@@ -324,7 +324,7 @@ void Channel::sendLine(MsgLevel level, const std::string* line) {
 // via the std::string* version of send_line().  The original
 // string is freed by the caller sometime after send_line()
 // returns, while the new string is freed by the output task
-// after the message is forwared to the output channel.
+// after the message is forwarded to the output channel.
 // This is the least efficient form, requiring two strings
 // to be allocated and freed, with an intermediate copy.
 // It is used only rarely.

--- a/FluidNC/src/Config.h
+++ b/FluidNC/src/Config.h
@@ -121,7 +121,7 @@ const bool RESTORE_OVERRIDES_AFTER_PROGRAM_END = true;  // Default enabled. Comm
 // change often. The following macros configures how many times a status report needs to be called before
 // the associated data is refreshed and included in the status report. However, if one of these value
 // changes, this data will be included in the next status report, regardless of the current count.
-// This reduces the communication overhead of high frequency reporting and agressive streaming.
+// This reduces the communication overhead of high frequency reporting and aggressive streaming.
 // The busy and idle refresh counts send refreshes more frequently when not doing anything important.
 // With a good GUI, this data doesn't need to be refreshed very often, on the order of a several seconds.
 // NOTE: WCO refresh must be 2 or greater. OVR refresh must be 1 or greater.
@@ -160,7 +160,7 @@ const float MINIMUM_JUNCTION_SPEED = 0.0f;  // (mm/min)
 const double MINIMUM_FEED_RATE = 1.0;  // (mm/min)
 
 // Number of arc generation iterations by small angle approximation before exact arc trajectory
-// correction with expensive sin() and cos() calcualtions. This parameter maybe decreased if there
+// correction with expensive sin() and cos() calculations. This parameter maybe decreased if there
 // are issues with the accuracy of the arc generations, or increased if arc execution is getting
 // bogged down by too many trig calculations.
 const int N_ARC_CORRECTION = 12;  // Integer (1-255)
@@ -178,7 +178,7 @@ const double ARC_ANGULAR_TRAVEL_EPSILON = 5E-7;  // Float (radians)
 // Serial send and receive buffer size. The receive buffer is often used as another streaming
 // buffer to store incoming blocks to be processed when ready. Most streaming
 // interfaces will character count and track each block send to each block response. So,
-// increase the receive buffer if a deeper receive buffer is needed for streaming and avaiable
+// increase the receive buffer if a deeper receive buffer is needed for streaming and available
 // memory allows. The send buffer primarily handles messages. Only increase if large
 // messages are sent and the system begins to stall, waiting to send the rest of the message.
 // #define RX_BUFFER_SIZE 128 // (1-254) Uncomment to override defaults in serial.h
@@ -188,7 +188,7 @@ const double ARC_ANGULAR_TRAVEL_EPSILON = 5E-7;  // Float (radians)
 // execution, causing problems for the stepper ISRs and serial comm ISRs and subsequent loss of
 // stepper position and serial data. This configuration option forces the planner buffer to completely
 // empty whenever the NVS is written, to prevent any chance of lost steps.
-// It doesn't prevent loss of serial Rx data, especially if a GUI is premptively filling up the
+// It doesn't prevent loss of serial Rx data, especially if a GUI is preemptively filling up the
 // serial Rx buffer.  GUIs should detect GCodes that write to NVS - notably G10,G28.1,G30.1 -
 // and wait for an 'ok' before sending more data.
 // NOTE: Most setting changes - $ commands - are blocked when a job is running. Coordinate setting

--- a/FluidNC/src/Configuration/Parser.md
+++ b/FluidNC/src/Configuration/Parser.md
@@ -58,7 +58,7 @@ value.
 
 Can be found in `Parser.h` / `Parser.cpp`. The parser is responsible
 for handling the hierarchical nature of the yaml files, and provides
-some convienient way to enumerate it.
+some convenient way to enumerate it.
 
 It is important to note at this point, that the tree builder won't just 
 randomly traverse through the configuration file. All keys that are 

--- a/FluidNC/src/Configuration/Tokenizer.cpp
+++ b/FluidNC/src/Configuration/Tokenizer.cpp
@@ -88,7 +88,7 @@ namespace Configuration {
             }
             _line.remove_prefix(_token._indent);
 
-            // Disallow inital tabs
+            // Disallow initial tabs
             if (_line.front() == '\t') {
                 ParseError("Use spaces, not tabs, for indentation");
             }

--- a/FluidNC/src/Configuration/_Overview.md
+++ b/FluidNC/src/Configuration/_Overview.md
@@ -11,7 +11,7 @@ functionality like tree building and validation.
 It is worth noting that some parts of the configuration system might 
 seem strange at first, due to the way it works. The main reason of 
 implementing it like this, is because no RTTI (e.g. `dynamic_cast`)
-is available on the ESP32, which severily limits the possibities in 
+is available on the ESP32, which severily limits the possibilities in 
 the architecture.
 
 Because of that, we basically iterate all settings within a section 

--- a/FluidNC/src/Control.cpp
+++ b/FluidNC/src/Control.cpp
@@ -7,7 +7,7 @@
 #include "Machine/Macros.h"  // macro0Event
 
 Control::Control() {
-    // The SafetyDoor pin must be defined first because it is checked explicity in safety_door_ajar()
+    // The SafetyDoor pin must be defined first because it is checked explicitly in safety_door_ajar()
     _pins.push_back(new ControlPin(&safetyDoorEvent, "safety_door_pin", 'D'));
     _pins.push_back(new ControlPin(&rtResetEvent, "reset_pin", 'R'));
     _pins.push_back(new ControlPin(&feedHoldEvent, "feed_hold_pin", 'H'));

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -154,7 +154,7 @@ void collapseGCode(char* line) {
     // parenPtr, if non-NULL, is the address of the character after (
     const char* parenPtr = NULL;
     // outPtr is the address where newly-processed characters will be placed.
-    // outPtr is alway less than or equal to inPtr.
+    // outPtr is always less than or equal to inPtr.
     char* outPtr = line;
     char  c;
     for (char* inPtr = line; (c = *inPtr) != '\0'; inPtr++) {
@@ -385,7 +385,7 @@ Error gc_execute_line(const char* input_line) {
                                 mantissa = 0;  // Set to zero to indicate valid non-integer G command.
                                 break;
                             default:
-                                log_info("M4 requires laser mode or a reversable spindle");
+                                log_info("M4 requires laser mode or a reversible spindle");
                                 return Error::GcodeUnsupportedCommand;
                         }
                         mg_word_bit = ModalGroup::MG0;

--- a/FluidNC/src/GCode.h
+++ b/FluidNC/src/GCode.h
@@ -53,7 +53,7 @@ enum class ModalGroup : uint8_t {
 // Command actions for within execution-type modal groups (motion, stopping, non-modal). Used
 // internally by the parser to know which command to execute.
 // NOTE: Some macro values are assigned specific values to make g-code state reporting and parsing
-// compile a litte smaller. Necessary due to being completely out of flash on the 328p. Although not
+// compile a little smaller. Necessary due to being completely out of flash on the 328p. Although not
 // ideal, just be careful with values that state 'do not alter' and check both report.c and gcode.c
 // to see how they are used, if you need to alter them.
 

--- a/FluidNC/src/JSONEncoder.h
+++ b/FluidNC/src/JSONEncoder.h
@@ -75,7 +75,7 @@ public:
     // WebUI sends JSON objects to the UI to generate configuration
     // page entries. Each object describes a named setting with a
     // type, current value, and a description of the possible values.
-    // The possible values can either be a minumum and maximum
+    // The possible values can either be a minimum and maximum
     // integer value, min/max string length, or an enumeration list.
     // When the user chooses a value, this command is sent back:
     //   [ESP401]P=p T=type V=value

--- a/FluidNC/src/Kinematics/Cartesian.cpp
+++ b/FluidNC/src/Kinematics/Cartesian.cpp
@@ -28,7 +28,7 @@ namespace Kinematics {
         pl_data->limits_checked = true;
 
         auto axes = config->_axes;
-        // Handle the orthognal axis first to get it out of the way.
+        // Handle the orthogonal axis first to get it out of the way.
         size_t the_axis = caxes[2];
         if (axes->_axis[the_axis]->_softLimits) {
             float amin = std::min(position[the_axis], target[the_axis]);

--- a/FluidNC/src/Kinematics/ParallelDelta.cpp
+++ b/FluidNC/src/Kinematics/ParallelDelta.cpp
@@ -62,7 +62,7 @@ namespace Kinematics {
     // the geometry of the delta
     float rf;  // radius of the fixed side (length of motor cranks)
     float re;  // radius of end effector side (length of linkages)
-    float f;   // sized of fixed side triangel
+    float f;   // sized of fixed side triangle
     float e;   // size of end effector side triangle
 
     static float last_angle[MAX_N_AXIS]     = { 0.0 };  // A place to save the previous motor angles for distance/feed rate calcs
@@ -146,7 +146,7 @@ namespace Kinematics {
         }
 
         // TO DO better idea
-        // loop back from the target in increments of  kinematic_segment_len_mm unitl the position is valid.
+        // loop back from the target in increments of  kinematic_segment_len_mm until the position is valid.
         // constrain to that target.
     }
 

--- a/FluidNC/src/Kinematics/ParallelDelta.h
+++ b/FluidNC/src/Kinematics/ParallelDelta.h
@@ -66,7 +66,7 @@ namespace Kinematics {
         float re = 133.50;
         float e  = 86.603;
 
-        float _kinematic_segment_len_mm = 1.0;  // the maximun segment length the move is broken into
+        float _kinematic_segment_len_mm = 1.0;  // the maximum segment length the move is broken into
         bool  _softLimits               = false;
         float _homing_mpos              = 0.0;
         float _max_z                    = 0.0;

--- a/FluidNC/src/Limits.cpp
+++ b/FluidNC/src/Limits.cpp
@@ -9,7 +9,7 @@
 #include "System.h"         // sys.*
 #include "Protocol.h"       // protocol_execute_realtime
 #include "Platform.h"       // WEAK_LINK
-#include "Machine/Axis.h"
+#include "Machine/fAxis.h"
 
 #include <freertos/task.h>
 #include <freertos/queue.h>

--- a/FluidNC/src/Machine/LimitPin.cpp
+++ b/FluidNC/src/Machine/LimitPin.cpp
@@ -48,7 +48,7 @@ namespace Machine {
 
         // If there is a positive or negative limit pin that is initially true,
         // calling trigger(false) during the initialization of the all limit
-        // pin would incorrectly clear the bit in the positive or negative maks,
+        // pin would incorrectly clear the bit in the positive or negative mask,
         // thus trigger() must only be called if _value is true.
         if (_value) {
             trigger(_value);

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -235,7 +235,7 @@ namespace Machine {
                 config->group(validator);
             } catch (std::exception& ex) { log_config_error("Validation error: " << ex.what()); }
 
-            // log_info("Heap size after configuation load is " << uint32_t(xPortGetFreeHeapSize()));
+            // log_info("Heap size after configuration load is " << uint32_t(xPortGetFreeHeapSize()));
 
         } catch (const Configuration::ParseException& ex) {
             log_config_error("Configuration parse error on line " << ex.LineNumber() << ": " << ex.What());

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -41,7 +41,7 @@ void mc_init() {
 // kinematics.
 //
 // NOTE: This is the primary gateway to the planner. All line motions, including arc line
-// segments, must pass through this routine before being passed to the planner. The seperation of
+// segments, must pass through this routine before being passed to the planner. The separation of
 // mc_linear and plan_buffer_line is done primarily to place non-planner-type functions from being
 // in the planner and to let backlash compensation or canned cycle integration simple and direct.
 // returns true if line was submitted to planner, or false if intentionally dropped.

--- a/FluidNC/src/Motors/RcServo.cpp
+++ b/FluidNC/src/Motors/RcServo.cpp
@@ -73,7 +73,7 @@ namespace MotorDrivers {
         }
     }
 
-    // Homing justs sets the new system position and the servo will move there
+    // Homing just sets the new system position and the servo will move there
     bool RcServo::set_homing_mode(bool isHoming) {
         log_debug("Servo homing:" << isHoming);
         if (_has_errors)

--- a/FluidNC/src/Pin.cpp
+++ b/FluidNC/src/Pin.cpp
@@ -34,7 +34,7 @@ const char* Pin::parse(std::string_view pin_str, Pins::PinDetail*& pinImplementa
     pin_str = string_util::trim(pin_str);
 
     if (pin_str.empty()) {
-        // Re-use undefined pins happens in 'create':
+        // Reuse undefined pins happens in 'create':
         pinImplementation = undefinedPin;
         return nullptr;
     }

--- a/FluidNC/src/Pins/PinCapabilities.h
+++ b/FluidNC/src/Pins/PinCapabilities.h
@@ -11,7 +11,7 @@ namespace Pins {
     /*
     Pin capabilities are what a pin _can_ do using the internal hardware. For GPIO pins, these
     are the internal hardware capabilities of the pins, such as the capability to pull-up from
-    hardware, wether or not a pin supports input/output, etc.
+    hardware, whether or not a pin supports input/output, etc.
     */
     class PinCapabilities {
         uint32_t _value;

--- a/FluidNC/src/Planner.cpp
+++ b/FluidNC/src/Planner.cpp
@@ -431,7 +431,7 @@ bool plan_buffer_line(float* target, plan_line_data_t* pl_data) {
 // Reset the planner position vectors. Called by the system abort/initialization routine.
 void plan_sync_position() {
     // TODO: For motor configurations not in the same coordinate frame as the machine position,
-    // this function needs to be updated to accomodate the difference.
+    // this function needs to be updated to accommodate the difference.
     if (config->_axes) {
         get_motor_steps(pl.position);
     }

--- a/FluidNC/src/Planner.h
+++ b/FluidNC/src/Planner.h
@@ -84,7 +84,7 @@ void plan_reset_buffer();  // Reset buffer only.
 bool plan_buffer_line(float* target, plan_line_data_t* pl_data);
 
 // Called when the current block is no longer needed. Discards the block and makes the memory
-// availible for new blocks.
+// available for new blocks.
 void plan_discard_current_block();
 
 // Gets the planner block for the special system motion cases. (Parking/Homing)

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -142,7 +142,7 @@ void polling_loop(void* unused) {
             module->poll();
         }
 
-        // If activeChannel is non-null, it means that we have recieved a line
+        // If activeChannel is non-null, it means that we have received a line
         // but the task running protocol_main_loop() has not yet picked it up.
         // activeChannel is thus a form of flow control between the protocol
         // task that processes GCode lines and other events and this task that

--- a/FluidNC/src/Regex.cpp
+++ b/FluidNC/src/Regex.cpp
@@ -10,7 +10,7 @@
 // project while replacing ints used as flags by bools.  The regex
 // syntax was changed by omitting '.' and making '*' equivalent to
 // ".*".  This regular expression matcher is for matching setting
-// names, where arbitrary repetion of literal characters is
+// names, where arbitrary repetition of literal characters is
 // unlikely.  Literal character repetition is most useful for
 // skipping whitespace, which does not occur in setting names.  The
 // "bare * wildcard" is similar to filename wildcarding in many shells

--- a/FluidNC/src/SSD1306_I2C.h
+++ b/FluidNC/src/SSD1306_I2C.h
@@ -59,7 +59,7 @@ public:
         }
 
         // If the minBoundY wasn't updated
-        // we can savely assume that buffer_back[pos] == buffer[pos]
+        // we can safely assume that buffer_back[pos] == buffer[pos]
         // holdes true for all values of pos
 
         if (minBoundY == UINT8_MAX)

--- a/FluidNC/src/Spindles/10vSpindle.cpp
+++ b/FluidNC/src/Spindles/10vSpindle.cpp
@@ -49,7 +49,7 @@ namespace Spindles {
         init_atc();
         config_message();
 
-        is_reversable = true;  // these VFDs are always reversable
+        is_reversable = true;  // these VFDs are always reversible
     }
 
     // prints the startup message of the spindle config

--- a/FluidNC/src/Spindles/HBridgeSpindle.h
+++ b/FluidNC/src/Spindles/HBridgeSpindle.h
@@ -9,7 +9,7 @@
      enable_pin : optional.
      output_cw_pin : Clockwise PWM signal
      output_ccw_pin : Counter Clockwise PWM signal
-     When the output CW is toggling, CCW is set LOW, and viceversa.
+     When the output CW is toggling, CCW is set LOW, and vice-versa.
 
      Features which could be added afterwards:
 

--- a/FluidNC/src/Spindles/VFD/HuanyangProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/HuanyangProtocol.cpp
@@ -56,7 +56,7 @@
 
     Manuals: https://github.com/RobertOlechowski/Huanyang_VFD/tree/master/Documentations/pdf
     Reference: https://github.com/Smoothieware/Smoothieware/blob/edge/src/modules/tools/spindle/HuanyangSpindleControl.cpp
-    Refernece: https://gist.github.com/Bouni/803492ed0aab3f944066
+    Reference: https://gist.github.com/Bouni/803492ed0aab3f944066
     VFD settings: https://www.hobbytronics.co.za/Content/external/1159/Spindle_Settings.pdf
     Spindle Talker 2 https://github.com/GilchristT/SpindleTalker2/releases
     Python https://github.com/RobertOlechowski/Huanyang_VFD
@@ -103,8 +103,8 @@
     Status registers
     Addr    Read    Len     Reg     DataH   DataL   CRC     CRC
     0x01    0x04    0x03    0x00    0x00    0x00    CRC     CRC     //  Set Frequency * 100 (25Hz = 2500)
-    0x01    0x04    0x03    0x01    0x00    0x00    CRC     CRC     //  Ouput Frequency * 100
-    0x01    0x04    0x03    0x02    0x00    0x00    CRC     CRC     //  Ouput Amps * 10
+    0x01    0x04    0x03    0x01    0x00    0x00    CRC     CRC     //  Output Frequency * 100
+    0x01    0x04    0x03    0x02    0x00    0x00    CRC     CRC     //  Output Amps * 10
     0x01    0x04    0x03    0x03    0x00    0x00    0xF0    0x4E    //  Read RPM (example CRC shown)
     0x01    0x04    0x03    0x0     0x00    0x00    CRC     CRC     //  DC voltage
     0x01    0x04    0x03    0x05    0x00    0x00    CRC     CRC     //  AC voltage
@@ -311,7 +311,7 @@ namespace Spindles {
                     };
                     break;
                 case -6:
-                    data.msg[3] = 15;  // Decel alue displayed is X.X
+                    data.msg[3] = 15;  // Decel value displayed is X.X
 
                     return [](const uint8_t* response, VFDSpindle* vfd, VFDProtocol* detail) -> bool {
                         uint16_t value = (response[4] << 8) | response[5];

--- a/FluidNC/src/Spindles/VFD/NowForeverProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/NowForeverProtocol.cpp
@@ -13,7 +13,7 @@ namespace Spindles {
             data.msg[3] = 0x00;  // Register address, low byte (spindle status)
             data.msg[4] = 0x00;  // Number of elements, high byte
             data.msg[5] = 0x01;  // Number of elements, low byte (1 element)
-            data.msg[6] = 0x02;  // Length of first element in bytes (1 regsiter with 2 bytes length)
+            data.msg[6] = 0x02;  // Length of first element in bytes (1 register with 2 bytes length)
             data.msg[7] = 0x00;  // Data, high byte
 
             /*
@@ -56,7 +56,7 @@ namespace Spindles {
             data.msg[3] = 0x01;  // Register address, low byte (speed in hz)
             data.msg[4] = 0x00;  // Number of elements, high byte
             data.msg[5] = 0x01;  // Number of elements, low byte (1 element)
-            data.msg[6] = 0x02;  // Length of first element in bytes (1 regsiter with 2 bytes length)
+            data.msg[6] = 0x02;  // Length of first element in bytes (1 register with 2 bytes length)
 
             /*
         Contents of register 0x0901

--- a/FluidNC/src/Spindles/VFD/SiemensV20Protocol.cpp
+++ b/FluidNC/src/Spindles/VFD/SiemensV20Protocol.cpp
@@ -65,7 +65,7 @@ SINAMICS V20 at S7-1200 via Modbus Entry-ID: 63696870, V1.2, 11/2014
 
 
 VFD Settings:
-To use this spindle type - it assumes you have a working/ configued VFD with motor - the following settings
+To use this spindle type - it assumes you have a working/ configured VFD with motor - the following settings
 are to change the method of which the VFD takes it information.
 please do not enable this without a properly configured VFD
 
@@ -152,7 +152,7 @@ namespace Spindles {
                                                        << _maxFrequency << ")");
             }
             /*
-            V20 has a scalled input and is standardized to 16384 
+            V20 has a scaled input and is standardized to 16384 
             please note Signed numbers work IE -16384 to 16384 
             but for this implementation only posivite number are allowed
             */

--- a/FluidNC/src/Spindles/VFDSpindle.cpp
+++ b/FluidNC/src/Spindles/VFDSpindle.cpp
@@ -58,7 +58,7 @@ namespace Spindles {
             return;
         }
 
-        // These VFDs are always reversable, but most can be set via the operator panel
+        // These VFDs are always reversible, but most can be set via the operator panel
         // to only allow one direction.  In principle we could check that setting and
         // automatically set is_reversable.
         is_reversable = true;

--- a/FluidNC/src/Stepper.cpp
+++ b/FluidNC/src/Stepper.cpp
@@ -135,7 +135,7 @@ static st_prep_t prep;
    AMASS artificially increases the Bresenham resolution without effecting the algorithm's
    innate exactness. AMASS adapts its resolution levels automatically depending on the step
    frequency to be executed, meaning that for even lower step frequencies the step smoothing
-   level increases. Algorithmically, AMASS is acheived by a simple bit-shifting of the Bresenham
+   level increases. Algorithmically, AMASS is achieved by a simple bit-shifting of the Bresenham
    step count for each AMASS level. For example, for a Level 1 step smoothing, we bit shift
    the Bresenham step event count, effectively multiplying it by 2, while the axis step counts
    remain the same, and then double the stepper ISR frequency. In effect, we are allowing the

--- a/FluidNC/src/ToolChangers/atc_manual.cpp
+++ b/FluidNC/src/ToolChangers/atc_manual.cpp
@@ -29,7 +29,7 @@
      -- Set TLO
      -- Returns to position before command
 
-  Posible New Persistant values (might want a save_ATC_values: config item. default false)
+  Possible New Persistent values (might want a save_ATC_values: config item. default false)
      -- TLO
      -- Tool number
 
@@ -190,7 +190,7 @@ namespace ATCs {
         // do a fast probe if there is a seek that is faster than feed
         if (_probe_seek_rate > _probe_feed_rate) {
             _macro.addf("G53 G38.2 Z%0.3f F%0.3f", _ets_mpos[2], _probe_seek_rate);
-            _macro.addf("G53G0Z[#<_abs_z> + 5]");  // retract befor next probe
+            _macro.addf("G53G0Z[#<_abs_z> + 5]");  // retract before next probe
         }
 
         // do the feed rate probe

--- a/FluidNC/src/WebUI/WebServer.cpp
+++ b/FluidNC/src/WebUI/WebServer.cpp
@@ -260,7 +260,7 @@ namespace WebUI {
             return true;
         }
 
-        // Check for brower cache match
+        // Check for browser cache match
         hash = HashFS::hash(fpath);
         if (!hash.length()) {
             std::filesystem::path gzpath(fpath);
@@ -1265,7 +1265,7 @@ namespace WebUI {
         return m->mime_type;
     }
 
-    //check authentification
+    //check authentication
     AuthenticationLevel Web_Server::is_authenticated() {
 #ifdef ENABLE_AUTHENTICATION
         if (_webserver->hasHeader("Cookie")) {

--- a/FluidNC/src/xmodem.cpp
+++ b/FluidNC/src/xmodem.cpp
@@ -49,7 +49,7 @@ static void _outbytes(uint8_t* buf, size_t len) {
     serialPort->write(buf, len);
 }
 
-/* CRC16 implementation acording to CCITT standards */
+/* CRC16 implementation according to CCITT standards */
 
 static const uint16_t crc16tab[256] = {
     0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7, 0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,

--- a/FluidNC/test/UnitTests.md
+++ b/FluidNC/test/UnitTests.md
@@ -69,7 +69,7 @@ Code here is split into two parts:
 
 ## Folders and how this works
 
-Support libraries are implemented that sort-of mimick the Arduino API where
+Support libraries are implemented that sort-of mimic the Arduino API where
 appropriate. This functionality might be extended in the future, and is by 
 no means intended to be or a complete or even a "working" version; it's 
 designed to be _testable_.

--- a/X86TestSupport/TestSupport/Print.h
+++ b/X86TestSupport/TestSupport/Print.h
@@ -59,7 +59,7 @@ public:
 
     // add availableForWrite to make compatible with Arduino Print.h
     // default to zero, meaning "a single write may block"
-    // should be overriden by subclasses with buffering
+    // should be overridden by subclasses with buffering
     virtual int availableForWrite() { return 0; }
     size_t      print(const String&);
     size_t      print(const char[]);

--- a/X86TestSupport/TestSupport/Stream.cpp
+++ b/X86TestSupport/TestSupport/Stream.cpp
@@ -210,7 +210,7 @@ long Stream::parseInt(char skipChar) {
 
     do {
         if (c == skipChar) {
-        }  // ignore this charactor
+        }  // ignore this character
         else if (c == '-') {
             isNegative = true;
         } else if (c >= '0' && c <= '9') {  // is c a digit?

--- a/X86TestSupport/TestSupport/Stream.h
+++ b/X86TestSupport/TestSupport/Stream.h
@@ -25,7 +25,7 @@
 #include <inttypes.h>
 #include "Print.h"
 
-// compatability macros for testing
+// compatibility macros for testing
 /*
  #define   getInt()            parseInt()
  #define   getInt(skipChar)    parseInt(skipchar)

--- a/X86TestSupport/TestSupport/nvs.h
+++ b/X86TestSupport/TestSupport/nvs.h
@@ -116,7 +116,7 @@ enum nvs_open_mode { NVS_READWRITE };
 #define ESP_ERR_NVS_INVALID_HANDLE (ESP_ERR_NVS_BASE + 0x07)   /*!< Handle has been closed or is NULL */
 #define ESP_ERR_NVS_REMOVE_FAILED                                                                                                          \
     (ESP_ERR_NVS_BASE +                                                                                                                    \
-     0x08) /*!< The value wasn’t updated because flash write operation has failed. The value was written however, and update will be finished after re-initialization of nvs, provided that flash operation doesn’t fail again. */
+     0x08) /*!< The value wasn't’t updated because flash write operation has failed. The value was written however, and update will be finished after re-initialization of nvs, provided that flash operation doesn’t fail again. */
 #define ESP_ERR_NVS_KEY_TOO_LONG (ESP_ERR_NVS_BASE + 0x09) /*!< Key name is too long */
 #define ESP_ERR_NVS_PAGE_FULL (ESP_ERR_NVS_BASE + 0x0a)    /*!< Internal error; never returned by nvs API functions */
 #define ESP_ERR_NVS_INVALID_STATE                                                                                                          \

--- a/embedded/www/js/script.js
+++ b/embedded/www/js/script.js
@@ -189,7 +189,7 @@ formData.append('path', currentpath);
 for (var i3 = 0; i3 < files.length; i3++) {
 var file = files[i3];
 var arg = currentpath + file.name + "S";
- //append file size first to check updload is complete
+ //append file size first to check upload is complete
  formData.append(arg, file.size);
  formData.append('myfiles[]', file, currentpath+file.name);}
 xmlhttpupload = new XMLHttpRequest();
@@ -419,7 +419,7 @@ var formData = new FormData();
 for (var i4 = 0; i4 < files.length; i4++) {
 var file = files[i4];
 var arg =  "/" + file.name + "S";
- //append file size first to check updload is complete
+ //append file size first to check upload is complete
  formData.append(arg, file.size);
  formData.append('myfile[]', file, "/"+file.name);}
 typeupload = 0;


### PR DESCRIPTION
Found via `codespell -q 3 -L ascript,bu,datas,mot,nd,ot,ser`

Note: there are 2 source typos that were omitted from this PR in order not to block its merge. 
./FluidNC/src/Limits.h:21: cordinate ==> coordinate
./FluidNC/src/Pins/PinDetail.h:39: frequencey ==> frequency