### PR TITLE
Fix scara DRO

### DIFF
--- a/FluidNC/src/Kinematics/SingleArmScara.cpp
+++ b/FluidNC/src/Kinematics/SingleArmScara.cpp
@@ -181,8 +181,11 @@ namespace Kinematics {
 
         cartesian[X_AXIS] = cosf(A3) * D;
         cartesian[Y_AXIS] = sinf(A3) * D;
-        // The rest of cartesian are not changed
 
+        // Copy position for non-kinematic axes directly
+        for (int axis = Z_AXIS; axis < n_axis; axis++) {
+            cartesian[axis] = motors[axis];
+        }
         //log_info("cartesian (" << cartesian[X_AXIS] << "," << cartesian[Y_AXIS] << ")");
     }
 


### PR DESCRIPTION
The Issue
In `SingleArmScara::motors_to_cartesian`, the code previously only calculated and updated the X and Y axes. The `cartesian[]` array entries for other axes (like Z) were left untouched (defaulting to 0), causing the position report to be incorrect.

The Fix
Added a loop to the end of `motors_to_cartesian` that copies the motor position directly to the Cartesian array for any axis not handled by the SCARA kinematics (like is done in xy_to_angles).

Verification
Tested on a physical SCARA machine. The Z-axis position now updates correctly in the Web UI during motion.