### PR TITLE
Adds idle_disable config item to axes.

### DIFF
--- a/FluidNC/esp32/PwmPin.cpp
+++ b/FluidNC/esp32/PwmPin.cpp
@@ -161,6 +161,7 @@ void IRAM_ATTR PwmPin::setDuty(uint32_t duty) {
     // -> ledc_hal_set_sig_out_en(&(p_ledc_obj[speed_mode]->ledc_hal), channel, true);
     ch.conf0.sig_out_en = on;
     // -> ledc_hal_set_duty_start(&(p_ledc_obj[speed_mode]->ledc_hal), channel, true);
+    while (ch.conf1.duty_start) {}
     ch.conf1.duty_start = on;
     // -> ledc_ls_channel_update(speed_mode, channel); // Doesn't seem to hurt for high speed channels.
     ch.conf0.low_speed_update = 1;

--- a/FluidNC/src/Kinematics/ParallelDelta.cpp
+++ b/FluidNC/src/Kinematics/ParallelDelta.cpp
@@ -406,7 +406,7 @@ namespace Kinematics {
 
         // For servo motors, we let the motor do the homing and then
         // set the position accordingly
-        Axes::set_disable(false);
+        Axes::set_disable(false, false);
 
         float motor_pos[3];
         setArray(motor_pos, _up_degrees, 3);

--- a/FluidNC/src/Machine/Axes.cpp
+++ b/FluidNC/src/Machine/Axes.cpp
@@ -71,7 +71,10 @@ namespace Machine {
         config_motors();
     }
 
-    void IRAM_ATTR Axes::set_disable(axis_t axis, bool disable) {
+    void IRAM_ATTR Axes::set_disable(axis_t axis, bool disable, bool manual_override) {
+        if (disable && !manual_override && !_axis[axis]->_idleDisable) {  //skip if idle disable is not allowed for this axis
+            return;
+        }
         for (motor_t motor = 0; motor < Axis::MAX_MOTORS_PER_AXIS; motor++) {
             auto m = _axis[axis]->_motors[motor];
             if (m) {
@@ -83,9 +86,9 @@ namespace Machine {
         }
     }
 
-    void IRAM_ATTR Axes::set_disable(bool disable) {
+    void IRAM_ATTR Axes::set_disable(bool disable, bool manual_override) {
         for (axis_t axis = X_AXIS; axis < _numberAxis; axis++) {
-            set_disable(axis, disable);
+            set_disable(axis, disable, manual_override);
         }
 
         _sharedStepperDisable.synchronousWrite(disable);

--- a/FluidNC/src/Machine/Axes.h
+++ b/FluidNC/src/Machine/Axes.h
@@ -77,8 +77,8 @@ namespace Machine {
         // The return value is a bitmask of axes that can home
         static MotorMask set_homing_mode(AxisMask homing_mask, bool isHoming);
 
-        static void set_disable(axis_t axis, bool disable);
-        static void set_disable(bool disable);
+        static void set_disable(axis_t axis, bool disable, bool manual_override);
+        static void set_disable(bool disable, bool manual_override);
         static void config_motors();
 
         static std::string maskToNames(AxisMask mask);

--- a/FluidNC/src/Machine/Axis.cpp
+++ b/FluidNC/src/Machine/Axis.cpp
@@ -11,6 +11,7 @@ namespace Machine {
         handler.item("acceleration_mm_per_sec2", _acceleration, 0.001, 100000.0);
         handler.item("max_travel_mm", _maxTravel, 0.1, 10000000.0);
         handler.item("soft_limits", _softLimits);
+        handler.item("idle_disable", _idleDisable);
         handler.section("homing", _homing);
 
         char tmp[7];

--- a/FluidNC/src/Machine/Axis.h
+++ b/FluidNC/src/Machine/Axis.h
@@ -35,6 +35,7 @@ namespace Machine {
         float _acceleration = 25.0f;
         float _maxTravel    = 1000.0f;
         bool  _softLimits   = false;
+        bool  _idleDisable  = true;
 
         // Configuration system helpers:
         void group(Configuration::HandlerBase& handler) override;

--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -238,7 +238,7 @@ namespace Machine {
         Stepper::reset();  // Stop moving
         send_alarm(alarm);
         Axes::set_homing_mode(_cycleAxes, false);  // tell motors homing is done...failed
-        Axes::set_disable(Stepping::_idleMsecs != 255);
+        Axes::set_disable(Stepping::_idleMsecs != 255, false);
     }
 
     bool Homing::needsPulloff2(MotorMask motors) {

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -664,6 +664,10 @@ static Error motor_control(const char* value, bool disable) {
         return Error::InvalidValue;
     }
     log_info((disable ? "Dis" : "En") << "abling " << value << " motors");
+
+    if (axis == INVALID_AXIS || axis >= axes->_numberAxis || axes->_axis[axis] == nullptr) {
+        return Error::InvalidValue;
+    }
     axes->set_disable(axis, disable, true);
     return Error::Ok;
 }

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -648,7 +648,7 @@ static Error motor_control(const char* value, bool disable) {
     }
     if (!value || *value == '\0') {
         log_info((disable ? "Dis" : "En") << "abling all motors");
-        Axes::set_disable(disable);
+        Axes::set_disable(disable, true);
         return Error::Ok;
     }
 
@@ -664,7 +664,7 @@ static Error motor_control(const char* value, bool disable) {
         return Error::InvalidValue;
     }
     log_info((disable ? "Dis" : "En") << "abling " << value << " motors");
-    axes->set_disable(axis, disable);
+    axes->set_disable(axis, disable, true);
     return Error::Ok;
 }
 static Error motor_disable(const char* value, AuthenticationLevel auth_level, Channel& out) {

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -778,7 +778,7 @@ void protocol_disable_steppers() {
     }
     if (state_is(State::Sleep)) {
         // Disable steppers immediately in sleep or alarm state
-        Axes::set_disable(true, false);
+        Axes::set_disable(true, true);
         return;
     }
     if (Stepping::_idleMsecs == 255) {
@@ -1155,6 +1155,8 @@ void protocol_do_rt_reset() {
         } else {
             set_state(State::Idle);
         }
+    } else if (state_is(State::Sleep)) {
+        protocol_do_alarm((void*)ExecAlarm::AbortCycle);
     } else if (!state_is(State::Alarm)) {
         set_state(State::Idle);
     }

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -289,7 +289,7 @@ void protocol_main_loop() {
 
         if (idleEndTime && (getCpuTicks() - idleEndTime) > 0) {
             idleEndTime = 0;  //
-            Axes::set_disable(true);
+            Axes::set_disable(true, false);
         }
         uint32_t newHeapSize = xPortGetFreeHeapSize();
         if (newHeapSize < heapLowWater) {
@@ -773,17 +773,17 @@ static void protocol_do_cycle_start() {
 void protocol_disable_steppers() {
     if (state_is(State::Homing)) {
         // Leave steppers enabled while homing
-        Axes::set_disable(false);
+        Axes::set_disable(false, false);
         return;
     }
     if (state_is(State::Sleep)) {
         // Disable steppers immediately in sleep or alarm state
-        Axes::set_disable(true);
+        Axes::set_disable(true, false);
         return;
     }
     if (Stepping::_idleMsecs == 255) {
         // Leave steppers enabled if configured for "stay enabled"
-        Axes::set_disable(false);
+        Axes::set_disable(false, false);
         return;
     }
     // Otherwise, schedule stepper disable in a few milliseconds

--- a/FluidNC/src/Stepper.cpp
+++ b/FluidNC/src/Stepper.cpp
@@ -276,7 +276,7 @@ void Stepper::wake_up() {
     // Cancel any pending stepper disable
     protocol_cancel_disable_steppers();
     // Enable stepper drivers.
-    Axes::set_disable(false);
+    Axes::set_disable(false, false);
 
     // Enable Stepping Driver Interrupt
     Stepping::startTimer();


### PR DESCRIPTION
This allows selected motors to ignore the idle_disable and stay on.

example

```yaml
  y:
    steps_per_mm: 800.000
    max_rate_mm_per_min: 5000.000
    acceleration_mm_per_sec2: 100.000
    max_travel_mm: 300.000
    soft_limits: false
    idle_disable: false
```