### PR TITLE
Fix Telnet output after Portability merge

### DIFF
--- a/FluidNC/src/WebUI/TelnetClient.cpp
+++ b/FluidNC/src/WebUI/TelnetClient.cpp
@@ -7,6 +7,11 @@
 
 #include <WiFi.h>
 
+#ifdef ARDUINO_ARCH_ESP32
+#    include <errno.h>
+#    include <lwip/sockets.h>
+#endif
+
 namespace WebUI {
     TelnetClient::TelnetClient(WiFiClient* wifiClient) : Channel("telnet"), _wifiClient(wifiClient) {
 #if !HOSTED
@@ -62,6 +67,24 @@ namespace WebUI {
     void TelnetClient::flushQueue() {
         while (_txTail != _txHead) {
             size_t contiguous = _txHead > _txTail ? _txHead - _txTail : TX_QUEUE_SIZE - _txTail;
+#ifdef ARDUINO_ARCH_ESP32
+            int sockfd = _wifiClient->fd();
+            if (sockfd < 0) {
+                closeOnDisconnect();
+                return;
+            }
+            int sent = ::send(sockfd, _txQueue.data() + _txTail, contiguous, MSG_DONTWAIT);
+            if (sent > 0) {
+                _txTail = (_txTail + (size_t)sent) % TX_QUEUE_SIZE;
+                continue;
+            }
+            if (sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                return;
+            }
+            _wifiClient->stop();
+            closeOnDisconnect();
+            return;
+#else
             size_t canSend    = _wifiClient->availableForWrite();
             size_t toSend     = contiguous < canSend ? contiguous : canSend;
             if (toSend == 0) {
@@ -77,6 +100,7 @@ namespace WebUI {
                 closeOnDisconnect();
             }
             return;
+#endif
         }
     }
 
@@ -98,7 +122,7 @@ namespace WebUI {
         if (_state == -1 || buffer == nullptr || length == 0) {
             return length;
         }
-        if (_wifiClient->connected()) {
+        if (!_wifiClient->connected()) {
             closeOnDisconnect();
             return length;
         }


### PR DESCRIPTION
Two issues were introduced in `TelnetClient` from the Portability branch that prevented Telnet from sending responses:

- The `connected()` check was inverted, causing writes to return early for connected clients.
- `availableForWrite()` always returns `0` for ESP32 `WiFiClient`, so the transmit queue never drained.

ESP32 now uses non-blocking socket writes again. The existing Arduino path remains in place for RP2040/RP2350.

This fixes G-code senders and FluidDial repeatedly disconnecting when using Telnet.