### PR TITLE
Fix speed syncing for non-generic VFD drivers

### DIFF
--- a/FluidNC/src/Spindles/VFD/DanfossVLT2800Protocol.cpp
+++ b/FluidNC/src/Spindles/VFD/DanfossVLT2800Protocol.cpp
@@ -55,8 +55,8 @@ namespace Spindles {
                 // const uint8_t function = response[1]
                 // const uint8_t response_byte_count = response[2]
 
-                uint16_t freq        = (uint16_t(response[3]) << 8) | uint16_t(response[4]);
-                vfd->_sync_dev_speed = freq;
+                uint32_t dev_speed = (uint16_t(response[3]) << 8) | response[4];
+                xQueueSend(VFD::VFDProtocol::vfd_speed_queue, &dev_speed, 0);
                 return true;
             };
         }

--- a/FluidNC/src/Spindles/VFD/H100Protocol.cpp
+++ b/FluidNC/src/Spindles/VFD/H100Protocol.cpp
@@ -163,10 +163,8 @@ namespace Spindles {
 
             return [](const uint8_t* response, VFDSpindle* vfd, VFDProtocol* detail) -> bool {
                 // 01 04 04 [freq 16] [set freq 16] [crc16]
-                uint16_t frequency = (uint16_t(response[3]) << 8) | uint16_t(response[4]);
-
-                // Store speed for synchronization
-                vfd->_sync_dev_speed = frequency;
+                uint32_t dev_speed = (uint16_t(response[3]) << 8) | response[4];
+                xQueueSend(VFD::VFDProtocol::vfd_speed_queue, &dev_speed, 0);
                 return true;
             };
         }

--- a/FluidNC/src/Spindles/VFD/H2AProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/H2AProtocol.cpp
@@ -102,7 +102,8 @@ namespace Spindles {
             //  Recv: 01 03 0004 095D 0000
             //                   ---- = 2397 (val #1)
             return [](const uint8_t* response, VFDSpindle* vfd, VFDProtocol* detail) -> bool {
-                vfd->_sync_dev_speed = (uint16_t(response[4]) << 8) | uint16_t(response[5]);
+                uint32_t dev_speed = (uint16_t(response[4]) << 8) | response[5];
+                xQueueSend(VFD::VFDProtocol::vfd_speed_queue, &dev_speed, 0);
                 return true;
             };
         }

--- a/FluidNC/src/Spindles/VFD/HuanyangProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/HuanyangProtocol.cpp
@@ -379,10 +379,8 @@ namespace Spindles {
             data.msg[5] = 0x00;
 
             return [](const uint8_t* response, VFDSpindle* vfd, VFDProtocol* detail) -> bool {
-                uint16_t frequency = (response[4] << 8) | response[5];
-
-                // Store speed for synchronization
-                vfd->_sync_dev_speed = frequency;
+                uint32_t dev_speed = (uint16_t(response[4]) << 8) | response[5];
+                xQueueSend(VFD::VFDProtocol::vfd_speed_queue, &dev_speed, 0);
                 return true;
             };
         }

--- a/FluidNC/src/Spindles/VFD/NowForeverProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/NowForeverProtocol.cpp
@@ -160,10 +160,8 @@ namespace Spindles {
                 }
 
                 // Conversion from hz to rpm not required ?
-                vfd->_sync_dev_speed = (uint16_t(response[3]) << 8) | uint16_t(response[4]);
-
-                log_debug("VFD: Current speed: " << vfd->_sync_dev_speed / 100 << "hz or " << (vfd->_sync_dev_speed * 60 / 100) << "rpm");
-
+                uint32_t dev_speed = (uint16_t(response[3]) << 8) | response[4];
+                xQueueSend(VFD::VFDProtocol::vfd_speed_queue, &dev_speed, 0);
                 return true;
             };
         }

--- a/FluidNC/src/Spindles/VFD/SiemensV20Protocol.cpp
+++ b/FluidNC/src/Spindles/VFD/SiemensV20Protocol.cpp
@@ -222,9 +222,9 @@ namespace Spindles {
                 int16_t Scaledfrequency = ((response[3] << 8) | response[4]);
                 int16_t frequency       = int16_t(float(Scaledfrequency) / (-1 * (siemensV20->_FreqScaler)));
                 log_debug("VFD Measured Value " << int16_t(Scaledfrequency) << " Freq " << int16_t(frequency));
+                uint32_t dev_speed = std::abs(frequency);
+                xQueueSend(VFD::VFDProtocol::vfd_speed_queue, &dev_speed, 0);
 
-                // Store speed for synchronization
-                vfd->_sync_dev_speed = uint16_t(frequency);
                 return true;
             };
         }

--- a/FluidNC/src/Spindles/VFD/VFDProtocol.cpp
+++ b/FluidNC/src/Spindles/VFD/VFDProtocol.cpp
@@ -237,12 +237,6 @@ namespace Spindles {
             // Do variant-specific command preparation
             set_speed_command(speed, data);
 
-#if 0
-            // Sometimes sync_dev_speed is retained between different set_speed_command's. We don't want that - we want
-            // spindle sync to kick in after we set the speed. This forces that.
-            spindle->_sync_dev_speed = UINT32_MAX;
-#endif
-
             return true;
         }
 

--- a/FluidNC/src/Spindles/VFD/YL620Protocol.cpp
+++ b/FluidNC/src/Spindles/VFD/YL620Protocol.cpp
@@ -196,9 +196,8 @@ namespace Spindles {
             //  Recv: 01 03 02 05 DC xx xx
             //                 ---- = 1500
             return [](const uint8_t* response, VFDSpindle* vfd, VFDProtocol* detail) -> bool {
-                uint16_t freq = (uint16_t(response[3]) << 8) | uint16_t(response[4]);
-
-                vfd->_sync_dev_speed = freq;
+                uint32_t dev_speed = (uint16_t(response[3]) << 8) | response[4];
+                xQueueSend(VFD::VFDProtocol::vfd_speed_queue, &dev_speed, 0);
                 return true;
             };
         }

--- a/FluidNC/src/Spindles/VFDSpindle.cpp
+++ b/FluidNC/src/Spindles/VFDSpindle.cpp
@@ -135,10 +135,6 @@ namespace Spindles {
             return;
         }
 
-        // _sync_dev_speed is set by a callback that handles
-        // responses from periodic get_current_speed() requests.
-        // It changes as the actual speed ramps toward the target.
-
         _syncing = true;  // poll for speed
 
         auto minSpeedAllowed = dev_speed > _slop ? (dev_speed - _slop) : 0;
@@ -148,7 +144,7 @@ namespace Spindles {
 
         const int limit = 100;  // 10 sec / 100 ms
 
-        if (_debug > 1 && _sync_dev_speed != UINT32_MAX) {
+        if (_debug > 1) {
             log_info("Syncing to " << int(dev_speed));
         }
 

--- a/FluidNC/src/Spindles/VFDSpindle.h
+++ b/FluidNC/src/Spindles/VFDSpindle.h
@@ -56,7 +56,6 @@ namespace Spindles {
         void setState(SpindleState state, SpindleSpeed speed);
         void setSpeedfromISR(uint32_t dev_speed) override;
 
-        // volatile uint32_t _sync_dev_speed;
         uint32_t     _sync_dev_speed;
         SpindleSpeed _slop;
 


### PR DESCRIPTION
The problem was a variable that is no longer volatile.  I changed it to use the VFD speed queue instead, for consistency with the generic protocol implementation.