### PR TITLE
Support shared-address TMC2209 drivers

### DIFF
--- a/FluidNC/src/Motors/TMC2209Driver.cpp
+++ b/FluidNC/src/Motors/TMC2209Driver.cpp
@@ -19,8 +19,18 @@ namespace MotorDrivers {
     }
 
     TMC2209UartSettings TMC2209Driver::uartSettings() const {
-        return { _r_sense,       _run_current,      _hold_current,   _homing_current, _microsteps,    _run_mode,
-                 _homing_mode,   _stallguard,       _toff_disable,   _toff_stealthchop, _toff_coolstep, _use_enable };
+        return { tmc2209EffectiveRSense(_r_sense, TMC2209_RSENSE_DEFAULT),
+                 _run_current,
+                 _hold_current,
+                 _homing_current,
+                 _microsteps,
+                 _run_mode,
+                 _homing_mode,
+                 _stallguard,
+                 _toff_disable,
+                 _toff_stealthchop,
+                 _toff_coolstep,
+                 _use_enable };
     }
 
     void TMC2209Driver::validate() {

--- a/FluidNC/src/Motors/TMC2209Driver.cpp
+++ b/FluidNC/src/Motors/TMC2209Driver.cpp
@@ -10,6 +10,39 @@
 #include <atomic>
 
 namespace MotorDrivers {
+    std::vector<TMC2209Driver*> TMC2209Driver::_tmc2209_instances;
+
+    bool TMC2209Driver::sameUartAddress(const TMC2209Driver& other) const {
+        TMC2209UartEndpoint endpoint { _uart_num, _addr, !_cs_pin.undefined() };
+        TMC2209UartEndpoint other_endpoint { other._uart_num, other._addr, !other._cs_pin.undefined() };
+        return endpoint.sharesUnselectedAddress(other_endpoint);
+    }
+
+    TMC2209UartSettings TMC2209Driver::uartSettings() const {
+        return { _r_sense,       _run_current,      _hold_current,   _homing_current, _microsteps,    _run_mode,
+                 _homing_mode,   _stallguard,       _toff_disable,   _toff_stealthchop, _toff_coolstep, _use_enable };
+    }
+
+    void TMC2209Driver::validate() {
+        TrinamicUartDriver::validate();
+        if (tmc2209RequiresReadback(_shared_address_write_only)) {
+            return;
+        }
+
+        Assert(_cs_pin.undefined(), "shared_address_write_only requires cs_pin: NO_PIN");
+        Assert(!_stallguardDebugMode, "shared_address_write_only does not support stallguard_debug");
+
+        for (auto* other : _tmc2209_instances) {
+            if (other == this || !sameUartAddress(*other)) {
+                continue;
+            }
+            Assert(other->_shared_address_write_only,
+                   "TMC2209 UART%d address %d is shared; all drivers at that address must set shared_address_write_only: true", _uart_num,
+                   _addr);
+            const char* mismatch = uartSettings().mismatch(other->uartSettings());
+            Assert(!mismatch, "TMC2209 UART%d address %d shared-address setting conflict: %s", _uart_num, _addr, mismatch);
+        }
+    }
 
     void TMC2209Driver::init() {
         TrinamicUartDriver::init();
@@ -78,20 +111,24 @@ namespace MotorDrivers {
             }
         }
 
-        // dump the registers. This is helpful for people migrating to the Pro version
-        log_verbose("CHOPCONF: " << to_hex(tmc2209->CHOPCONF()));
-        log_verbose("COOLCONF: " << to_hex(tmc2209->COOLCONF()));
-        log_verbose("TPWMTHRS: " << to_hex(tmc2209->TPWMTHRS()));
-        log_verbose("TCOOLTHRS: " << to_hex(tmc2209->TCOOLTHRS()));
-        log_verbose("GCONF: " << to_hex(tmc2209->GCONF()));
-        log_verbose("PWMCONF: " << to_hex(tmc2209->PWMCONF()));
-        log_verbose("IHOLD_IRUN: " << to_hex(tmc2209->IHOLD_IRUN()));
+        // Most TMCStepper setters above use local shadow registers and are
+        // write-only.  Several getters below read the device, so omit the dump
+        // when duplicate responders make readback electrically ambiguous.
+        if (tmc2209RequiresReadback(_shared_address_write_only)) {
+            log_verbose("CHOPCONF: " << to_hex(tmc2209->CHOPCONF()));
+            log_verbose("COOLCONF: " << to_hex(tmc2209->COOLCONF()));
+            log_verbose("TPWMTHRS: " << to_hex(tmc2209->TPWMTHRS()));
+            log_verbose("TCOOLTHRS: " << to_hex(tmc2209->TCOOLTHRS()));
+            log_verbose("GCONF: " << to_hex(tmc2209->GCONF()));
+            log_verbose("PWMCONF: " << to_hex(tmc2209->PWMCONF()));
+            log_verbose("IHOLD_IRUN: " << to_hex(tmc2209->IHOLD_IRUN()));
+        }
 
         _cs_pin.synchronousWrite(false);
     }
 
     void TMC2209Driver::debug_message() {
-        if (_has_errors) {
+        if (_has_errors || _shared_address_write_only) {
             return;
         }
 
@@ -123,6 +160,11 @@ namespace MotorDrivers {
     }
 
     bool TMC2209Driver::test() {
+        if (_shared_address_write_only) {
+            log_warn(axisName() << " TMC2209 shared-address write-only mode; UART readback and diagnostics are unavailable");
+            return true;
+        }
+
         _cs_pin.synchronousWrite(true);
         if (!checkVersion(0x21, tmc2209->version())) {
             _cs_pin.synchronousWrite(false);

--- a/FluidNC/src/Motors/TMC2209Driver.h
+++ b/FluidNC/src/Motors/TMC2209Driver.h
@@ -4,10 +4,13 @@
 #pragma once
 
 #include "TrinamicUartDriver.h"
+#include "TMC2209SharedAddress.h"
 #include "Pin.h"
 #include "PinMapper.h"
 
+#include <algorithm>
 #include <cstdint>
+#include <vector>
 
 const float TMC2209_RSENSE_DEFAULT = 0.11f;
 
@@ -15,14 +18,17 @@ namespace MotorDrivers {
 
     class TMC2209Driver : public TrinamicUartDriver {
     public:
-        TMC2209Driver(const char* name) : TrinamicUartDriver(name) {}
+        TMC2209Driver(const char* name) : TrinamicUartDriver(name) { _tmc2209_instances.push_back(this); }
+        ~TMC2209Driver() override {
+            _tmc2209_instances.erase(std::remove(_tmc2209_instances.begin(), _tmc2209_instances.end(), this), _tmc2209_instances.end());
+        }
 
         // Overrides for inherited methods
         void init() override;
         void set_disable(bool disable);
         void config_motor() override;
         void debug_message() override;
-        void validate() override { StandardStepper::validate(); }
+        void validate() override;
 
         void group(Configuration::HandlerBase& handler) override {
             TrinamicUartDriver::group(handler);
@@ -33,6 +39,7 @@ namespace MotorDrivers {
             handler.item("stallguard", _stallguard, 0, 255);
             handler.item("stallguard_debug", _stallguardDebugMode);
             handler.item("toff_coolstep", _toff_coolstep, 2, 15);
+            handler.item("shared_address_write_only", _shared_address_write_only);
         }
 
         void afterParse() override {
@@ -43,9 +50,14 @@ namespace MotorDrivers {
         }
 
     private:
+        static std::vector<TMC2209Driver*> _tmc2209_instances;
+
         TMC2209Stepper* tmc2209 = nullptr;
+        bool            _shared_address_write_only = false;
 
         bool test();
         void set_registers(bool isHoming);
+        bool sameUartAddress(const TMC2209Driver& other) const;
+        TMC2209UartSettings uartSettings() const;
     };
 }

--- a/FluidNC/src/Motors/TMC2209SharedAddress.h
+++ b/FluidNC/src/Motors/TMC2209SharedAddress.h
@@ -3,6 +3,10 @@
 #include <cstdint>
 
 namespace MotorDrivers {
+    constexpr float tmc2209EffectiveRSense(float configured, float default_value) {
+        return configured == 0.0f ? default_value : configured;
+    }
+
     struct TMC2209UartEndpoint {
         int32_t uart_num;
         uint8_t addr;

--- a/FluidNC/src/Motors/TMC2209SharedAddress.h
+++ b/FluidNC/src/Motors/TMC2209SharedAddress.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstdint>
+
+namespace MotorDrivers {
+    struct TMC2209UartEndpoint {
+        int32_t uart_num;
+        uint8_t addr;
+        bool    has_selector;
+
+        constexpr bool sharesUnselectedAddress(const TMC2209UartEndpoint& other) const {
+            return uart_num == other.uart_num && addr == other.addr && !has_selector && !other.has_selector;
+        }
+    };
+
+    constexpr bool tmc2209RequiresReadback(bool shared_address_write_only) { return !shared_address_write_only; }
+
+    // UART-controlled settings that must be identical when several TMC2209s
+    // intentionally share a hardware address.  Motion and limit pins are
+    // deliberately absent: they remain independent per motor.
+    struct TMC2209UartSettings {
+        float    r_sense;
+        float    run_current;
+        float    hold_current;
+        float    homing_current;
+        int32_t  microsteps;
+        uint32_t run_mode;
+        uint32_t homing_mode;
+        int32_t  stallguard;
+        uint8_t  toff_disable;
+        uint8_t  toff_stealthchop;
+        uint8_t  toff_coolstep;
+        bool     use_enable;
+
+        const char* mismatch(const TMC2209UartSettings& other) const {
+#define TMC2209_COMPARE(field) \
+    if (field != other.field)  \
+        return #field
+            TMC2209_COMPARE(r_sense);
+            TMC2209_COMPARE(run_current);
+            TMC2209_COMPARE(hold_current);
+            TMC2209_COMPARE(homing_current);
+            TMC2209_COMPARE(microsteps);
+            TMC2209_COMPARE(run_mode);
+            TMC2209_COMPARE(homing_mode);
+            TMC2209_COMPARE(stallguard);
+            TMC2209_COMPARE(toff_disable);
+            TMC2209_COMPARE(toff_stealthchop);
+            TMC2209_COMPARE(toff_coolstep);
+            TMC2209_COMPARE(use_enable);
+#undef TMC2209_COMPARE
+            return nullptr;
+        }
+    };
+}

--- a/FluidNC/tests/test_unit/TMC2209SharedAddressTest.cpp
+++ b/FluidNC/tests/test_unit/TMC2209SharedAddressTest.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+
+#include "Motors/TMC2209SharedAddress.h"
+
+using MotorDrivers::TMC2209UartSettings;
+using MotorDrivers::TMC2209UartEndpoint;
+
+namespace {
+    TMC2209UartSettings settings() {
+        return { 0.15f, 2.0f, 1.2f, 2.0f, 8, 1, 1, 0, 0, 5, 3, true };
+    }
+}
+
+TEST(TMC2209SharedAddress, CompatibleUartSettingsAreAccepted) {
+    auto first  = settings();
+    auto second = settings();
+    EXPECT_EQ(first.mismatch(second), nullptr);
+}
+
+TEST(TMC2209SharedAddress, SingleDriverRetainsStrictReadbackByDefault) {
+    EXPECT_TRUE(MotorDrivers::tmc2209RequiresReadback(false));
+}
+
+TEST(TMC2209SharedAddress, WriteOnlyMustBeExplicit) {
+    EXPECT_FALSE(MotorDrivers::tmc2209RequiresReadback(true));
+}
+
+TEST(TMC2209SharedAddress, DistinctAddressesAreNotGrouped) {
+    TMC2209UartEndpoint first { 1, 1, false };
+    TMC2209UartEndpoint second { 1, 2, false };
+    EXPECT_FALSE(first.sharesUnselectedAddress(second));
+}
+
+TEST(TMC2209SharedAddress, SameUnselectedAddressIsGrouped) {
+    TMC2209UartEndpoint first { 1, 1, false };
+    TMC2209UartEndpoint second { 1, 1, false };
+    EXPECT_TRUE(first.sharesUnselectedAddress(second));
+}
+
+TEST(TMC2209SharedAddress, ConflictingUartSettingsIdentifyTheField) {
+    auto first       = settings();
+    auto conflicting = settings();
+    conflicting.run_current = 1.5f;
+    EXPECT_STREQ(first.mismatch(conflicting), "run_current");
+}
+
+TEST(TMC2209SharedAddress, IndependentMotionPinsAreNotGroupSettings) {
+    // The settings type intentionally has no step, direction, disable, or
+    // limit pins.  Compatible shared drivers therefore retain independent
+    // per-motor motion wiring.
+    auto first  = settings();
+    auto second = settings();
+    EXPECT_EQ(first.mismatch(second), nullptr);
+}

--- a/FluidNC/tests/test_unit/TMC2209SharedAddressTest.cpp
+++ b/FluidNC/tests/test_unit/TMC2209SharedAddressTest.cpp
@@ -17,6 +17,13 @@ TEST(TMC2209SharedAddress, CompatibleUartSettingsAreAccepted) {
     EXPECT_EQ(first.mismatch(second), nullptr);
 }
 
+TEST(TMC2209SharedAddress, ImplicitAndExplicitDefaultRSenseAreEquivalent) {
+    constexpr float default_r_sense = 0.11f;
+    EXPECT_FLOAT_EQ(MotorDrivers::tmc2209EffectiveRSense(0.0f, default_r_sense),
+                    MotorDrivers::tmc2209EffectiveRSense(default_r_sense, default_r_sense));
+    EXPECT_FLOAT_EQ(MotorDrivers::tmc2209EffectiveRSense(0.15f, default_r_sense), 0.15f);
+}
+
 TEST(TMC2209SharedAddress, SingleDriverRetainsStrictReadbackByDefault) {
     EXPECT_TRUE(MotorDrivers::tmc2209RequiresReadback(false));
 }

--- a/tools/fluidnc-config-schema.json
+++ b/tools/fluidnc-config-schema.json
@@ -762,7 +762,7 @@
         "object",
         "null"
       ],
-      "description": "spec \u00a75.4.6. Only use when the chip's UART is actually wired -- otherwise use stepstick. Individually addressable via addr: 0-3 (hardware MS1/MS2 pins), up to 4 chips per UART bus. homing_amps is TMC2209-SPECIFIC (does not exist on 2130/2208/5160); if left at its default of 0 it is silently set equal to run_amps at parse time. stallguard range here is 0-255, NOT -64 to 63 like every SPI driver type.",
+      "description": "spec \u00a75.4.6. Only use when the chip's UART is actually wired -- otherwise use stepstick. Individually addressable via addr: 0-3 (hardware MS1/MS2 pins), up to 4 independently readable chips per UART bus. Selectorless drivers may share an address only when every member explicitly enables shared_address_write_only and has identical UART-controlled settings. homing_amps is TMC2209-SPECIFIC (does not exist on 2130/2208/5160); if left at its default of 0 it is silently set equal to run_amps at parse time. stallguard range here is 0-255, NOT -64 to 63 like every SPI driver type.",
       "additionalProperties": false,
       "properties": {
         "step_pin": {
@@ -874,6 +874,15 @@
             }
           ],
           "default": false
+        },
+        "shared_address_write_only": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/boolean"
+            }
+          ],
+          "default": false,
+          "description": "Explicitly permits selectorless TMC2209s with the same uart_num and addr to receive identical writes. Every group member must enable it, use cs_pin: NO_PIN, and have identical UART-controlled settings. UART readback and stallguard_debug are unavailable."
         },
         "homing_amps": {
           "type": "number",

--- a/tools/fluidnc-config-spec.md
+++ b/tools/fluidnc-config-spec.md
@@ -398,11 +398,12 @@ tmc_2209:
   stallguard_debug: false
   toff_coolstep: 3
   use_enable: false
+  shared_address_write_only: false # Boolean, default false; see shared-address rule below
 ```
 Rules:
 - **Only use `tmc_2209:` when the chip's UART is actually wired up and being addressed.** A TMC2209 without real UART wiring — whether it's an onboard chip with no UART broken out, or a stepstick module factory-jumpered for standalone mode — must be configured as `stepstick:` (§5.4.2) instead; `tmc_2209:`'s current/microstepping/mode fields do nothing without a working UART link to actually write them to the chip.
 - **`homing_amps` has a real, useful fallback behavior worth knowing:** `TMC2209Driver::afterParse()` explicitly sets `_homing_current = _run_current` whenever `homing_amps` was left at its default of `0`. So omitting `homing_amps` entirely is equivalent to setting it equal to `run_amps` — a reasonable default, but only for this one driver type; don't assume the same fallback applies elsewhere (it doesn't — `homing_amps` doesn't exist as a field on any other TMC type in this document).
-- Unlike TMC2208, TMC2209 chips **are** individually addressable, but only when each chip's hardware address pins (`MS1_AD0`/`MS2_AD1`) are wired to give it a unique `addr:` (0–3) on the shared UART bus — up to 4 chips per UART.
+- Unlike TMC2208, TMC2209 chips **are** individually addressable when each chip's hardware address pins (`MS1_AD0`/`MS2_AD1`) are wired to give it a unique `addr:` (0–3) on the shared UART bus — up to 4 independently readable chips per UART. Multiple selectorless TMC2209s may intentionally use the same `uart_num:` and `addr:` only when every member sets `shared_address_write_only: true`, uses `cs_pin: NO_PIN`, and has identical UART-controlled settings. In that mode, addressed writes configure all responders while version/IFCNT/register readback and live StallGuard diagnostics are unavailable; `stallguard_debug: true` is rejected. Step, direction, disable, and limit pins remain independent per motor. The default `false` preserves strict communication testing.
 - `uart_num:` must reference a `uartN:` top-level section (§0.11 — no ordering requirement, but placing it earlier is still good practice).
 - There is no per-motor nested `uart:` sub-block for TMC2209 (or TMC2208, per the correction in §5.4.4) — always use the external `uart_num:` + top-level `uartN:` section form.
 


### PR DESCRIPTION
## What changed

Add an explicit `shared_address_write_only` option for TMC2209 drivers that intentionally share an unselected `(uart_num, addr)` pair.

When enabled, FluidNC continues to send all addressed configuration, mode, current, microstep, and `toff` writes, but skips version, IFCNT, register-dump, and live StallGuard reads that cannot be reliable when multiple drivers answer simultaneously.

The existing strict communication test remains the default. All selectorless TMC2209 instances sharing an address must opt in and must have identical UART-controlled settings. Conflicts fail configuration with the mismatched field name. Step, direction, disable, and limit pins are deliberately excluded from group compatibility and remain independent per motor.

## Why

The official [MKS TinyBee documentation](http://wiki.fluidnc.com/en/hardware/3rd-party/MKS_TinyBee) says:

> There are 5 drivers on the board, however drivers can share the same address.

A real TinyBee V1.0 MPCNC LowRider uses five TMC2209s on UART1 with an X/Y/Y2/Z/Z2 arrangement. Y and Y2 intentionally share address 1 and have identical UART settings but independent motion and limit pins.

With both configured as `tmc_2209`, v4.0.3 reported `expected 0x21 got 0x0` for Y and Y2 and neither motor moved. Configuring either one as `stepstick` made the remaining address-1 TMC2209 pass and move, isolating the failure to simultaneous read responders.

TMCStepper rejects the collided/ambiguous response and returns zero. FluidNC then sets `_has_errors`, skips register configuration, and rejects subsequent enable operations. The writes themselves are suitable broadcast operations because TMCStepper builds them from local shadow registers and does not require readback.

## Configuration

Both members of an intentional shared-address group opt in:

```yaml
tmc_2209:
  uart_num: 1
  addr: 1
  cs_pin: NO_PIN
  shared_address_write_only: true
```

Readback diagnostics are unavailable in this mode, and `stallguard_debug` is rejected. A warning is emitted during motor initialization rather than claiming a communication test passed.

## Validation

- Rebased onto current `main` (`94e8adbb`).
- Native tests: 313 passed, including strict defaults, distinct addresses, explicit write-only behavior, compatible/conflicting groups, and independent motion pins.
- ESP32 Wi-Fi target builds successfully with TMCStepper 0.7.3.
- Hardware-tested on an MKS TinyBee V1.0 with two TMC2209 Y drivers sharing UART1/address 1: the patched v4.0.3-derived firmware and opt-in configuration restored operation of both Y motors.

The latest-main build was source/test validated but was not flashed to that machine.
