### PR TITLE
Improve VFD spindle speed synchronization handling and abort condition

### DIFF
--- a/FluidNC/src/Spindles/VFDSpindle.cpp
+++ b/FluidNC/src/Spindles/VFDSpindle.cpp
@@ -140,21 +140,31 @@ namespace Spindles {
         auto minSpeedAllowed = dev_speed > _slop ? (dev_speed - _slop) : 0;
         auto maxSpeedAllowed = dev_speed + _slop;
 
-        int unchanged = 0;
-
-        const int limit = 100;  // 10 sec / 100 ms
-
         if (_debug > 1) {
             log_info("Syncing to " << int(dev_speed));
         }
 
+        uint32_t   prev_sync_speed   = _sync_dev_speed;
+        TickType_t last_change_ticks = xTaskGetTickCount();
         while ((_last_override_value == sys.spindle_speed_ovr()) &&  // skip if the override changes
-               ((_sync_dev_speed < minSpeedAllowed || _sync_dev_speed > maxSpeedAllowed) && unchanged < limit)) {
+               (_sync_dev_speed < minSpeedAllowed || _sync_dev_speed > maxSpeedAllowed)) {
+            if (sys.abort()) {
+                _syncing = false;
+                return;
+            }
             if (!xQueueReceive(VFD::VFDProtocol::vfd_speed_queue, &_sync_dev_speed, 3000)) {
                 mc_critical(ExecAlarm::SpindleControl);
                 log_error(name() << ": spindle did not reach device units " << dev_speed << ". Reported value is " << _sync_dev_speed);
                 _syncing = false;
                 return;
+            }
+            if (_sync_dev_speed == prev_sync_speed) {
+                if ((xTaskGetTickCount() - last_change_ticks) >= pdMS_TO_TICKS(3000)) {
+                    break;  // speed has not changed for 3 seconds; give up waiting
+                }
+            } else {
+                last_change_ticks = xTaskGetTickCount();
+                prev_sync_speed   = _sync_dev_speed;
             }
         }
         _last_override_value = sys.spindle_speed_ovr();


### PR DESCRIPTION
Occasionally, FluidNC 4.0.1 will go into a loop reading the spindle speed after a job finishes.

My first PR, let me know if I missed anything obvious.

* `unchanged` is now properly counted: tracks how many consecutive readings returned the same speed value. After 100 unchanged readings (limit = 100, ~25 seconds at default 250ms poll rate), the loop exits.

* `sys.abort()` is checked each iteration: if a reset fires while syncing, _syncing is cleared and the function returns immediately.