### PR TITLE
Use full git commit hash for usb libraries

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -124,8 +124,8 @@ build_flags =
     ; -DBOARD_HAS_PSRAM
     -DMCU=\"esp32s3\"
 lib_deps_usb_host =
-    https://github.com/X-Stuff/usb_host_cdc_acm.git#7c6e0ce
-    https://github.com/APIUM/usb_host_vcp.git#3ceae75
+    https://github.com/X-Stuff/usb_host_cdc_acm.git#7c6e0ce3ad6bf8f51735367ad605bd210f95ce35
+    https://github.com/APIUM/usb_host_vcp.git#3ceae756e35b187052b8bed0f87f48dc62b4b8ba
 debug_tool = esp-builtin
 
 [common_wifi]


### PR DESCRIPTION
Sometimes the build fails because git cannot fetch with the short hashes.