### PR TITLE
Fix1727

### DIFF
--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -1668,7 +1668,7 @@ Error gc_execute_line(const char* input_line) {
             if (new_spindle) {
                 gc_state.spindle_speed = 0.0;
             }
-            log_info("Current T:" << gc_state.current_tool << ", Selected T:" << gc_state.selected_tool);
+            log_info("Current T:" << gc_state.current_tool << " Selected T:" << gc_state.selected_tool);
             spindle->tool_change(gc_state.selected_tool, false, false);
             if (spindle->_atc_name == "" && spindle->_m6_macro.get().empty()) {  // if neither of these exist we need to set the value here
                 gc_state.current_tool = gc_state.selected_tool;

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -1668,7 +1668,7 @@ Error gc_execute_line(const char* input_line) {
             if (new_spindle) {
                 gc_state.spindle_speed = 0.0;
             }
-            log_info("Current T:" << gc_state.current_tool << "Selected T:" << gc_state.selected_tool);
+            log_info("Current T:" << gc_state.current_tool << ", Selected T:" << gc_state.selected_tool);
             spindle->tool_change(gc_state.selected_tool, false, false);
             if (spindle->_atc_name == "" && spindle->_m6_macro.get().empty()) {  // if neither of these exist we need to set the value here
                 gc_state.current_tool = gc_state.selected_tool;

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -595,6 +595,7 @@ Error gc_execute_line(const char* input_line) {
                                 gc_block.modal.coord_select = CoordIndex::G59_3;
                                 break;
                         }
+                        mantissa    = 0;  // Set to zero to indicate valid non-integer G command.
                         mg_word_bit = ModalGroup::MG12;
                         break;
                         // NOTE: G59.x are not supported.

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -594,6 +594,8 @@ Error gc_execute_line(const char* input_line) {
                             case 30:
                                 gc_block.modal.coord_select = CoordIndex::G59_3;
                                 break;
+                            default:
+                                return Error::GcodeUnsupportedCommand;  // [G59.4+ not supported]
                         }
                         mantissa    = 0;  // Set to zero to indicate valid non-integer G command.
                         mg_word_bit = ModalGroup::MG12;
@@ -1666,7 +1668,7 @@ Error gc_execute_line(const char* input_line) {
             if (new_spindle) {
                 gc_state.spindle_speed = 0.0;
             }
-            log_info("Current T:" << gc_state.current_tool  << "Selected T:" << gc_state.selected_tool);
+            log_info("Current T:" << gc_state.current_tool << "Selected T:" << gc_state.selected_tool);
             spindle->tool_change(gc_state.selected_tool, false, false);
             if (spindle->_atc_name == "" && spindle->_m6_macro.get().empty()) {  // if neither of these exist we need to set the value here
                 gc_state.current_tool = gc_state.selected_tool;

--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -252,7 +252,13 @@ void report_gcode_modes(Channel& channel) {
             break;
     }
 
-    msg << " G" << (gc_state.modal.coord_select + 54);
+    if (gc_state.modal.coord_select < 6) {
+        // G54 .. G59
+        msg << " G" << (gc_state.modal.coord_select + 54);
+    } else {
+        // G59.1 .. G59.3
+        msg << " G59." << (gc_state.modal.coord_select - 5);
+    }
 
     switch (gc_state.modal.plane_select) {
         case Plane::XY:

--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -252,12 +252,12 @@ void report_gcode_modes(Channel& channel) {
             break;
     }
 
-    if (gc_state.modal.coord_select < 6) {
+    if (gc_state.modal.coord_select < CoordIndex::G59_1) {
         // G54 .. G59
         msg << " G" << (gc_state.modal.coord_select + 54);
     } else {
         // G59.1 .. G59.3
-        msg << " G59." << (gc_state.modal.coord_select - 5);
+        msg << " G59." << (gc_state.modal.coord_select - CoordIndex::G59);
     }
 
     switch (gc_state.modal.plane_select) {


### PR DESCRIPTION
GCode.cpp was parsing G59.1-3, but failing to clear the mantissa, triggering the "not integer" error.  Also it was failing to explicitly reject G59.4+, although the "not integer" error effectively rejected that anyway.

Finally, $G was incorrectly reporting G59.1-3 as G60-62