### PR TITLE
Fixed NO_PIN and homing switch warning

### DIFF
--- a/FluidNC/src/Machine/Axis.cpp
+++ b/FluidNC/src/Machine/Axis.cpp
@@ -60,12 +60,17 @@ namespace Machine {
 
         // see if the configured switches support the homing direction.
         if (_homing) {
-            auto direction = _homing->_positiveDirection;
+            bool homing_dir_supported = false;
+            auto direction            = _homing->_positiveDirection;
             for (motor_t i = 0; i < MAX_MOTORS_PER_AXIS; i++) {
                 auto m = _motors[i];
-                if (m && !m->supports_homing_dir(direction)) {
-                    log_warn("  Motor" << i << " switches do not support " << (direction ? "positive" : "negative") << " homing dir");
+                if (m && m->supports_homing_dir(direction)) {
+                    homing_dir_supported = true;
+                    break;
                 }
+            }
+            if (!homing_dir_supported) {
+                log_warn("  Limit switches do not support " << (direction ? "positive" : "negative") << " homing dir");
             }
         }
     }

--- a/FluidNC/src/Pins/VoidPinDetail.cpp
+++ b/FluidNC/src/Pins/VoidPinDetail.cpp
@@ -5,7 +5,7 @@
 
 namespace Pins {
     VoidPinDetail::VoidPinDetail(pinnum_t number) : PinDetail(number) {
-        _name = "NO PIN";
+        _name = "NO_PIN";
     }
     VoidPinDetail::VoidPinDetail(const PinOptionsParser& options) : VoidPinDetail() {}
 


### PR DESCRIPTION
- Config dumps were sending "NO PIN" rather than "NO_PIN". This was affecting people who used dumps to create and edit files.
- The warning about switches not supporting the selected homing direction was not working with dual motor axes and only one switch. [Discord Issue](https://discord.com/channels/780079161460916227/1460062220821201089)