### PR TITLE
Fix remaining typos

### DIFF
--- a/FluidNC/esp32/fnc_idf_uart.h
+++ b/FluidNC/esp32/fnc_idf_uart.h
@@ -819,7 +819,7 @@ esp_err_t fnc_uart_wait_tx_idle_polling(uart_port_t uart_num);
   * @brief Configure TX signal loop back to RX module, just for the test usage.
   *
   * @param uart_num UART number
-  * @param loop_back_en Set ture to enable the loop back function, else set it false.
+  * @param loop_back_en Set true to enable the loop back function, else set it false.
   *
   * * @return
   *      - ESP_OK on success

--- a/FluidNC/src/Limit.h
+++ b/FluidNC/src/Limit.h
@@ -18,7 +18,7 @@ MotorMask limits_get_state();
 bool      limits_startup_check();
 
 void limit_error();
-void limit_error(axis_t axis, float cordinate);
+void limit_error(axis_t axis, float coordinate);
 
 float limitsMaxPosition(axis_t axis);
 float limitsMinPosition(axis_t axis);

--- a/FluidNC/src/Pins/PinDetail.h
+++ b/FluidNC/src/Pins/PinDetail.h
@@ -37,7 +37,7 @@ namespace Pins {
         virtual void          setDuty(uint32_t duty) {};
         virtual uint32_t      maxDuty() { return 0; }
         virtual bool          read()                                                = 0;
-        virtual void          setAttr(PinAttributes value, uint32_t frequencey = 0) = 0;
+        virtual void          setAttr(PinAttributes value, uint32_t frequency = 0) = 0;
         virtual PinAttributes getAttr() const                                       = 0;
 
         virtual int8_t driveStrength() { return -1; }


### PR DESCRIPTION
Fixes two source typos and one documentation typo.

Note, this PR is:   
* forked from the `S3OldCompiler` branch. 
* hasn't been tested.  
* a follow-up to #1576
