### PR TITLE
Use upstream ESPAsyncWebServer

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -43,11 +43,7 @@ bt_deps =
 	BluetoothSerial
 wifi_deps =
 	ESP32Async/AsyncTCP
-  	; This specific commit has the bug fix to support uploading zero byte files, should be released soon in their official
-        ;fork that adds WebDAV methods
-	ESPAsyncWebServer=https://github.com/MitchBradley/ESPAsyncWebServer.git#WebDAV
-        ;upstream version
-	;ESPAsyncWebServer=https://github.com/ESP32Async/ESPAsyncWebServer.git
+	ESPAsyncWebServer=https://github.com/ESP32Async/ESPAsyncWebServer.git
 	;WiFi=https://github.com/MitchBradley/WiFi#canWrite
         ; If we include the following explicit dependencies when we get the
         ; Arduino framework code from github, platformio picks up different


### PR DESCRIPTION
Our recent changes to ESPAsyncWebServer were accepted upstream so it is no longer necessary to use the fork of that library.