### PR TITLE
Fix invalid_arc routine to check for full rotations in G2/G3 arc commands

### DIFF
--- a/FluidNC/src/Kinematics/Cartesian.h
+++ b/FluidNC/src/Kinematics/Cartesian.h
@@ -31,7 +31,8 @@ namespace Kinematics {
                                  float             center[3],
                                  float             radius,
                                  size_t            caxes[3],
-                                 bool              is_clockwise_arc) override;
+                                 bool              is_clockwise_arc,
+                                 int               pword_rotations) override;
 
         virtual bool cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) override;
         virtual void init() override;

--- a/FluidNC/src/Kinematics/Kinematics.cpp
+++ b/FluidNC/src/Kinematics/Kinematics.cpp
@@ -19,9 +19,9 @@ namespace Kinematics {
     }
 
     bool Kinematics::invalid_arc(
-        float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
+        float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc, int pword_rotations) {
         Assert(_system != nullptr, "No kinematic system");
-        return _system->invalid_arc(target, pl_data, position, center, radius, caxes, is_clockwise_arc);
+        return _system->invalid_arc(target, pl_data, position, center, radius, caxes, is_clockwise_arc, pword_rotations);
     }
 
     bool Kinematics::cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) {

--- a/FluidNC/src/Kinematics/Kinematics.h
+++ b/FluidNC/src/Kinematics/Kinematics.h
@@ -43,7 +43,7 @@ namespace Kinematics {
         void constrain_jog(float* target, plan_line_data_t* pl_data, float* position);
         bool invalid_line(float* target);
         bool invalid_arc(
-            float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc);
+            float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc, int pword_rotations);
 
         bool canHome(AxisMask axisMask);
         bool kinematics_homing(AxisMask axisMask);
@@ -73,7 +73,7 @@ namespace Kinematics {
         virtual void constrain_jog(float* cartesian, plan_line_data_t* pl_data, float* position) {}
         virtual bool invalid_line(float* cartesian) { return false; }
         virtual bool invalid_arc(
-            float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
+            float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc, int pword_rotations) {
             return false;
         }
 

--- a/FluidNC/src/Kinematics/ParallelDelta.cpp
+++ b/FluidNC/src/Kinematics/ParallelDelta.cpp
@@ -123,7 +123,7 @@ namespace Kinematics {
 
     // TO DO. This is not supported yet. Other levels of protection will prevent "damage"
     bool ParallelDelta::invalid_arc(
-        float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc) {
+        float* target, plan_line_data_t* pl_data, float* position, float center[3], float radius, size_t caxes[3], bool is_clockwise_arc, int pword_rotations) {
         return false;
     }
 

--- a/FluidNC/src/Kinematics/ParallelDelta.h
+++ b/FluidNC/src/Kinematics/ParallelDelta.h
@@ -47,7 +47,8 @@ namespace Kinematics {
                                  float             center[3],
                                  float             radius,
                                  size_t            caxes[3],
-                                 bool              is_clockwise_arc) override;
+                                 bool              is_clockwise_arc,
+                                 int               pword_rotations) override;
 
         void releaseMotors(AxisMask axisMask, MotorMask motors) override;
 

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -137,7 +137,7 @@ void mc_arc(float*            target,
 
     // The first two axes are the circle plane and the third is the orthogonal plane
     size_t caxes[3] = { axis_0, axis_1, axis_linear };
-    if (config->_kinematics->invalid_arc(target, pl_data, position, center, radius, caxes, is_clockwise_arc)) {
+    if (config->_kinematics->invalid_arc(target, pl_data, position, center, radius, caxes, is_clockwise_arc, pword_rotations)) {
         return;
     }
 


### PR DESCRIPTION
Simple fixes to account for the fact that if G2/G3 commands include Pn with n > 1, arcs perform at least one full rotation in the working plane before arriving at the final position. 

Before, the invalid_arc routine did not contemplate this but rather calculated the min/max positions along the commanded path by considering a partial arc between the current and desired position. 

With these changes, the routine correctly contemplates the case where n > 1 and calculates the min/max coordinates in the working plane along the commanded path correctly.