### PR TITLE
Serve .html files instead of download

### DIFF
--- a/FluidNC/src/WebUI/WebUIServer.cpp
+++ b/FluidNC/src/WebUI/WebUIServer.cpp
@@ -464,8 +464,10 @@ namespace WebUI {
             return;
         }
 
-        // Download a file.  The true forces a download instead of displaying the file
-        if (myStreamFile(request, path.c_str(), true)) {
+        // Serve HTML files inline so the browser renders them; download everything else
+        auto dot = path.rfind('.');
+        bool download = (dot == std::string::npos || path.substr(dot) != ".html");
+        if (myStreamFile(request, path.c_str(), download)) {
             return;
         }
 


### PR DESCRIPTION
FluidNC will serve the index.html(.gz) file from the flash storage as the default file when accessing the root URL.  However, other .html(.gz) files are instead downloaded by the browser.  This will allow any .html(.gz) file to be rendered by the browser instead of downloaded.

This would be useful for custom interfaces.  The alternatives are to completely replace the WebUI index.html.gz file or to create a WebUI v3 extension.  Replacing the full WebUI is a lot of work since it allows for FluidNC configuration.  A WebUI v3 extension is ok but there are some formatting limitations.  You also cannot access a page extension by URL.

If you wanted to make it easier to access an HTML page from WebUI v3, it works to create a macro of Type "URL address" and an Action of "test.html".

This was tested by creating a basic HTML page as test.html.gz, saving to flash, and accessing via http://fluidnc.local/test.html.  Additionally, WebUI v3 extensions were also validated to still load properly since they are also .html.gz files.

A potential concern is that this means any standalone UI would have its own websocket connection, however, FluidNC v4.0 has better handling for this.

Since this still calls myStreamFile, it is still subject to all the normal handling such as block during motion, HTTP 304 responses, and .gz files.

Existing issue #1143 requests this and provides a draft PR.  However, that code is out of date for v4.0 and untested.  This provides an updated and simplified version.