### PR TITLE
Stream WebUI and WebDAV directory listings

### DIFF
--- a/FluidNC/src/JSONEncoder.h
+++ b/FluidNC/src/JSONEncoder.h
@@ -34,12 +34,13 @@ private:
 
     std::string category;
 
-    void flush();
-
 public:
     // Constructor; set _json_tag for [MSG:JSON: ,,,] encapsulation
     JSONencoder(Channel* channel, const char* json_tag = nullptr);
     JSONencoder(JsonCallback);
+
+    // Emits any buffered JSON output without changing encoder state.
+    void flush();
 
     // begin() starts the encoding process.
     void begin();

--- a/FluidNC/src/WebUI/WebDAV.cpp
+++ b/FluidNC/src/WebUI/WebDAV.cpp
@@ -4,6 +4,7 @@
 #include <AsyncTCP.h>
 #include "ESP32SHA1.h"
 
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 #include <functional>

--- a/FluidNC/src/WebUI/WebDAV.cpp
+++ b/FluidNC/src/WebUI/WebDAV.cpp
@@ -85,13 +85,20 @@ namespace {
     };
 
     std::string propfind_time_string(const stdfs::path& fpath) {
-        auto ftime = stdfs::last_write_time(fpath);
+        std::error_code ec;
+        auto            ftime = stdfs::last_write_time(fpath, ec);
 
         // last modified
 #if __cpp_lib_format
+        if (ec) {
+            return "Fri, 05 Sep 2014 19:00:00 GMT";
+        }
         return std::format("{:%c}", ftime);
 #else
 #    if 0
+        if (ec) {
+            return "Fri, 05 Sep 2014 19:00:00 GMT";
+        }
         std::time_t cftime  = std::chrono::system_clock::to_time_t(std::chrono::file_clock::to_sys(ftime));
         std::string timestr = std::asctime(std::localtime(&cftime));
         timestr.pop_back();  // rm the trailing '\n' put by `asctime`
@@ -108,8 +115,12 @@ namespace {
             return;
         }
 
-        frame.is_dir       = stdfs::is_directory(frame.path);
-        frame.size         = frame.is_dir ? -1 : static_cast<int32_t>(stdfs::file_size(frame.path));
+        std::error_code ec;
+        frame.is_dir = stdfs::is_directory(frame.path, ec) && !ec;
+
+        ec = {};
+        auto file_size = frame.is_dir ? static_cast<uintmax_t>(-1) : stdfs::file_size(frame.path, ec);
+        frame.size     = (ec || file_size == static_cast<uintmax_t>(-1)) ? -1 : static_cast<int32_t>(file_size);
         frame.display_name = state.replace_fs_name(frame.path).string();
         frame.timestr      = propfind_time_string(frame.path);
         frame.initialized  = true;

--- a/FluidNC/src/WebUI/WebDAV.cpp
+++ b/FluidNC/src/WebUI/WebDAV.cpp
@@ -6,6 +6,9 @@
 
 #include <chrono>
 #include <ctime>
+#include <functional>
+#include <memory>
+#include <vector>
 // #include <format>
 #include "string_util.h"
 
@@ -30,6 +33,247 @@ bool WebDAV::canHandle(AsyncWebServerRequest* request) const {
 static const char* rootname = "/";
 static const char* slashstr = "/";
 static const char  slash    = '/';
+
+namespace {
+    struct PropfindNodeFrame {
+        enum class Stage : uint8_t { Enter, EmitMacMetadata, IterateChildren };
+
+        explicit PropfindNodeFrame(stdfs::path node_path, int remaining_depth) : path(std::move(node_path)), level(remaining_depth) {}
+
+        stdfs::path               path;
+        std::string               display_name;
+        std::string               timestr;
+        int32_t                   size            = -1;
+        int                       level           = 0;
+        bool                      is_dir          = false;
+        bool                      initialized     = false;
+        bool                      iter_initialized = false;
+        Stage                     stage           = Stage::Enter;
+        stdfs::directory_iterator iter;
+        stdfs::directory_iterator end;
+    };
+
+    struct PropfindChunkState {
+        enum class Phase : uint8_t { Start, Traverse, End, Done };
+
+        PropfindChunkState(FluidPath                                      root,
+                   bool                                           want_json_response,
+                           bool                                           is_macos_request,
+                           std::function<stdfs::path(const stdfs::path&)> replace_fs_name_fn,
+                           std::function<bool(const stdfs::path&)>        is_fs_root_fn) :
+            root_path(std::move(root)),
+            want_json(want_json_response),
+            is_macos(is_macos_request),
+            replace_fs_name(std::move(replace_fs_name_fn)),
+            is_fs_root(std::move(is_fs_root_fn)) {
+            if (want_json) {
+                encoder = std::make_unique<JSONencoder>([this](const char* s) { pending += s; });
+            }
+        }
+
+        Phase                                             phase          = Phase::Start;
+        FluidPath                                         root_path;
+        bool                                              want_json      = false;
+        bool                                              is_macos       = false;
+        std::string                                       pending;
+        size_t                                            pending_offset = 0;
+        std::vector<PropfindNodeFrame>                    stack;
+        std::unique_ptr<JSONencoder>                      encoder;
+        std::function<stdfs::path(const stdfs::path&)>    replace_fs_name;
+        std::function<bool(const stdfs::path&)>           is_fs_root;
+    };
+
+    std::string propfind_time_string(const stdfs::path& fpath) {
+        auto ftime = stdfs::last_write_time(fpath);
+
+        // last modified
+#if __cpp_lib_format
+        return std::format("{:%c}", ftime);
+#else
+#    if 0
+        std::time_t cftime  = std::chrono::system_clock::to_time_t(std::chrono::file_clock::to_sys(ftime));
+        std::string timestr = std::asctime(std::localtime(&cftime));
+        timestr.pop_back();  // rm the trailing '\n' put by `asctime`
+        return timestr;
+#    else
+        (void)fpath;
+        return "Fri, 05 Sep 2014 19:00:00 GMT";
+#    endif
+#endif
+    }
+
+    void initialize_propfind_frame(PropfindChunkState& state, PropfindNodeFrame& frame) {
+        if (frame.initialized) {
+            return;
+        }
+
+        frame.is_dir       = stdfs::is_directory(frame.path);
+        frame.size         = frame.is_dir ? -1 : static_cast<int32_t>(stdfs::file_size(frame.path));
+        frame.display_name = state.replace_fs_name(frame.path).string();
+        frame.timestr      = propfind_time_string(frame.path);
+        frame.initialized  = true;
+    }
+
+    void append_propfind_xml_response(PropfindChunkState& state, const PropfindNodeFrame& frame) {
+        state.pending += "<d:response>";
+        state.pending += "<d:href>";
+        state.pending += frame.display_name;
+        state.pending += "</d:href>";
+        state.pending += "<d:propstat>";
+        state.pending += "<d:prop>";
+        if (frame.is_dir) {
+            state.pending += "<d:resourcetype><d:collection/></d:resourcetype>";
+        } else {
+            state.pending += "<d:getlastmodified>";
+            state.pending += frame.timestr;
+            state.pending += "</d:getlastmodified>";
+            state.pending += "<d:resourcetype/>";
+            state.pending += "<d:getcontentlength>";
+            state.pending += std::to_string(frame.size);
+            state.pending += "</d:getcontentlength>";
+            state.pending += "<d:getcontenttype>";
+            state.pending += getContentType(frame.display_name.c_str());
+            state.pending += "</d:getcontenttype>";
+        }
+        state.pending += "</d:prop>";
+        state.pending += "<d:status>HTTP/1.1 200 OK</d:status>";
+        state.pending += "</d:propstat>";
+        state.pending += "</d:response>";
+    }
+
+    void append_macos_metadata_response(PropfindChunkState& state, const PropfindNodeFrame& frame) {
+        PropfindNodeFrame metadata_frame(frame.path / ".metadata_never_index", 0);
+        metadata_frame.display_name = state.replace_fs_name(metadata_frame.path).string();
+        metadata_frame.timestr      = frame.timestr;
+        metadata_frame.size         = 0;
+        metadata_frame.initialized  = true;
+        append_propfind_xml_response(state, metadata_frame);
+    }
+
+    void initialize_propfind_iterator(PropfindNodeFrame& frame) {
+        if (frame.iter_initialized) {
+            return;
+        }
+
+        std::error_code ec;
+        frame.iter = stdfs::directory_iterator { frame.path, ec };
+        if (ec) {
+            frame.iter = frame.end;
+        }
+        frame.iter_initialized = true;
+    }
+
+    bool advance_propfind_json_chunk(PropfindChunkState& state) {
+        auto& frame = state.stack.back();
+        initialize_propfind_frame(state, frame);
+
+        switch (frame.stage) {
+            case PropfindNodeFrame::Stage::Enter:
+                state.encoder->begin_object();
+                state.encoder->member("name", frame.display_name);
+                state.encoder->member("size", frame.size);
+                state.encoder->member("datetime", frame.timestr);
+                if (frame.is_dir && frame.level > 0) {
+                    state.encoder->begin_array("files");
+                    frame.stage = PropfindNodeFrame::Stage::IterateChildren;
+                } else {
+                    state.encoder->end_object();
+                    state.stack.pop_back();
+                }
+                state.encoder->flush();
+                return true;
+
+            case PropfindNodeFrame::Stage::EmitMacMetadata:
+                state.stack.back().stage = PropfindNodeFrame::Stage::IterateChildren;
+                return true;
+
+            case PropfindNodeFrame::Stage::IterateChildren:
+                initialize_propfind_iterator(frame);
+                if (frame.iter == frame.end) {
+                    state.encoder->end_array();
+                    state.encoder->end_object();
+                    state.stack.pop_back();
+                    state.encoder->flush();
+                } else {
+                    stdfs::path child_path = frame.iter->path();
+                    ++frame.iter;
+                    state.stack.emplace_back(std::move(child_path), frame.level - 1);
+                }
+                return true;
+        }
+
+        return false;
+    }
+
+    bool advance_propfind_xml_chunk(PropfindChunkState& state) {
+        auto& frame = state.stack.back();
+        initialize_propfind_frame(state, frame);
+
+        switch (frame.stage) {
+            case PropfindNodeFrame::Stage::Enter:
+                append_propfind_xml_response(state, frame);
+                if (frame.is_dir && frame.level > 0) {
+                    frame.stage = state.is_macos && state.is_fs_root(frame.path) ? PropfindNodeFrame::Stage::EmitMacMetadata :
+                                                                                PropfindNodeFrame::Stage::IterateChildren;
+                } else {
+                    state.stack.pop_back();
+                }
+                return true;
+
+            case PropfindNodeFrame::Stage::EmitMacMetadata:
+                append_macos_metadata_response(state, frame);
+                frame.stage = PropfindNodeFrame::Stage::IterateChildren;
+                return true;
+
+            case PropfindNodeFrame::Stage::IterateChildren:
+                initialize_propfind_iterator(frame);
+                if (frame.iter == frame.end) {
+                    state.stack.pop_back();
+                } else {
+                    stdfs::path child_path = frame.iter->path();
+                    ++frame.iter;
+                    state.stack.emplace_back(std::move(child_path), frame.level - 1);
+                }
+                return true;
+        }
+
+        return false;
+    }
+
+    bool advance_propfind_chunk(PropfindChunkState& state) {
+        switch (state.phase) {
+            case PropfindChunkState::Phase::Start:
+                if (state.want_json) {
+                    state.encoder->flush();
+                } else {
+                    state.pending += "<?xml version=\"1.0\"?>";
+                    state.pending += "<d:multistatus xmlns:d=\"DAV:\">";
+                }
+                state.phase = PropfindChunkState::Phase::Traverse;
+                return true;
+
+            case PropfindChunkState::Phase::Traverse:
+                if (state.stack.empty()) {
+                    state.phase = PropfindChunkState::Phase::End;
+                    return true;
+                }
+                return state.want_json ? advance_propfind_json_chunk(state) : advance_propfind_xml_chunk(state);
+
+            case PropfindChunkState::Phase::End:
+                if (state.want_json) {
+                } else {
+                    state.pending += "</d:multistatus>";
+                }
+                state.phase = PropfindChunkState::Phase::Done;
+                return true;
+
+            case PropfindChunkState::Phase::Done:
+                return false;
+        }
+
+        return false;
+    }
+}
 
 // Mac command to prevent .DS_Store files:
 //  defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool TRUE
@@ -240,6 +484,8 @@ bool WebDAV::acceptsType(AsyncWebServerRequest* request, const char* type) {
 }
 
 void WebDAV::handlePropfind(const FluidPath& fpath, DavResource resource, AsyncWebServerRequest* request) {
+    (void)resource;
+
     // check depth header
     auto depth = DavDepth::NONE;
 
@@ -259,34 +505,43 @@ void WebDAV::handlePropfind(const FluidPath& fpath, DavResource resource, AsyncW
             noroot = true;
         }
     }
-
-    JSONencoder* j = nullptr;
-
     bool wantJSON = acceptsType(request, T_application_json);
 
-    AsyncResponseStream* response = request->beginResponseStream(wantJSON ? T_application_json : "application/xml");
+    auto state = std::make_shared<PropfindChunkState>(
+        fpath,
+        wantJSON,
+        _isMacOS,
+        [this](const stdfs::path& path) { return replace_fs_name(path); },
+        [this](const stdfs::path& path) { return is_fs_root(path); });
+    state->stack.emplace_back(fpath, static_cast<int>(depth));
+
+    AsyncWebServerResponse* response = request->beginChunkedResponse(
+        wantJSON ? T_application_json : "application/xml",
+        [state](uint8_t* buffer, size_t maxLen, size_t total) mutable -> size_t {
+            (void)total;
+
+            size_t written = 0;
+
+            while (written < maxLen) {
+                if (state->pending_offset < state->pending.length()) {
+                    size_t chunk_len = std::min(maxLen - written, state->pending.length() - state->pending_offset);
+                    memcpy(buffer + written, state->pending.data() + state->pending_offset, chunk_len);
+                    state->pending_offset += chunk_len;
+                    written += chunk_len;
+                    continue;
+                }
+
+                state->pending.clear();
+                state->pending_offset = 0;
+
+                if (!advance_propfind_chunk(*state)) {
+                    break;
+                }
+            }
+
+            return written;
+        });
     response->setCode(207);
-
-    if (wantJSON) {
-        j = new JSONencoder([response](const char* s) { response->print(s); });
-    }
-
-    if (j) {
-        j->begin();
-    } else {
-        response->print("<?xml version=\"1.0\"?>");
-        response->print("<d:multistatus xmlns:d=\"DAV:\">");
-    }
-    //    if (!is_dir || !noroot) {
-    sendPropResponse(response, (int)depth, fpath, j);
-    //    }
-
-    if (j) {
-        j->end();
-        delete j;
-    } else {
-        response->print("</d:multistatus>");
-    }
 
     return request->send(response);
 }
@@ -513,76 +768,3 @@ stdfs::path WebDAV::replace_fs_name(const stdfs::path& p) {
     return new_path;
 }
 
-void WebDAV::sendXMLResponse(
-    AsyncResponseStream* response, bool is_dir, const std::string& name, const std::string& tag, const std::string& time, size_t size) {
-    response->printf("<d:response>");
-    response->printf("<d:href>%s</d:href>", name.c_str());
-    response->printf("<d:propstat>");
-    response->printf("<d:prop>");
-    if (is_dir) {
-        response->printf("<d:resourcetype><d:collection/></d:resourcetype>");
-    } else {
-        // response->printf("<d:getetag>%s</d:getetag>", tag.c_str());
-        response->printf("<d:getlastmodified>%s</d:getlastmodified>", time.c_str());
-        response->printf("<d:resourcetype/>");
-        response->printf("<d:getcontentlength>%d</d:getcontentlength>", size);
-        response->printf("<d:getcontenttype>%s</d:getcontenttype>", getContentType(name));
-    }
-    response->printf("</d:prop>");
-    response->printf("<d:status>HTTP/1.1 200 OK</d:status>");
-    response->printf("</d:propstat>");
-    response->printf("</d:response>");
-}
-void WebDAV::sendPropResponse(AsyncResponseStream* response, int level, const stdfs::path& fpath, JSONencoder* j) {
-    auto   ftime  = stdfs::last_write_time(fpath);
-    bool   is_dir = stdfs::is_directory(fpath);
-    size_t size   = is_dir ? -1 : stdfs::file_size(fpath);
-
-    // last modified
-#if __cpp_lib_format
-    std::string timestr = std::format("{:%c}", ftime);
-#else
-#    if 0
-    std::time_t cftime  = std::chrono::system_clock::to_time_t(std::chrono::file_clock::to_sys(ftime));
-    std::string timestr = std::asctime(std::localtime(&cftime));
-    timestr.pop_back();  // rm the trailing '\n' put by `asctime`
-#    else
-    std::string timestr = "Fri, 05 Sep 2014 19:00:00 GMT";
-#    endif
-#endif
-
-    if (j) {
-        j->begin_object();
-        j->member("name", replace_fs_name(fpath));
-        // j->member("shortname", fullPath);
-        j->member("size", is_dir ? -1 : size);
-        j->member("datetime", timestr);
-        if (is_dir && level--) {
-            j->begin_array("files");
-            std::error_code ec;
-            auto            iter = stdfs::directory_iterator { fpath, ec };
-            for (auto const& dirent : iter) {
-                sendPropResponse(response, level, dirent.path(), j);
-            }
-            j->end_array();
-        }
-        j->end_object();
-    } else {
-        // send response
-        std::string tag(fpath.string() + timestr);
-
-        sendXMLResponse(response, is_dir, replace_fs_name(fpath).string(), tag, timestr, size);
-
-        if (is_dir && level--) {
-            if (_isMacOS && is_fs_root(fpath)) {
-                auto mni = fpath / ".metadata_never_index";
-                sendXMLResponse(response, false, replace_fs_name(mni).string(), "", timestr, 0);
-            }
-            std::error_code ec;
-            auto            iter = stdfs::directory_iterator { fpath, ec };
-            for (auto const& dirent : iter) {
-                sendPropResponse(response, level, dirent.path(), j);
-            }
-        }
-    }
-}

--- a/FluidNC/src/WebUI/WebDAV.cpp
+++ b/FluidNC/src/WebUI/WebDAV.cpp
@@ -126,10 +126,42 @@ namespace {
         frame.initialized  = true;
     }
 
+    std::string xml_escape(std::string_view text) {
+        std::string escaped;
+        escaped.reserve(text.size());
+
+        for (char ch : text) {
+            switch (ch) {
+                case '&':
+                    escaped += "&amp;";
+                    break;
+                case '<':
+                    escaped += "&lt;";
+                    break;
+                case '>':
+                    escaped += "&gt;";
+                    break;
+                case '\"':
+                    escaped += "&quot;";
+                    break;
+                case '\'':
+                    escaped += "&apos;";
+                    break;
+                default:
+                    escaped += ch;
+                    break;
+            }
+        }
+
+        return escaped;
+    }
+
     void append_propfind_xml_response(PropfindChunkState& state, const PropfindNodeFrame& frame) {
+        auto escaped_name = xml_escape(frame.display_name);
+
         state.pending += "<d:response>";
         state.pending += "<d:href>";
-        state.pending += frame.display_name;
+        state.pending += escaped_name;
         state.pending += "</d:href>";
         state.pending += "<d:propstat>";
         state.pending += "<d:prop>";
@@ -137,14 +169,14 @@ namespace {
             state.pending += "<d:resourcetype><d:collection/></d:resourcetype>";
         } else {
             state.pending += "<d:getlastmodified>";
-            state.pending += frame.timestr;
+            state.pending += xml_escape(frame.timestr);
             state.pending += "</d:getlastmodified>";
             state.pending += "<d:resourcetype/>";
             state.pending += "<d:getcontentlength>";
             state.pending += std::to_string(frame.size);
             state.pending += "</d:getcontentlength>";
             state.pending += "<d:getcontenttype>";
-            state.pending += getContentType(frame.display_name.c_str());
+            state.pending += xml_escape(getContentType(frame.display_name.c_str()));
             state.pending += "</d:getcontenttype>";
         }
         state.pending += "</d:prop>";

--- a/FluidNC/src/WebUI/WebDAV.h
+++ b/FluidNC/src/WebUI/WebDAV.h
@@ -47,10 +47,6 @@ private:
     void handleDelete(const FluidPath& path, DavResource resource, AsyncWebServerRequest* request);
     void handleHead(DavResource resource, AsyncWebServerRequest* request);
     void handleNotFound(AsyncWebServerRequest* request);
-    void sendPropResponse(AsyncResponseStream* response, int level, const stdfs::path& fpath, JSONencoder* j);
-
-    void sendXMLResponse(
-        AsyncResponseStream* response, bool is_dir, const std::string& name, const std::string& tag, const std::string& time, uint32_t size);
 
     std::string urlToUri(std::string url);
 

--- a/FluidNC/src/WebUI/WebUIServer.cpp
+++ b/FluidNC/src/WebUI/WebUIServer.cpp
@@ -25,6 +25,8 @@
 
 #include "HashFS.h"
 #include <list>
+#include <algorithm>
+#include <memory>
 
 #include "Mime.h"  // getContentType
 
@@ -35,6 +37,189 @@
 namespace WebUI {
     const byte DNS_PORT = 53;
     DNSServer  dnsServer;
+}
+
+namespace {
+    struct FileListChunkState {
+        enum class Phase : uint8_t { Begin, FileEntries, Footer, End, Done };
+
+        explicit FileListChunkState(
+            FluidPath root,
+            std::string request_path,
+            std::string response_status,
+            std::string total_bytes,
+            std::string used_bytes,
+            uint8_t occupation_percent,
+            bool emit_file_array) :
+            root_path(std::move(root)),
+            path(std::move(request_path)),
+            status(std::move(response_status)),
+            total(std::move(total_bytes)),
+            used(std::move(used_bytes)),
+            percent(occupation_percent),
+            emit_files(emit_file_array),
+            encoder([this](const char* s) { pending += s; }) {}
+
+        FileListChunkState(const FileListChunkState&) = delete;
+        FileListChunkState& operator=(const FileListChunkState&) = delete;
+
+        Phase                     phase          = Phase::Begin;
+        stdfs::directory_iterator iter;
+        stdfs::directory_iterator end;
+        FluidPath                 root_path;
+        std::string               path;
+        std::string               status;
+        std::string               total;
+        std::string               used;
+        std::string               pending;
+        size_t                    pending_offset = 0;
+        uint8_t                   percent        = 100;
+        bool                      emit_files     = false;
+        JSONencoder               encoder;
+    };
+
+    int32_t file_entry_size(const stdfs::directory_entry& dir_entry) {
+        std::error_code ec;
+
+        if (dir_entry.is_directory(ec) || ec) {
+            return -1;
+        }
+
+        ec = {};
+        if (!dir_entry.is_regular_file(ec) || ec) {
+            return -1;
+        }
+
+        ec = {};
+        auto entry_size = dir_entry.file_size(ec);
+        if (ec || entry_size == static_cast<uintmax_t>(-1)) {
+            return -1;
+        }
+
+        return static_cast<int32_t>(entry_size);
+    }
+
+    void advance_file_iterator(FileListChunkState& state) {
+        std::error_code ec;
+        state.iter.increment(ec);
+        if (ec) {
+            state.iter = state.end;
+        }
+    }
+
+    void append_file_entry(FileListChunkState& state) {
+        const auto& dir_entry = *state.iter;
+        std::string name      = dir_entry.path().filename().string();
+        int32_t     size      = file_entry_size(dir_entry);
+
+        state.encoder.begin_object();
+        state.encoder.member("name", name);
+        state.encoder.member("shortname", name);
+        state.encoder.member("size", size);
+        state.encoder.member("datetime", "");
+        state.encoder.end_object();
+        advance_file_iterator(state);
+    }
+
+    bool advance_file_list_chunk(FileListChunkState& state) {
+        switch (state.phase) {
+            case FileListChunkState::Phase::Begin:
+                state.encoder.begin();
+                if (state.emit_files) {
+                    state.encoder.begin_array("files");
+                    state.phase = FileListChunkState::Phase::FileEntries;
+                } else {
+                    state.phase = FileListChunkState::Phase::Footer;
+                }
+                state.encoder.flush();
+                return true;
+
+            case FileListChunkState::Phase::FileEntries:
+                if (state.iter == state.end) {
+                    state.encoder.end_array();
+                    state.phase = FileListChunkState::Phase::Footer;
+                } else {
+                    append_file_entry(state);
+                }
+                state.encoder.flush();
+                return true;
+
+            case FileListChunkState::Phase::Footer:
+                state.encoder.member("path", state.path.c_str());
+                state.encoder.member("total", state.total.c_str());
+                state.encoder.member("used", state.used.c_str());
+                state.encoder.member("occupation", state.percent);
+                state.encoder.member("status", state.status.c_str());
+                state.phase = FileListChunkState::Phase::End;
+                state.encoder.flush();
+                return true;
+
+            case FileListChunkState::Phase::End:
+                state.encoder.end();
+                state.phase = FileListChunkState::Phase::Done;
+                return true;
+
+            case FileListChunkState::Phase::Done:
+                return false;
+        }
+
+        return false;
+    }
+
+    AsyncWebServerResponse* create_file_list_response(AsyncWebServerRequest* request,
+                                                      const FluidPath&          fpath,
+                                                      const std::string&        path,
+                                                      const std::string&        status,
+                                                      bool                      list_files) {
+        std::error_code ec;
+        auto            space      = stdfs::space(fpath, ec);
+        uint64_t        totalspace = space.capacity;
+        uint64_t        usedspace  = totalspace - space.available;
+        uint8_t         percent    = totalspace ? (usedspace * 100) / totalspace : 100;
+
+        auto state = std::make_shared<FileListChunkState>(
+            fpath,
+            path,
+            status,
+            formatBytes(totalspace),
+            formatBytes(usedspace + 1),
+            percent,
+            false);
+
+        if (list_files) {
+            state->iter       = stdfs::directory_iterator { fpath, stdfs::directory_options::skip_permission_denied, ec };
+            state->emit_files = !ec;
+        }
+
+        AsyncWebServerResponse* response = request->beginChunkedResponse(
+            asyncsrv::T_application_json,
+            [state](uint8_t* buffer, size_t maxLen, size_t total) mutable -> size_t {
+                (void)total;
+
+                size_t written = 0;
+
+                while (written < maxLen) {
+                    if (state->pending_offset < state->pending.length()) {
+                        size_t chunk_len = std::min(maxLen - written, state->pending.length() - state->pending_offset);
+                        memcpy(buffer + written, state->pending.data() + state->pending_offset, chunk_len);
+                        state->pending_offset += chunk_len;
+                        written += chunk_len;
+                        continue;
+                    }
+
+                    state->pending.clear();
+                    state->pending_offset = 0;
+
+                    if (!advance_file_list_chunk(*state)) {
+                        break;
+                    }
+                }
+
+                return written;
+            });
+        response->addHeader(asyncsrv::T_Cache_Control, asyncsrv::T_no_cache);
+        return response;
+    }
 }
 
 using namespace asyncsrv;
@@ -997,8 +1182,6 @@ namespace WebUI {
         }
         _upload_status      = UploadStatus::NONE;
         bool     list_files = true;
-        uint64_t totalspace = 0;
-        uint64_t usedspace  = 0;
 
         //get current path
         if (request->hasParam("path")) {
@@ -1080,45 +1263,7 @@ namespace WebUI {
             list_files = false;
         }
 
-        AsyncResponseStream* response = request->beginResponseStream(T_application_json);
-        response->setCode(200);
-        response->addHeader(T_Cache_Control, T_no_cache);
-
-        JSONencoder j([response](const char* s) { response->print(s); });
-
-        j.begin();
-
-        if (list_files) {
-            auto iter = stdfs::directory_iterator { fpath, ec };
-            if (!ec) {
-                j.begin_array("files");
-                for (auto const& dir_entry : iter) {
-                    j.begin_object();
-                    j.member("name", dir_entry.path().filename().string());
-                    j.member("shortname", dir_entry.path().filename().string());
-                    j.member("size", dir_entry.is_directory() ? -1 : dir_entry.file_size());
-                    j.member("datetime", "");
-                    j.end_object();
-                }
-                j.end_array();
-            }
-        }
-
-        auto space = stdfs::space(fpath, ec);
-        totalspace = space.capacity;
-        usedspace  = totalspace - space.available;
-
-        j.member("path", path.c_str());
-        j.member("total", formatBytes(totalspace));
-        j.member("used", formatBytes(usedspace + 1));
-
-        uint8_t percent = totalspace ? (usedspace * 100) / totalspace : 100;
-
-        j.member("occupation", percent);
-        j.member("status", sstatus);
-        j.end();
-
-        request->send(response);
+        request->send(create_file_list_response(request, fpath, path, sstatus, list_files));
     }
 
     void WebUI_Server::handle_direct_SDFileList(AsyncWebServerRequest* request) {

--- a/FluidNC/src/WebUI/WebUIServer.cpp
+++ b/FluidNC/src/WebUI/WebUIServer.cpp
@@ -49,15 +49,13 @@ namespace {
             std::string response_status,
             std::string total_bytes,
             std::string used_bytes,
-            uint8_t occupation_percent,
-            bool emit_file_array) :
+            uint8_t occupation_percent) :
             root_path(std::move(root)),
             path(std::move(request_path)),
             status(std::move(response_status)),
             total(std::move(total_bytes)),
             used(std::move(used_bytes)),
             percent(occupation_percent),
-            emit_files(emit_file_array),
             encoder([this](const char* s) { pending += s; }) {}
 
         FileListChunkState(const FileListChunkState&) = delete;
@@ -183,8 +181,7 @@ namespace {
             status,
             formatBytes(totalspace),
             formatBytes(usedspace + 1),
-            percent,
-            false);
+            percent);
 
         if (list_files) {
             state->iter       = stdfs::directory_iterator { fpath, stdfs::directory_options::skip_permission_denied, ec };


### PR DESCRIPTION
## Summary

This changes the WebUI file-list and WebDAV PROPFIND responses to stream large directory listings with chunked responses instead of building the whole payload in memory first.

## What changed

- made `JSONencoder::flush()` public so chunked emitters can flush partial output safely
- converted WebUI `handleFileOps()` file listing to a chunked response
- converted WebDAV `PROPFIND` to chunked traversal for both XML and JSON responses
- kept the root `FluidPath` alive for the lifetime of each chunked response so SD-backed iterators do not outlive the mount
- fixed the JSON PROPFIND wrapper so the response is a single valid JSON object

## Why

Large directory listings could consume too much memory, and the first chunked implementation exposed a mount-lifetime bug where the SD card could be unmounted before later iterator steps ran.

## Validation

- `platformio run --environment wifi`
- live WebUI file listing against SD card
- live `PROPFIND /sd` XML response returned all entries
- live `PROPFIND /sd` JSON response returned valid JSON with all entries

Fixes #1720
