### PR TITLE
Update platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -134,7 +134,7 @@ build_flags = -DVARIANT=\"wifi\"
 
 [common_bt]
 build_src_filter = +<BTConfig.cpp> +<WebUI/WebCommands.cpp>
-build_flags = -DVARIANT=\"bt\"
+build_flags = -DVARIANT=\"bt\" -DCONFIG_BT_ENABLED
 
 [common_noradio]
 build_src_filter =


### PR DESCRIPTION
The platformio.ini BT config got messed up when ESP32-S3 was added.