### PR TITLE
Added a probe hard limit option

### DIFF
--- a/FluidNC/src/Probe.h
+++ b/FluidNC/src/Probe.h
@@ -29,6 +29,7 @@ class Probe : public Configuration::Configurable {
 
 public:
     bool _hard_stop = false;
+    bool _probe_hard_limit = false;
     // Configurable
     bool _check_mode_start = true;
     // _check_mode_start configures the position after a probing cycle

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -45,6 +45,7 @@ const std::map<ExecAlarm, const char*> AlarmNames = {
     { ExecAlarm::Init, "Init" },
     { ExecAlarm::ExpanderReset, "Expander Reset" },
     { ExecAlarm::GCodeError, "GCode Error" },
+    { ExecAlarm::ProbeHardLimit, "Probe Hard Limit" },
 };
 
 const char* alarmString(ExecAlarm alarmNumber) {

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -70,6 +70,7 @@ enum class ExecAlarm : uint8_t {
     Init                  = 15,
     ExpanderReset         = 16,
     GCodeError            = 17,
+    ProbeHardLimit        = 18,
 };
 
 extern volatile ExecAlarm lastAlarm;


### PR DESCRIPTION
This optionally gives an ExecAlarm::ProbeHardLimit alarm if the probe is tripped during homing, jogging or any motion cycle other than probing.