### PR TITLE
Fix Bug when using Airedale / Expansion Pin as a User Input

### DIFF
--- a/FluidNC/src/Machine/UserInputs.cpp
+++ b/FluidNC/src/Machine/UserInputs.cpp
@@ -24,13 +24,13 @@ namespace Machine {
     void UserInputs::init() {
         for (auto& input : _analogInput) {
             if (input.pin.defined()) {
-                input.pin.setAttr(Pin::Attr::Input);
+                input.pin.init();  // This will register for events
                 log_info("User Analog Input: " << input.name << " on Pin " << input.pin.name());
             }
         }
         for (auto& input : _digitalInput) {
             if (input.pin.defined()) {
-                input.pin.setAttr(Pin::Attr::Input);
+                input.pin.init();  // This will register for events
                 log_info("User Digital Input: " << input.name << " on Pin " << input.pin.name());
             }
         }
@@ -44,7 +44,7 @@ namespace Machine {
         if (!input.pin.defined()) {
             return Error::InvalidValue;
         }
-        return input.pin.read();
+        return input.pin.get();  // Use cached value from InputPin, updated by events
     }
 
     UserInputs::ReadInputResult UserInputs::readAnalogInput(uint8_t input_number) {
@@ -56,6 +56,7 @@ namespace Machine {
         if (!input.pin.defined()) {
             return Error::InvalidValue;
         }
+
         return input.pin.read();
     }
 

--- a/FluidNC/src/Machine/UserInputs.h
+++ b/FluidNC/src/Machine/UserInputs.h
@@ -5,6 +5,7 @@
 
 #include "../Configuration/Configurable.h"
 #include "../GCode.h"
+#include "EventPin.h"
 
 #include <variant>
 #include <array>
@@ -14,7 +15,9 @@ namespace Machine {
     class UserInputs : public Configuration::Configurable {
         struct PinAndName {
             std::string name;
-            Pin         pin;
+            InputPin pin;
+            
+            PinAndName() : pin("User Input") {}  // Required: InputPin needs a string parameter
         };
 
         std::array<PinAndName, MaxUserDigitalPin> _digitalInput;


### PR DESCRIPTION
When using an Expansion Pin as a User Input, M66 always read 0.  This fix changes the pin type in the UserInput class to InputPin and uses the get() method.  M66 now appears to work.  

I have not yet regression tested to see how this affects non expansion inputs.  I just wanted to post this in case it helps someone with a better understanding of the input classes.  There is an issue where UserInput creates a std::array of the pins, but InputPin requires the pin name to be provided in the ctor.  It would require a number of changes to make this work (array of InputPin* maybe), so right now this just puts a generic pin name / legend so the array can be created during class initialization. 