### PR TITLE
for expander pin initializations, allow up to 75 milliseconds for a response

### DIFF
--- a/FluidNC/src/UartChannel.cpp
+++ b/FluidNC/src/UartChannel.cpp
@@ -170,12 +170,12 @@ void UartChannel::registerEvent(pinnum_t pinnum, InputPin* obj) {
 bool UartChannel::setAttr(pinnum_t index, bool* value, const std::string& attrString) {
     out(attrString, "EXP:");
     _ackwait = 1;
-    for (size_t i = 0; i < 20; i++) {
+    for (size_t i = 0; i < 75000; i++) { // allow uart channel 75 milliseconds to respond
         pollLine(nullptr);
         if (_ackwait < 1) {
             return _ackwait == 0;
         }
-        delay_us(100);
+        delay_us(10);
     }
     _ackwait = 0;
     log_error("IO Expander is unresponsive");


### PR DESCRIPTION
Similar to the limitations of some [UI devices for auto-reporting](http://wiki.fluidnc.com/en/support/interface/automatic_reporting), certain microcontrollers need a longer time to respond to `EXP` messages.