### PR TITLE
Fix slow feedrate during simultaneous X/Y and Z moves in SingleArmScara

### DIFF
--- a/FluidNC/src/Kinematics/SingleArmScara.cpp
+++ b/FluidNC/src/Kinematics/SingleArmScara.cpp
@@ -130,7 +130,7 @@ namespace Kinematics {
                 return false;
             }
 
-            float motor_dist = vector_distance(_last_motor_segment_end, motor_segment_end, 2);
+            float motor_dist = vector_distance(_last_motor_segment_end, motor_segment_end, n_axis);
 
             // Remember the last motor position so the length can be computed the next time
             copyAxes(_last_motor_segment_end, motor_segment_end);


### PR DESCRIPTION
The Issue: 
In cartesian_to_motors in SingleArmScara.cpp, motor_dist was calculated using vector_distance(..., 2), which only accounts for the arm angles (radians) and ignores the Z-axis travel (mm). this causes movements that contain both x/y and z movements to be extremely slow

The Fix:
Changed the calculation to use vector_distance(..., n_axis). This accounts for the Z-axis distance and essentially make it dictate the feedrate.

Testing: Tested on a physical SCARA machine. G1 X-50 Z30 now moves at the correct requested feedrate.