### PR TITLE
flush VFD receive buffer so that modbus frames are aligned

### DIFF
--- a/FluidNC/src/Spindles/VFD/VFDProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/VFDProtocol.cpp
@@ -145,6 +145,7 @@ namespace Spindles {
                 for (; retry_count < instance->_retries; ++retry_count) {
                     // Flush the UART and write the data:
                     uart.flush();
+                    uart.flushRx();
                     uart.write(cmd.msg, cmd.tx_length);
                     uart.flushTxTimed(response_ticks);
                     if (instance->_debug > 2) {


### PR DESCRIPTION
prior to sending an RS485 Modbus frame, clear out the receive buffer so that any previously leftover data doesn't misalign the newly received frame (#1620)