### PR TITLE
Fix telnet channel unresponsive after connect (#1776)

### DIFF
--- a/FluidNC/src/WebUI/TelnetClient.cpp
+++ b/FluidNC/src/WebUI/TelnetClient.cpp
@@ -7,6 +7,23 @@
 
 #include <WiFi.h>
 
+#if defined(ESP32)
+// arduino-esp32's NetworkClient never overrides Print::availableForWrite() --
+// it is hard-coded to return 0 ("a single write may block"), so gating sends
+// on it means queued data never gets flushed. Send directly through a
+// non-blocking socket call instead.
+//
+// This is opt-in for ESP32 specifically (rather than opt-out for everything
+// else) because it depends on details of arduino-esp32's NetworkClient --
+// a raw BSD socket fd and lwip/sockets.h. arduino-pico's WiFiClient
+// (RP2040/RP2350) and the POSIX/Arduino-Emulator hosted build have neither,
+// but both *do* implement availableForWrite() correctly, so they use the
+// portable Client-API path below instead.
+#define TELNET_RAW_SOCKET_SEND 1
+#include <lwip/sockets.h>  // ::send(), MSG_DONTWAIT
+#include <errno.h>
+#endif
+
 namespace WebUI {
     TelnetClient::TelnetClient(WiFiClient* wifiClient) : Channel("telnet"), _wifiClient(wifiClient) {
 #if !HOSTED
@@ -19,13 +36,19 @@ namespace WebUI {
 
     void TelnetClient::handle() {}
 
-    void TelnetClient::closeOnDisconnect() {
+    void TelnetClient::closeOnDisconnectLocked() {
         if (!_wifiClient->connected()) {
             bool expected = false;
             if (_disconnected.compare_exchange_strong(expected, true)) {
                 allChannels.kill(this);
             }
         }
+    }
+
+    void TelnetClient::closeOnDisconnect() {
+        xSemaphoreTake(_wifiMutex, portMAX_DELAY);
+        closeOnDisconnectLocked();
+        xSemaphoreGive(_wifiMutex);
     }
 
     void TelnetClient::flushRx() {
@@ -57,27 +80,66 @@ namespace WebUI {
         return true;
     }
 
+    // Attempts to send up to `len` bytes without blocking the polling task.
+    // Returns the number of bytes actually sent (0 if the socket isn't ready
+    // to accept more right now), or -1 if the connection has failed.
+    // Assumes _wifiMutex is already held.
+    int TelnetClient::trySend(const uint8_t* data, size_t len) {
+#ifdef TELNET_RAW_SOCKET_SEND
+        int sockfd = _wifiClient->fd();
+        if (sockfd < 0) {
+            return -1;
+        }
+        int sent = ::send(sockfd, data, len, MSG_DONTWAIT);
+        if (sent >= 0) {
+            return sent;
+        }
+        return (errno == EAGAIN || errno == EWOULDBLOCK) ? 0 : -1;
+#else
+        size_t canSend = _wifiClient->availableForWrite();
+        size_t toSend  = len < canSend ? len : canSend;
+        if (toSend == 0) {
+            return _wifiClient->connected() ? 0 : -1;
+        }
+        size_t sent = _wifiClient->write(data, toSend);
+        if (sent == 0 && !_wifiClient->connected()) {
+            return -1;
+        }
+        return (int)sent;
+#endif
+    }
+
     // Non-blocking drain of the queue. Bytes that can't be sent now stay queued
     // and go out on the next write().
     void TelnetClient::flushQueue() {
+        xSemaphoreTake(_wifiMutex, portMAX_DELAY);
         while (_txTail != _txHead) {
             size_t contiguous = _txHead > _txTail ? _txHead - _txTail : TX_QUEUE_SIZE - _txTail;
-            size_t canSend    = _wifiClient->availableForWrite();
-            size_t toSend     = contiguous < canSend ? contiguous : canSend;
-            if (toSend == 0) {
-                return;  // nothing can be sent right now
-            }
-            size_t sent = _wifiClient->write(_txQueue.data() + _txTail, toSend);
+            int    sent       = trySend(_txQueue.data() + _txTail, contiguous);
             if (sent > 0) {
-                _txTail = (_txTail + sent) % TX_QUEUE_SIZE;
+                _txTail = (_txTail + (size_t)sent) % TX_QUEUE_SIZE;
                 continue;
             }
-            if (!_wifiClient->connected()) {
-                _wifiClient->stop();  // hard error / peer gone
-                closeOnDisconnect();
+            if (sent < 0) {
+                // Hard error (e.g. connection reset) -- disconnect immediately,
+                // independent of the stall counter below.
+                _wifiClient->stop();
+                closeOnDisconnectLocked();
+                xSemaphoreGive(_wifiMutex);
+                return;
             }
-            return;
+            break;  // sent == 0: socket not ready right now
         }
+
+        if (_txTail == _txHead) {
+            _txStallCount = 0;  // fully drained
+        } else if (++_txStallCount >= TX_STALL_LIMIT) {
+            // Connected but not draining what we send it -- wedged peer.
+            // Force it out so the slot can be reused.
+            _wifiClient->stop();
+            closeOnDisconnectLocked();
+        }
+        xSemaphoreGive(_wifiMutex);
     }
 
     void TelnetClient::queueCompletedLine() {
@@ -86,8 +148,10 @@ namespace WebUI {
 
         if (isCriticalLine(_txLine)) {
             if (!queueLine(data, len, 0)) {
+                xSemaphoreTake(_wifiMutex, portMAX_DELAY);
                 _wifiClient->stop();
-                closeOnDisconnect();
+                closeOnDisconnectLocked();
+                xSemaphoreGive(_wifiMutex);
             }
         } else {
             queueLine(data, len, TX_CRITICAL_RESERVE);
@@ -98,7 +162,10 @@ namespace WebUI {
         if (_state == -1 || buffer == nullptr || length == 0) {
             return length;
         }
-        if (_wifiClient->connected()) {
+        xSemaphoreTake(_wifiMutex, portMAX_DELAY);
+        bool isConnected = _wifiClient->connected();
+        xSemaphoreGive(_wifiMutex);
+        if (!isConnected) {
             closeOnDisconnect();
             return length;
         }
@@ -130,14 +197,20 @@ namespace WebUI {
         if (_disconnected.load()) {
             return -1;
         }
-        return _wifiClient->peek();
+        xSemaphoreTake(_wifiMutex, portMAX_DELAY);
+        int ret = _wifiClient->peek();
+        xSemaphoreGive(_wifiMutex);
+        return ret;
     }
 
     int TelnetClient::available() {
         if (_disconnected.load()) {
             return 0;
         }
-        return _wifiClient->available();
+        xSemaphoreTake(_wifiMutex, portMAX_DELAY);
+        int ret = _wifiClient->available();
+        xSemaphoreGive(_wifiMutex);
+        return ret;
     }
 
     int TelnetClient::rx_buffer_available() {
@@ -149,6 +222,7 @@ namespace WebUI {
             return -1;
         }
 
+        xSemaphoreTake(_wifiMutex, portMAX_DELAY);
         auto ret = _wifiClient->read();
         if (ret < 0) {
             // calling _wifiClient->connected() is expensive when the client is
@@ -156,14 +230,13 @@ namespace WebUI {
             // infrequently, only after quite a few reads have returned no data
             if (++_empty_reads >= DISCONNECT_CHECK_COUNTS) {
                 _empty_reads = 0;
-                if (!_wifiClient->connected()) {
-                    closeOnDisconnect();
-                }
+                closeOnDisconnectLocked();
             }
         } else {
             // Reset the counter if we have data
             _empty_reads = 0;
         }
+        xSemaphoreGive(_wifiMutex);
         return ret;
     }
 

--- a/FluidNC/src/WebUI/TelnetClient.cpp
+++ b/FluidNC/src/WebUI/TelnetClient.cpp
@@ -80,7 +80,7 @@ namespace WebUI {
         return true;
     }
 
-    // Attempts to send up to `len` bytes without blocking the polling task.
+    // Attempts to send up to `len` bytes without blocking.
     // Returns the number of bytes actually sent (0 if the socket isn't ready
     // to accept more right now), or -1 if the connection has failed.
     // Assumes _wifiMutex is already held.
@@ -242,5 +242,6 @@ namespace WebUI {
 
     TelnetClient::~TelnetClient() {
         delete _wifiClient;
+        vSemaphoreDelete(_wifiMutex);
     }
 }

--- a/FluidNC/src/WebUI/TelnetClient.h
+++ b/FluidNC/src/WebUI/TelnetClient.h
@@ -49,8 +49,8 @@ namespace WebUI {
         // critical-line disconnect. Count consecutive flushQueue() calls that
         // fail to fully drain the backlog and force the client out once it's
         // wedged for TX_STALL_LIMIT of them in a row, freeing the slot.
-        static const int TX_STALL_LIMIT = 10;
-        int              _txStallCount  = 0;
+        static constexpr int TX_STALL_LIMIT = 10;
+        int                  _txStallCount  = 0;
 
         int32_t     _state = 0;
         std::string _txLine;             // output accumulated until a full line

--- a/FluidNC/src/WebUI/TelnetClient.h
+++ b/FluidNC/src/WebUI/TelnetClient.h
@@ -29,10 +29,28 @@ namespace WebUI {
         std::atomic<bool> _disconnected { false };
         int32_t           _empty_reads = 0;
 
+        // Guards all access to _wifiClient. write()/flushQueue() run on the
+        // output task while read()/peek()/available()/closeOnDisconnect() run
+        // on the polling task; WiFiClient has no internal locking of its own,
+        // so without this a stop() on one task could race a fd()/send() (or
+        // similar) on the other and hit a socket fd that has already been
+        // closed and reissued to an unrelated connection.
+        mutable SemaphoreHandle_t _wifiMutex = xSemaphoreCreateMutex();
+
         // Outgoing telnet bytes are buffered as whole lines in this ring,
         // momentarilly full socket shall never truncates a line or drop an ack.
         static constexpr size_t TX_QUEUE_SIZE       = 2304;
         static constexpr size_t TX_CRITICAL_RESERVE = 256;
+
+        // A TCP peer can stay "connected" (no FIN/RST) while no longer
+        // draining what we send it -- a frozen terminal, a dead network path,
+        // a zero TCP window. That alone doesn't fill the ring buffer's
+        // TX_CRITICAL_RESERVE headroom, so it isn't caught by queueLine()'s
+        // critical-line disconnect. Count consecutive flushQueue() calls that
+        // fail to fully drain the backlog and force the client out once it's
+        // wedged for TX_STALL_LIMIT of them in a row, freeing the slot.
+        static const int TX_STALL_LIMIT = 10;
+        int              _txStallCount  = 0;
 
         int32_t     _state = 0;
         std::string _txLine;             // output accumulated until a full line
@@ -45,8 +63,12 @@ namespace WebUI {
         static bool isCriticalLine(const std::string& line);
         size_t      queueFree() const;
         bool        queueLine(const uint8_t* data, size_t len, size_t reserve);
+        int         trySend(const uint8_t* data, size_t len);
         void        flushQueue();
         void        queueCompletedLine();
+
+        // Core of closeOnDisconnect(), assumes _wifiMutex is already held.
+        void closeOnDisconnectLocked();
 
     public:
         TelnetClient(WiFiClient* wifiClient);

--- a/git-version.py
+++ b/git-version.py
@@ -23,11 +23,18 @@ else:
     except:
         tag = "v4.x.x"
 
+    modified = (
+        subprocess.check_output(["git", "status", "-uno", "-s"])
+        .strip()
+        .decode("utf-8")
+    )
+    dirty = "-dirty" if modified else ""
+
     # Check to see if the head commit exactly matches a tag.
     # If so, the revision is "release", otherwise it is BRANCH-COMMIT
     try:
         subprocess.check_call(["git", "describe", "--tags", "--exact"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        rev = ''
+        rev = dirty
     except:
         branchname = (
             subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
@@ -39,15 +46,6 @@ else:
             .strip()
             .decode("utf-8")
         )
-        modified = (
-            subprocess.check_output(["git", "status", "-uno", "-s"])
-            .strip()
-            .decode("utf-8")
-        )
-        if modified:
-            dirty = "-dirty"
-        else:
-            dirty = ""
         rev = " (%s-%s%s)" % (branchname, revision, dirty)
 
     try:


### PR DESCRIPTION
## Summary
Fixes #1776 — telnet clients could connect but got no response to either
line-oriented or realtime (`?`) commands.

Two bugs combined to cause this in `TelnetClient::write()`/`flushQueue()`:
- `write()` had an inverted `connected()` check, so it bailed out on every
  call while the client was actually connected (the normal case).
- `flushQueue()` gated sends on `WiFiClient::availableForWrite()`, which
  arduino-esp32's `NetworkClient` never overrides (hard-coded to return 0),
  so queued output never drained even once the first bug was fixed.

## Changes
- Send directly through a non-blocking socket call (`::send(..., MSG_DONTWAIT)`)
  on ESP32, gated behind `#if defined(ESP32)` specifically (not an
  exclusion-based `#ifdef`), since it depends on arduino-esp32's raw BSD
  socket fd and `lwip/sockets.h`. RP2040/RP2350 (arduino-pico) and the
  POSIX/Arduino-Emulator hosted build have neither, but their
  `availableForWrite()` is correctly implemented, so they keep using that
  portable path.
- Added a mutex around all `WiFiClient` access: the write path (output
  task) and read path (polling task) touch the same `WiFiClient` object
  concurrently with no locking of their own, which could otherwise race a
  `stop()` against an in-flight `fd()`/`send()` and hit a socket fd already
  reissued to an unrelated connection.
- Ported the stall-detection/reap idea from #1742 (unmerged, predates this
  fix): count consecutive `flushQueue()` calls that fail to fully drain the
  backlog, and force-disconnect a client that stays wedged
  (`TX_STALL_LIMIT`, 10 in a row) so a TCP-alive-but-non-draining peer
  (frozen terminal, dead network path, zero TCP window) doesn't occupy the
  channel slot forever. Implemented inside the existing non-blocking
  ring-buffer design rather than #1742's blocking `delay()`-based retry
  loop, to avoid reintroducing blocking into the output task.

## Test plan
- [x] Builds clean: `wifi_s3`, `rp2040_wifi`, `rp2350_wifi`, `macos` (posix
      hosted)
- [x] Manual telnet test against real ESP32-S3 hardware: connect, verify
      line commands and `?` get responses
- [ ] Manual test of a wedged/frozen telnet client eventually getting
      disconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)