### PR TITLE
Restore FatFs SD usage statistics

### DIFF
--- a/FluidNC/src/WebUI/WebUIServer.cpp
+++ b/FluidNC/src/WebUI/WebUIServer.cpp
@@ -189,7 +189,7 @@ namespace {
             path,
             status,
             formatBytes(totalspace),
-            formatBytes(usedspace + 1),
+            formatBytes(usedspace),
             percent);
 
         if (list_files) {

--- a/FluidNC/stdfs/fluidnc_vfs_ops.cpp
+++ b/FluidNC/stdfs/fluidnc_vfs_ops.cpp
@@ -19,7 +19,6 @@ bool isLittleFS(const std::string_view mountpoint) {
 // cppcheck-suppress unusedFunction
 bool fluidnc_vfs_stats(const std::string_view mountpoint, uint64_t& total, uint64_t& used) {
     if (isSD(mountpoint)) {
-#if 0
         FATFS* fsinfo;
         DWORD  fre_clust;
         if (f_getfree("0:", &fre_clust, &fsinfo) != 0) {
@@ -30,7 +29,6 @@ bool fluidnc_vfs_stats(const std::string_view mountpoint, uint64_t& total, uint6
 
         total = clsize * total_cl;
         used  = clsize * (total_cl - fsinfo->free_clst);
-#endif
         return true;
     }
     size_t stotal, sused;

--- a/FluidNC/stdfs17/fluidnc_vfs_ops.cpp
+++ b/FluidNC/stdfs17/fluidnc_vfs_ops.cpp
@@ -19,7 +19,6 @@ bool isLittleFS(const std::string_view mountpoint) {
 // cppcheck-suppress unusedFunction
 bool fluidnc_vfs_stats(const std::string_view mountpoint, uint64_t& total, uint64_t& used) {
     if (isSD(mountpoint)) {
-#if 0
         FATFS* fsinfo;
         DWORD  fre_clust;
         if (f_getfree("0:", &fre_clust, &fsinfo) != 0) {
@@ -30,7 +29,6 @@ bool fluidnc_vfs_stats(const std::string_view mountpoint, uint64_t& total, uint6
 
         total = clsize * total_cl;
         used  = clsize * (total_cl - fsinfo->free_clst);
-#endif
         return true;
     }
     size_t stotal, sused;


### PR DESCRIPTION
The following block was compiled out in `stfds/fluidnc_vfs_ops.cpp` and `stfds17/fluidnc_vfs_ops.cpp`, which caused the available SD storage reported by WebUI server requests to be incorrect in v4.0.4:

```cpp
#if 0
        FATFS* fsinfo;
        DWORD  fre_clust;
        if (f_getfree("0:", &fre_clust, &fsinfo) != 0) {
            return false;
        }
        uint64_t clsize   = fsinfo->csize * fsinfo->ssize;
        uint32_t total_cl = fsinfo->n_fatent - 2;

        total = clsize * total_cl;
        used  = clsize * (total_cl - fsinfo->free_clst);
#endif
```

This PR restores proper SD card space reporting to the WebUI.