### PR TITLE
Fix #1753. The $HC alias in HttpCommand shadowed $HC for homing

### DIFF
--- a/FluidNC/src/WebUI/HttpCommand.cpp
+++ b/FluidNC/src/WebUI/HttpCommand.cpp
@@ -352,7 +352,7 @@ namespace WebUI {
         explicit HttpCommandModule(const char* name) : Module(name) {}
 
         void init() override {
-            new UserCommand("HC", "HTTP/Command", http_command_handler, http_state_check, WG);
+            new UserCommand("HCMD", "HTTP/Command", http_command_handler, http_state_check, WG);
             new UserCommand("HSL", "HTTP/Settings/Load", http_settings_load_handler, anyState, WA);
             HttpCommand::load_tokens();
             log_info("HTTP command registered");
@@ -368,10 +368,10 @@ namespace WebUI {
 
     Error HttpCommand::execute(const char* value, AuthenticationLevel auth_level, Channel& out) {
         // Check for command substitution (@commandname)
-        std::string command_value = value;
-        if (value && value[0] == '@') {
-            std::string command_name = value + 1;
-            auto        it           = _commands.find(command_name);
+        std::string_view command_value = value ? value : std::string_view();
+        if (!command_value.empty() && command_value[0] == '@') {
+            std::string command_name(command_value.substr(1));
+            auto        it = _commands.find(command_name);
             if (it != _commands.end()) {
                 command_value = it->second;
                 log_debug("HTTP: Substituting command @" << command_name);
@@ -384,7 +384,7 @@ namespace WebUI {
         // Parse command first so we can check fail_on_error
         std::string url;
         std::string json_options;
-        if (!parse_command(command_value.c_str(), url, json_options)) {
+        if (!parse_command(command_value, url, json_options)) {
             log_error_to(out, "HTTP: Invalid command format. Use: $HTTP/COMMAND=url or $HTTP/COMMAND=url{json}");
             return Error::InvalidStatement;  // Syntax errors always fail
         }
@@ -449,67 +449,66 @@ namespace WebUI {
     // Command parsing
     // ============================================================================
 
-    bool HttpCommand::parse_command(const char* value, std::string& url, std::string& json_options) {
+    bool HttpCommand::parse_command(std::string_view value, std::string& url, std::string& json_options) {
         // Format: url{json} or url
         // Note: ${...} is a token substitution pattern, NOT JSON start
-        if (!value || *value == '\0') {
+        if (value.empty()) {
             return false;
         }
 
         // Find the start of JSON options (if any)
         // Skip ${...} patterns - JSON starts with { that is NOT preceded by $
-        const char* json_start = nullptr;
-        const char* p          = value;
-        while (*p) {
-            if (*p == '{') {
-                // Check if this is a token pattern (preceded by $)
-                if (p > value && *(p - 1) == '$') {
-                    // This is ${...}, skip to the closing }
-                    p++;
-                    while (*p && *p != '}') {
-                        p++;
-                    }
-                    if (*p == '}') {
-                        p++;
-                    }
-                    continue;
+    std::string_view data = value;
+    size_t           json_pos = std::string_view::npos;
+    size_t           pos      = 0;
+    while (pos < data.size()) {
+        if (data[pos] == '{') {
+            // Check if this is a token pattern (preceded by $)
+            if (pos > 0 && data[pos - 1] == '$') {
+                // This is ${...}, skip to the closing }
+                pos++;
+                while (pos < data.size() && data[pos] != '}') {
+                    pos++;
                 }
-                // This is the start of JSON options
-                json_start = p;
-                break;
-            }
-            p++;
-        }
-
-        if (json_start) {
-            // URL is everything before the '{'
-            url = std::string(value, json_start - value);
-
-            // JSON is everything from '{' to matching '}'
-            int brace_count = 1;
-            p               = json_start + 1;
-
-            while (*p && brace_count > 0) {
-                if (*p == '{') {
-                    brace_count++;
-                } else if (*p == '}') {
-                    brace_count--;
+                if (pos < data.size() && data[pos] == '}') {
+                    pos++;
                 }
-                p++;
+                continue;
             }
-
-            if (brace_count != 0) {
-                return false;  // Unbalanced braces
-            }
-
-            json_options = std::string(json_start, p - json_start);
-        } else {
-            url = value;
-            json_options.clear();
+            // This is the start of JSON options
+            json_pos = pos;
+            break;
         }
-
-        return !url.empty();
+        pos++;
     }
+
+    if (json_pos != std::string_view::npos) {
+        // URL is everything before the '{'
+        url.assign(data.substr(0, json_pos));
+
+        // JSON is everything from '{' to matching '}'
+        int  brace_count = 1;
+        pos              = json_pos + 1;
+        while (pos < data.size() && brace_count > 0) {
+            if (data[pos] == '{') {
+                brace_count++;
+            } else if (data[pos] == '}') {
+                brace_count--;
+            }
+            pos++;
+        }
+
+        if (brace_count != 0) {
+            return false;  // Unbalanced braces
+        }
+
+        json_options.assign(data.substr(json_pos, pos - json_pos));
+    } else {
+        url.assign(data);
+    }
+
+    return !url.empty();
+}
 
     // ============================================================================
     // JSON parsing using streaming parser

--- a/FluidNC/src/WebUI/HttpCommand.cpp
+++ b/FluidNC/src/WebUI/HttpCommand.cpp
@@ -505,6 +505,7 @@ namespace WebUI {
         json_options.assign(data.substr(json_pos, pos - json_pos));
     } else {
         url.assign(data);
+        json_options.clear();
     }
 
     return !url.empty();

--- a/FluidNC/src/WebUI/HttpCommand.cpp
+++ b/FluidNC/src/WebUI/HttpCommand.cpp
@@ -458,58 +458,58 @@ namespace WebUI {
 
         // Find the start of JSON options (if any)
         // Skip ${...} patterns - JSON starts with { that is NOT preceded by $
-    std::string_view data = value;
-    size_t           json_pos = std::string_view::npos;
-    size_t           pos      = 0;
-    while (pos < data.size()) {
-        if (data[pos] == '{') {
-            // Check if this is a token pattern (preceded by $)
-            if (pos > 0 && data[pos - 1] == '$') {
-                // This is ${...}, skip to the closing }
-                pos++;
-                while (pos < data.size() && data[pos] != '}') {
-                    pos++;
-                }
-                if (pos < data.size() && data[pos] == '}') {
-                    pos++;
-                }
-                continue;
-            }
-            // This is the start of JSON options
-            json_pos = pos;
-            break;
-        }
-        pos++;
-    }
-
-    if (json_pos != std::string_view::npos) {
-        // URL is everything before the '{'
-        url.assign(data.substr(0, json_pos));
-
-        // JSON is everything from '{' to matching '}'
-        int  brace_count = 1;
-        pos              = json_pos + 1;
-        while (pos < data.size() && brace_count > 0) {
+        std::string_view data     = value;
+        size_t           json_pos = std::string_view::npos;
+        size_t           pos      = 0;
+        while (pos < data.size()) {
             if (data[pos] == '{') {
-                brace_count++;
-            } else if (data[pos] == '}') {
-                brace_count--;
+                // Check if this is a token pattern (preceded by $)
+                if (pos > 0 && data[pos - 1] == '$') {
+                    // This is ${...}, skip to the closing }
+                    pos++;
+                    while (pos < data.size() && data[pos] != '}') {
+                        pos++;
+                    }
+                    if (pos < data.size() && data[pos] == '}') {
+                        pos++;
+                    }
+                    continue;
+                }
+                // This is the start of JSON options
+                json_pos = pos;
+                break;
             }
             pos++;
         }
 
-        if (brace_count != 0) {
-            return false;  // Unbalanced braces
+        if (json_pos != std::string_view::npos) {
+            // URL is everything before the '{'
+            url.assign(data.substr(0, json_pos));
+
+            // JSON is everything from '{' to matching '}'
+            int brace_count = 1;
+            pos             = json_pos + 1;
+            while (pos < data.size() && brace_count > 0) {
+                if (data[pos] == '{') {
+                    brace_count++;
+                } else if (data[pos] == '}') {
+                    brace_count--;
+                }
+                pos++;
+            }
+
+            if (brace_count != 0) {
+                return false;  // Unbalanced braces
+            }
+
+            json_options.assign(data.substr(json_pos, pos - json_pos));
+        } else {
+            url.assign(data);
+            json_options.clear();
         }
 
-        json_options.assign(data.substr(json_pos, pos - json_pos));
-    } else {
-        url.assign(data);
-        json_options.clear();
+        return !url.empty();
     }
-
-    return !url.empty();
-}
 
     // ============================================================================
     // JSON parsing using streaming parser

--- a/FluidNC/src/WebUI/HttpCommand.cpp
+++ b/FluidNC/src/WebUI/HttpCommand.cpp
@@ -69,6 +69,7 @@
 //   - HTTPS certificates are not validated
 
 #include "HttpCommand.h"
+#include "HttpCommandParser.h"
 
 #include "System.h"
 #include "Protocol.h"
@@ -450,65 +451,7 @@ namespace WebUI {
     // ============================================================================
 
     bool HttpCommand::parse_command(std::string_view value, std::string& url, std::string& json_options) {
-        // Format: url{json} or url
-        // Note: ${...} is a token substitution pattern, NOT JSON start
-        if (value.empty()) {
-            return false;
-        }
-
-        // Find the start of JSON options (if any)
-        // Skip ${...} patterns - JSON starts with { that is NOT preceded by $
-        std::string_view data     = value;
-        size_t           json_pos = std::string_view::npos;
-        size_t           pos      = 0;
-        while (pos < data.size()) {
-            if (data[pos] == '{') {
-                // Check if this is a token pattern (preceded by $)
-                if (pos > 0 && data[pos - 1] == '$') {
-                    // This is ${...}, skip to the closing }
-                    pos++;
-                    while (pos < data.size() && data[pos] != '}') {
-                        pos++;
-                    }
-                    if (pos < data.size() && data[pos] == '}') {
-                        pos++;
-                    }
-                    continue;
-                }
-                // This is the start of JSON options
-                json_pos = pos;
-                break;
-            }
-            pos++;
-        }
-
-        if (json_pos != std::string_view::npos) {
-            // URL is everything before the '{'
-            url.assign(data.substr(0, json_pos));
-
-            // JSON is everything from '{' to matching '}'
-            int brace_count = 1;
-            pos             = json_pos + 1;
-            while (pos < data.size() && brace_count > 0) {
-                if (data[pos] == '{') {
-                    brace_count++;
-                } else if (data[pos] == '}') {
-                    brace_count--;
-                }
-                pos++;
-            }
-
-            if (brace_count != 0) {
-                return false;  // Unbalanced braces
-            }
-
-            json_options.assign(data.substr(json_pos, pos - json_pos));
-        } else {
-            url.assign(data);
-            json_options.clear();
-        }
-
-        return !url.empty();
+        return parse_http_command(value, url, json_options);
     }
 
     // ============================================================================

--- a/FluidNC/src/WebUI/HttpCommand.h
+++ b/FluidNC/src/WebUI/HttpCommand.h
@@ -9,6 +9,7 @@
 #include <JsonListener.h>
 #include <JsonStreamingParser.h>
 #include <string>
+#include <string_view>
 #include <map>
 
 namespace WebUI {
@@ -125,7 +126,7 @@ namespace WebUI {
 
     private:
         // Parse the command string into URL and JSON options
-        static bool parse_command(const char* value, std::string& url, std::string& json_options);
+        static bool parse_command(std::string_view value, std::string& url, std::string& json_options);
 
         // Parse JSON options into HttpRequest struct using streaming parser
         static bool parse_json_options(const std::string& json, HttpRequest& request);

--- a/FluidNC/src/WebUI/HttpCommandParser.cpp
+++ b/FluidNC/src/WebUI/HttpCommandParser.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 - FluidNC Contributors
+// Use of this source code be governed by a GPLv3 license that can be found in the LICENSE file.
+
+#include "HttpCommandParser.h"
+
+namespace WebUI {
+
+bool parse_http_command(std::string_view value, std::string& url, std::string& json_options) {
+    if (value.empty()) {
+        return false;
+    }
+
+    size_t pos = 0;
+    size_t json_pos = std::string_view::npos;
+    bool in_string = false;
+    bool escape = false;
+
+    while (pos < value.size()) {
+        char c = value[pos];
+
+        if (in_string) {
+            if (escape) {
+                escape = false;
+            } else if (c == '\\') {
+                escape = true;
+            } else if (c == '"') {
+                in_string = false;
+            }
+            pos++;
+            continue;
+        }
+
+        if (c == '$' && pos + 1 < value.size() && value[pos + 1] == '{') {
+            pos += 2;
+            while (pos < value.size() && value[pos] != '}') {
+                pos++;
+            }
+            if (pos < value.size() && value[pos] == '}') {
+                pos++;
+            }
+            continue;
+        }
+
+        if (c == '"') {
+            in_string = true;
+            pos++;
+            continue;
+        }
+
+        if (c == '{') {
+            json_pos = pos;
+            break;
+        }
+
+        pos++;
+    }
+
+    if (json_pos == std::string_view::npos) {
+        url.assign(value);
+        json_options.clear();
+        return !url.empty();
+    }
+
+    if (json_pos == 0) {
+        return false;
+    }
+
+    url.assign(value.substr(0, json_pos));
+
+    int brace_count = 1;
+    pos = json_pos + 1;
+    in_string = false;
+    escape = false;
+
+    while (pos < value.size() && brace_count > 0) {
+        char c = value[pos];
+
+        if (in_string) {
+            if (escape) {
+                escape = false;
+            } else if (c == '\\') {
+                escape = true;
+            } else if (c == '"') {
+                in_string = false;
+            }
+            pos++;
+            continue;
+        }
+
+        if (c == '"') {
+            in_string = true;
+        } else if (c == '{') {
+            brace_count++;
+        } else if (c == '}') {
+            brace_count--;
+        }
+        pos++;
+    }
+
+    if (brace_count != 0) {
+        return false;
+    }
+
+    json_options.assign(value.substr(json_pos, pos - json_pos));
+    return !url.empty();
+}
+
+}  // namespace WebUI

--- a/FluidNC/src/WebUI/HttpCommandParser.h
+++ b/FluidNC/src/WebUI/HttpCommandParser.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 - FluidNC Contributors
+// Use of this source code be governed by a GPLv3 license that can be found in the LICENSE file.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace WebUI {
+
+// Parse an HTTP command string of the form:
+//   url
+//   url{json_options}
+// Token substitution patterns like ${...} are skipped when searching for the JSON block.
+bool parse_http_command(std::string_view value, std::string& url, std::string& json_options);
+
+}  // namespace WebUI

--- a/platformio.ini
+++ b/platformio.ini
@@ -275,6 +275,7 @@ build_src_filter =
     +<Parameters.cpp>
     +<Expression.cpp>
     +<Pins/PinOptionsParser.cpp>
+    +<WebUI/HttpCommandParser.cpp>
     +<string_util.cpp>
     +<UTF8.cpp>
     +<Regexpr.cpp>


### PR DESCRIPTION
Also, the HTTP command value handling code was clumsy and crashed on an empty value, so I improved it.