### PR TITLE
Completion also handles commands like $sd/list

### DIFF
--- a/FluidNC/src/Configuration/Completer.h
+++ b/FluidNC/src/Configuration/Completer.h
@@ -9,10 +9,10 @@
 namespace Configuration {
     class Completer : public Configuration::HandlerBase {
     private:
-        std::string _key;
-        uint32_t    _reqMatch;
-        char*       _matchedStr;
-        std::string _currentPath;
+        std::string  _key;
+        uint32_t     _reqMatch;
+        std::string& _matchedStr;
+        std::string  _currentPath;
 
         void addCandidate(std::string fullName);
 
@@ -21,7 +21,7 @@ namespace Configuration {
         bool matchesUninitialized(const char* name) override { return false; }
 
     public:
-        Completer(const char* key, uint32_t requestedMatch, char* matchedStr);
+        Completer(const std::string_view key, uint32_t requestedMatch, std::string& matchedStr);
 
         uint32_t _numMatches;
 


### PR DESCRIPTION
Previously, it only completed NVS settings and config tree items.

This patch also changes the completion code to use std::string instead of unsafe char arrays.

To test:
* Attempt to complete something like $sd .  Previously, the only completion would be $sd/FallbackCS.  Now it also offers SD commands like $SD/Show, $SD/Run, $SD/List, etc.
* Verify that config tree completion works with $/ax<TAB> and deeper in the tree