### PR TITLE
Force status report to include overrides

### DIFF
--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -231,6 +231,9 @@ void gc_ngc_changed(CoordIndex coord) {
 
 void gc_ovr_changed() {
     allChannels.notifyOvr();
+
+    // Force the override to be reported on next status report
+    report_ovr_counter = 0;
 }
 
 void gc_wco_changed() {


### PR DESCRIPTION
It is important for the sender to get a status report with any override as soon as possible. 

Fixes: https://github.com/winder/Universal-G-Code-Sender/issues/2997

When changing the feed rate override it will report the override change on the next report. But with the spindle override it will take 10 reports before the sender is notified.

This fix will force any overrides to be reported on the next status report.
