### PR TITLE
Restore missing ESP32 vtable linker script

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -90,6 +90,7 @@ lib_extra_dirs =
 
 [common_esp32]
 extends = common_esp32_base
+extra_scripts =
     FluidNC/ld/esp32/vtable_in_dram.py
 board = esp32dev
 build_src_filter =


### PR DESCRIPTION
Commit c54e59144 removed the `extra_scripts` key from the ESP32 PlatformIO configuration, preventing `vtable_in_dram.py` from running.

Without it, spindle vtables used by `Stepper::pulse_func()` remained in flash and could be accessed while the flash cache was disabled, causing a panic.

This change restores the missing `extra_scripts` declaration for ` common_esp32 `.