### PR TITLE
Add @tuning/@default_note config-item annotations

### DIFF
--- a/FluidNC/docs/config_items.yaml
+++ b/FluidNC/docs/config_items.yaml
@@ -22,7 +22,8 @@
 
   meta:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
     description: |
       Free-form notes about the config file itself, e.g. "B. Dring 2022-03-15 Rev 2".
 
@@ -31,6 +32,7 @@
     min: 0.001
     max: 1.0
     default: '0.002'
+    tuning: typical
     description: |
       Maximum deviation, in mm, allowed when tessellating G2/G3 arcs into straight-line segments. Smaller values produce smoother arcs at the cost of more segments (and therefore more planner/computation work). Rarely changed from the default.
 
@@ -39,30 +41,35 @@
     min: 0.01
     max: 1.0
     default: '0.01'
+    tuning: typical
     description: |
       Controls how aggressively the planner slows down at sharp corners between consecutive moves (the Grbl-style "junction deviation" cornering algorithm). Smaller values force more slowdown at corners; larger values allow faster cornering at the cost of more deviation from the programmed path. Rarely changed from the default -- see the planner source for the full derivation.
 
   verbose_errors:
     type: boolean
     default: 'true'
+    tuning: typical
     description: |
       Includes descriptive text alongside the numeric error code in error responses. Some GCode senders may not parse the extra text correctly.
 
   report_inches:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Reports position and feed rate values in inches instead of millimeters. This only affects reporting, not how input values in the GCode/config are interpreted.
 
   enable_parking_override_control:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Enables the M56 GCode command, which lets a running program toggle the parking- motion override on/off at runtime (M56 P0 disables parking, M56 P1 enables it). This only gates whether M56 has any effect; start.deactivate_parking sets what the override defaults to, and parking.enable is the separate switch for the parking feature existing at all.
 
   use_line_numbers:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, line numbers written into GCode as N<number> (e.g. N100) are tracked and echoed back in status reports as Ln:100, so a report can be correlated with the source line currently being executed. Reports Ln:0 when the GCode has no line number information.
 
@@ -71,6 +78,7 @@
     min: 10
     max: 120
     default: '16'
+    tuning: typical
     description: |
       Number of motion blocks held in the look-ahead planner buffer. Leave at the default unless tuning for a special application.
 
@@ -78,18 +86,21 @@ start:
   must_home:
     type: boolean
     default: 'true'
+    tuning: typical
     description: |
       Refuses to accept motion commands until $H (home) has been run at least once since boot. Jogging and settings commands still work while unhomed.
 
   deactivate_parking:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Sets what the M56 parking-motion override defaults to at boot and after a program ends (only takes effect when enable_parking_override_control is also true): false leaves parking motion active by default; true starts with it disabled until M56 is used to turn it back on.
 
   check_limits:
     type: boolean
     default: 'true'
+    tuning: typical
     description: |
       Checks limit switches at power-up/reset; if hard limits are enabled and a switch is already active, the machine enters Alarm state instead of Idle.
 
@@ -97,7 +108,8 @@ stepping:
   engine:
     type: enum
     values: [Timed, RMT, I2S_STATIC, I2S_STREAM, Simulator, PIO]
-    default: 'board-dependent (DEFAULT_STEPPING_ENGINE, applied in afterParse())'
+    default: '(none)'
+    default_note: 'board-dependent (DEFAULT_STEPPING_ENGINE, applied in afterParse())'
     description: |
       Method used to generate step pulses in firmware. Controller board hardware is designed for either RMT or I2S stepping, so this must match what the board actually wires up -- stepping types cannot be mixed across motors. Choices come from stepTypes[] below.
 
@@ -107,7 +119,9 @@ stepping:
     type: integer
     min: 0
     max: 10000000
-    default: '255 -- special "never auto-disable" value (Grbl compatibility)'
+    default: '255'
+    default_note: 'special "never auto-disable" value (Grbl compatibility)'
+    tuning: typical
     description: |
       Milliseconds of inactivity before motors are automatically disabled. Any value other than 255 (0-254 or 256+) is a real delay. Motors can also be disabled manually at any time with $MD.
 
@@ -116,6 +130,7 @@ stepping:
     min: 0
     max: 30
     default: '4'
+    tuning: typical
     description: |
       Duration, in microseconds, of the "on" part of each step pulse; it typically needs an equal "off" duration, so this caps the max step rate at roughly 1000000/(2*pulse_us + dir_delay_us) steps/sec. Too short a pulse won't be registered by some stepper drivers -- check the driver's datasheet if unsure.
 
@@ -124,6 +139,7 @@ stepping:
     min: 0
     max: 10
     default: '0'
+    tuning: typical
     description: |
       Delay, in microseconds, required between a direction change and the next step pulse. Most drivers don't need this and can leave it at 0.
 
@@ -132,6 +148,7 @@ stepping:
     min: 0
     max: 1000000
     default: '0'
+    tuning: typical
     description: |
       Delay, in microseconds, some motors need between being enabled and being able to take their first step.
 
@@ -161,6 +178,7 @@ coolant:
     min: 0
     max: 10000
     default: '0'
+    tuning: typical
     description: |
       Delay, in milliseconds, after M7/M8 turns a coolant output on, before motion resumes -- gives the coolant device time to actually start flowing. Not applied if that coolant output is already on, and not applied to M9 (turning off).
 
@@ -180,18 +198,21 @@ probe:
   check_mode_start:
     type: boolean
     default: 'true'
+    tuning: typical
     description: |
       Only affects Grbl Check Mode ($C, dry-run parsing with no real motion): while in Check Mode, a probe move reports its position as the move's un-probed target when false, or leaves it at the pre-move start position when true. Has no effect on a real (non-Check-Mode) probe cycle.
 
   hard_stop:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       On a successful probe trigger, stops with an immediate hard stop instead of decelerating -- avoids the extra travel deceleration needs, at the cost of possibly losing steps (and therefore position accuracy) at higher speeds. Useful with fragile probes/bits that could be damaged by the overtravel a normal deceleration needs.
 
   probe_hard_limit:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, the probe pin(s) also act like a hard limit switch during non-probing motion (homing, jog, cycle): triggering it raises an alarm and immediately stops motion, the same as a real hard limit switch would. Guards against accidental probe damage from a collision during ordinary motion, not from the probing move itself.
 
@@ -199,24 +220,28 @@ parking:
   enable:
     type: boolean
     default: 'false'
+    tuning: per-machine
     description: |
       Enables the parking feature: opening the safety door (or sending the SafetyDoor real-time command, 0x84) pulls the parking axis out and retracts it to target_mpos_mm instead of just stopping motion. Also gated by enable_parking_override_control/M56 if that's enabled, and by parking.axis's homing status -- parking never runs before that axis has been homed.
 
   axis:
     type: axis
     default: 'z'
+    tuning: per-machine
     description: |
       Which axis performs the parking retract/return sequence. Typically Z. Homing that axis is required -- parking silently does nothing until it has been homed.
 
   target_mpos_mm:
     type: float
     default: '-5.0'
+    tuning: per-machine
     description: |
       Machine-position target (not affected by any active offset) for the final parking retract move.
 
   rate_mm_per_min:
     type: float
     default: '800.0'
+    tuning: per-machine
     description: |
       Feed rate for the final parking retract move, from the pull-out waypoint to target_mpos_mm.
 
@@ -225,12 +250,14 @@ parking:
     min: 0
     max: 3e38
     default: '5.0'
+    tuning: per-machine
     description: |
       Distance of the initial slow pull-out move, relative to the position where parking started -- done before the spindle stops and the fast retract to target_mpos_mm.
 
   pullout_rate_mm_per_min:
     type: float
     default: '250.0'
+    tuning: per-machine
     description: |
       Feed rate for the initial pull-out move (and the equivalent slow return move when resuming from park).
 
@@ -322,6 +349,7 @@ sdcard:
     min: 400000
     max: 20000000
     default: '8000000'
+    tuning: typical
     description: |
       SPI clock speed used for the SD card. Try a lower value if the card has consistent read/write problems.
 
@@ -460,12 +488,14 @@ uartN:
     min: 2400
     max: 10000000
     default: '115200'
+    tuning: typical
     description: |
-      UART data baud rate.
+      UART data baud rate. What "typical" means here depends heavily on what this bus actually carries -- a TMC2209 UART chain, an RS485/Modbus VFD link, and a uart_channel: pendant/DRO each have their own real conventional rate (commonly 115200, 9600, and a much higher rate respectively), but this one field/default is shared by all of them, so this is only a reasonable single-context starting point, not a universal one -- always verify against what's actually on the bus.
 
   mode:
     type: uart_mode
     default: '8N1'
+    tuning: typical
     description: |
       Data format as a 3-character code: data bits (5-8), parity (N/E/O), stop bits (1/1.5/2) -- e.g. 8N1. Always quote this value in YAML (see the config spec's note on 8E1 being ambiguous with scientific-notation floats to generic YAML parsers).
 
@@ -473,7 +503,8 @@ uartN:
     type: integer
     min: 0
     max: 10000000
-    default: '0 (not configured)'
+    default: '0'
+    default_note: 'not configured'
     description: |
       Baud rate used while this UART is in passthrough mode (e.g. forwarding firmware uploads from FluidTerm). 0 means passthrough is not configured for this UART.
 
@@ -486,13 +517,16 @@ uartN:
 uart_channelN:
   report_interval_ms:
     type: integer
-    default: '0 (off)'
+    default: '0'
+    default_note: 'off'
+    tuning: per-machine
     description: |
       Interval, in milliseconds, at which a status report is proactively pushed to this channel while moving -- useful for driving a DRO without it having to poll. 0 disables proactive reporting. No range is enforced by this item() call itself, but keeping it at 0 or in roughly the 50-5000 range is recommended to avoid overloading the processor with reports.
 
   uart_num:
     type: integer
     default: '0'
+    tuning: per-machine
     description: |
       Which previously-defined top-level uartN: section this channel runs over.
 
@@ -508,6 +542,7 @@ status_outputs:
     min: 100
     max: 5000
     default: '500'
+    tuning: typical
     description: |
       How often, in milliseconds, the output pins are refreshed against current status. Doesn't need to be fast -- an update also happens immediately on every status change regardless of this interval.
 
@@ -582,12 +617,73 @@ ethernet:
     description: |
       SPI clock speed used to talk to the Ethernet controller.
 
+# Lives under FluidNC/esp32/ (an ESP32-specific module), not FluidNC/src/ like every other section here -- the relative path above deliberately escapes SRC to reach it.
+oled:
+  report_interval_ms:
+    type: integer
+    min: 100
+    max: 5000
+    default: '500'
+    tuning: typical
+    description: |
+      Interval, in milliseconds, at which the display's status content (DRO, state, filename/percent) is refreshed.
+
+  i2c_num:
+    type: integer
+    default: '0'
+    tuning: per-machine
+    description: |
+      Which top-level i2cN: bus this display is wired to.
+
+  i2c_address:
+    type: integer
+    default: '0x3c'
+    tuning: per-machine
+    description: |
+      I2C address of the display module. Must match the actual hardware -- common SSD1306 modules use 0x3C or 0x3D.
+
+  width:
+    type: integer
+    default: '64'
+    tuning: per-machine
+    description: |
+      Physical panel width, in pixels. Must match the actual display module -- there's no generic value that works across different panels.
+
+  height:
+    type: integer
+    default: '48'
+    tuning: per-machine
+    description: |
+      Physical panel height, in pixels. Must match the actual display module -- there's no generic value that works across different panels.
+
+  flip:
+    type: boolean
+    default: 'true'
+    tuning: per-machine
+    description: |
+      Rotates the displayed content 180 degrees. Depends on how the panel is physically mounted.
+
+  mirror:
+    type: boolean
+    default: 'false'
+    tuning: per-machine
+    description: |
+      Mirrors the displayed content horizontally. Depends on how the panel is physically mounted.
+
+  radio_delay_ms:
+    type: integer
+    default: '0'
+    tuning: per-machine
+    description: |
+      Delay, in milliseconds, before the display shows radio (WiFi/BT) connection info after boot -- gives the radio hardware time to come up first.
+
 atc_manual:
   safe_z_mpos_mm:
     type: float
     min: -100000
     max: 100000
     default: '50.0'
+    tuning: per-machine
     description: |
       Machine-space Z position safe to travel at without hitting the workpiece or fixtures, used while moving to/from the tool-change and tool-setter locations.
 
@@ -596,6 +692,7 @@ atc_manual:
     min: 1
     max: 10000
     default: '200.0'
+    tuning: per-machine
     description: |
       Feed rate for the initial (fast) probe move onto the electronic tool setter.
 
@@ -604,6 +701,7 @@ atc_manual:
     min: 1
     max: 10000
     default: '80.0'
+    tuning: per-machine
     description: |
       Feed rate for the precise (slow) second probe touch on the electronic tool setter.
 
@@ -622,6 +720,7 @@ atc_manual:
   ets_rapid_z_mpos_mm:
     type: float
     default: '0.0'
+    tuning: per-machine
     description: |
       Z position to rapid to before starting the ETS probe approach, giving clearance above the probe before the slower seek/feed moves begin.
 
@@ -676,6 +775,7 @@ axes:
     min: 1
     max: 5
     default: '2'
+    tuning: typical
     description: |
       Number of approach/pulloff touches performed per axis during a homing sequence. Default of 2 matches Grbl's convention.
 
@@ -685,6 +785,7 @@ axes.<letter>:
     min: 0.001
     max: 100000.0
     default: '80.0'
+    tuning: per-machine
     description: |
       Controller-side step-pulse resolution for this axis -- really "steps per GCode unit," despite the name: in G21 (mm) mode, a one-unit move issues this many step pulses; for a linear (XYZ) axis in G20 (inches) mode, the step count is instead multiplied by 25.4. A rotary (ABC) axis always issues this many pulses per unit, regardless of G20/G21. If using a microstepping driver, this already needs to include the microstep multiplier.
 
@@ -693,6 +794,7 @@ axes.<letter>:
     min: 0.001
     max: 250000.0
     default: '1000.0'
+    tuning: per-machine
     description: |
       Maximum feed rate (rapids and feed moves alike are capped here) for this axis.
 
@@ -701,6 +803,7 @@ axes.<letter>:
     min: 0.001
     max: 100000.0
     default: '25.0'
+    tuning: per-machine
     description: |
       Acceleration used for this axis's motion ramps.
 
@@ -709,12 +812,14 @@ axes.<letter>:
     min: 0.1
     max: 10000000.0
     default: '1000.0'
+    tuning: per-machine
     description: |
       Working length of the axis, measured from its position immediately after homing pull-off. If a second limit switch exists at the far end of travel (for hard limits), make sure this value stays short enough that a soft-limit alarm trips before that second switch would be physically reached.
 
   soft_limits:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, a move that would exceed max_travel_mm is aborted before it starts; jogs are instead constrained to stop at the travel limit rather than alarming. Relies on accurate machine position, so the axis should be homed first -- always home before jogging or running GCode when soft limits are enabled.
 
@@ -730,6 +835,7 @@ axes.<letter>.homing:
     min: set_mpos_only
     max: MAX_N_AXIS
     default: '0'
+    tuning: per-machine
     description: |
       Which $H (home-all) pass this axis homes in. -1 (set_mpos_only): the axis doesn't move at all -- mpos_mm is just assigned directly, for an axis with no home switch. 0 (the default): excluded from $H, but still homeable individually with $H<axis> (as long as allow_single_axis stays true). 1 or higher: homes as part of $H; axes sharing the same cycle number home simultaneously in that pass (not usable with CoreXY kinematics, since it drives two motors per logical axis move). Typical convention: Z alone on cycle 1, then X/Y together on cycle 2.
 
@@ -742,12 +848,14 @@ axes.<letter>.homing:
   positive_direction:
     type: boolean
     default: 'true'
+    tuning: per-machine
     description: |
       Direction this axis moves while homing: true moves toward higher position values, false toward lower.
 
   mpos_mm:
     type: float
     default: '0.0'
+    tuning: per-machine
     description: |
       Machine position assigned to this axis once homing (and pull-off) completes. Set to 0 if the switch location should read as machine-position zero. No range is enforced by this item() call -- it accepts any float.
 
@@ -756,6 +864,7 @@ axes.<letter>.homing:
     min: 1.0
     max: 100000.0
     default: '50.0'
+    tuning: typical
     description: |
       Feed rate for the second (precise) touch of the limit switch, after the initial fast approach and pull-off. Usually slow, since the axis is already close to the switch -- a slower second touch tends to be more precise and consistent.
 
@@ -764,6 +873,7 @@ axes.<letter>.homing:
     min: 1.0
     max: 100000.0
     default: '200.0'
+    tuning: typical
     description: |
       Feed rate for the initial fast approach that finds the limit switch's rough position, before pulling off and re-touching at feed_mm_per_min for precision.
 
@@ -772,6 +882,7 @@ axes.<letter>.homing:
     min: 0
     max: 1000
     default: '250'
+    tuning: typical
     description: |
       Pause, in milliseconds, between homing cycles to let the machine settle mechanically after the previous cycle's motion.
 
@@ -780,6 +891,7 @@ axes.<letter>.homing:
     min: 1.0
     max: 100.0
     default: '1.1'
+    tuning: typical
     description: |
       Multiplied by max_travel_mm to get the maximum distance the initial seek move will travel before failing if it hasn't yet reached the limit switch -- needs to be a bit over 1.0 to allow for the extra distance a prior pull-off adds.
 
@@ -788,6 +900,7 @@ axes.<letter>.homing:
     min: 1.0
     max: 100.0
     default: '1.1'
+    tuning: typical
     description: |
       Multiplied by the motor's own pulloff_mm to get the max distance the axis will travel back toward the switch, after the first pull-off, before the precise second touch fails. A switch with a lot of positional variability (or sensorless homing) may need a larger value to reliably trigger the second touch.
 
@@ -814,6 +927,7 @@ axes.<letter>.motorN:
   hard_limits:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Treats the switches above as hard limits: activating one immediately stops all motion. Position is considered lost, so rehoming is required afterward.
 
@@ -912,6 +1026,7 @@ axes.<letter>.motorN.tmc_2130:
     min: 0.0
     max: 1.00
     default: '0.0'
+    tuning: per-machine
     description: |
       Sense resistor value for the physical driver module, in ohms. The 0.0 default is not a real, functional value -- TrinamicBase itself has no correct generic default, since this is purely a property of the specific module in hand (e.g. 0.11 is typical for genuine TMC2130/TMC2208/TMC2209 modules, 0.075 for TMC5160). A real value appropriate to the actual hardware must always be set explicitly.
 
@@ -920,6 +1035,7 @@ axes.<letter>.motorN.tmc_2130:
     min: 0.05
     max: 10.0
     default: '0.5'
+    tuning: per-machine
     description: |
       Motor current while running, in amps RMS.
 
@@ -928,6 +1044,7 @@ axes.<letter>.motorN.tmc_2130:
     min: 0.05
     max: 10.0
     default: '0.5'
+    tuning: per-machine
     description: |
       Motor current while holding position (not moving), in amps RMS.
 
@@ -936,6 +1053,7 @@ axes.<letter>.motorN.tmc_2130:
     min: 1
     max: 256
     default: '16'
+    tuning: per-machine
     description: |
       Microstep resolution. Needs to be reflected in the axis's steps_per_mm.
 
@@ -1052,6 +1170,7 @@ axes.<letter>.motorN.tmc_2208:
     min: 0.0
     max: 1.00
     default: '0.0'
+    tuning: per-machine
     description: |
       Sense resistor value for the physical driver module, in ohms. The 0.0 default is not a real, functional value -- TrinamicBase itself has no correct generic default, since this is purely a property of the specific module in hand (e.g. 0.11 is typical for genuine TMC2130/TMC2208/TMC2209 modules, 0.075 for TMC5160). A real value appropriate to the actual hardware must always be set explicitly.
 
@@ -1060,6 +1179,7 @@ axes.<letter>.motorN.tmc_2208:
     min: 0.05
     max: 10.0
     default: '0.5'
+    tuning: per-machine
     description: |
       Motor current while running, in amps RMS.
 
@@ -1068,6 +1188,7 @@ axes.<letter>.motorN.tmc_2208:
     min: 0.05
     max: 10.0
     default: '0.5'
+    tuning: per-machine
     description: |
       Motor current while holding position (not moving), in amps RMS.
 
@@ -1076,6 +1197,7 @@ axes.<letter>.motorN.tmc_2208:
     min: 1
     max: 256
     default: '16'
+    tuning: per-machine
     description: |
       Microstep resolution. Needs to be reflected in the axis's steps_per_mm.
 
@@ -1104,6 +1226,7 @@ axes.<letter>.motorN.tmc_2208:
   addr:
     type: integer
     default: '0'
+    tuning: per-machine
     description: |
       Hardware UART address of the chip. TMC2208/TMC2225 have a fixed address of 0 (this field has no effect on them); TMC2209/TMC2226 set their real address via their MS1/MS2 pins, making them individually addressable (up to 4 chips per UART bus).
 
@@ -1116,6 +1239,7 @@ axes.<letter>.motorN.tmc_2208:
   uart_num:
     type: integer
     default: '-1'
+    tuning: per-machine
     description: |
       Which top-level uartN: section this chip's UART register interface runs over. Required -- afterParse() asserts this is actually set.
 
@@ -1177,6 +1301,7 @@ axes.<letter>.motorN.tmc_2209:
     min: 0.0
     max: 1.00
     default: '0.0'
+    tuning: per-machine
     description: |
       Sense resistor value for the physical driver module, in ohms. The 0.0 default is not a real, functional value -- TrinamicBase itself has no correct generic default, since this is purely a property of the specific module in hand (e.g. 0.11 is typical for genuine TMC2130/TMC2208/TMC2209 modules, 0.075 for TMC5160). A real value appropriate to the actual hardware must always be set explicitly.
 
@@ -1185,6 +1310,7 @@ axes.<letter>.motorN.tmc_2209:
     min: 0.05
     max: 10.0
     default: '0.5'
+    tuning: per-machine
     description: |
       Motor current while running, in amps RMS.
 
@@ -1193,6 +1319,7 @@ axes.<letter>.motorN.tmc_2209:
     min: 0.05
     max: 10.0
     default: '0.5'
+    tuning: per-machine
     description: |
       Motor current while holding position (not moving), in amps RMS.
 
@@ -1201,6 +1328,7 @@ axes.<letter>.motorN.tmc_2209:
     min: 1
     max: 256
     default: '16'
+    tuning: per-machine
     description: |
       Microstep resolution. Needs to be reflected in the axis's steps_per_mm.
 
@@ -1229,6 +1357,7 @@ axes.<letter>.motorN.tmc_2209:
   addr:
     type: integer
     default: '0'
+    tuning: per-machine
     description: |
       Hardware UART address of the chip. TMC2208/TMC2225 have a fixed address of 0 (this field has no effect on them); TMC2209/TMC2226 set their real address via their MS1/MS2 pins, making them individually addressable (up to 4 chips per UART bus).
 
@@ -1241,6 +1370,7 @@ axes.<letter>.motorN.tmc_2209:
   uart_num:
     type: integer
     default: '-1'
+    tuning: per-machine
     description: |
       Which top-level uartN: section this chip's UART register interface runs over. Required -- afterParse() asserts this is actually set.
 
@@ -1260,7 +1390,8 @@ axes.<letter>.motorN.tmc_2209:
     type: unknown
     min: 0.0
     max: 10.0
-    default: '0.0 -- substituted with run_amps if left at 0'
+    default: '0.0'
+    default_note: 'substituted with run_amps if left at 0'
     description: |
       Motor current while homing. Leaving this at its default 0 isn't literally "zero current" -- afterParse() detects the default and substitutes run_amps instead, so omitting this field entirely is equivalent to setting it equal to run_amps. This fallback is specific to TMC2209; no other Trinamic driver type has a homing_amps field at all.
 
@@ -1316,6 +1447,7 @@ axes.<letter>.motorN.tmc_5160:
     min: 0.0
     max: 1.00
     default: '0.0'
+    tuning: per-machine
     description: |
       Sense resistor value for the physical driver module, in ohms. The 0.0 default is not a real, functional value -- TrinamicBase itself has no correct generic default, since this is purely a property of the specific module in hand (e.g. 0.11 is typical for genuine TMC2130/TMC2208/TMC2209 modules, 0.075 for TMC5160). A real value appropriate to the actual hardware must always be set explicitly.
 
@@ -1324,6 +1456,7 @@ axes.<letter>.motorN.tmc_5160:
     min: 0.05
     max: 10.0
     default: '0.5'
+    tuning: per-machine
     description: |
       Motor current while running, in amps RMS.
 
@@ -1332,6 +1465,7 @@ axes.<letter>.motorN.tmc_5160:
     min: 0.05
     max: 10.0
     default: '0.5'
+    tuning: per-machine
     description: |
       Motor current while holding position (not moving), in amps RMS.
 
@@ -1340,6 +1474,7 @@ axes.<letter>.motorN.tmc_5160:
     min: 1
     max: 256
     default: '16'
+    tuning: per-machine
     description: |
       Microstep resolution. Needs to be reflected in the axis's steps_per_mm.
 
@@ -1533,6 +1668,7 @@ axes.<letter>.motorN.rc_servo:
     min: SERVO_PWM_FREQ_MIN
     max: SERVO_PWM_FREQ_MAX
     default: '50'
+    tuning: typical
     description: |
       Servo PWM pulse repetition rate. 50Hz is the standard analog-servo value; some digital servos can repeat faster.
 
@@ -1541,6 +1677,7 @@ axes.<letter>.motorN.rc_servo:
     min: SERVO_PULSE_US_MIN
     max: SERVO_PULSE_US_MAX
     default: '1000'
+    tuning: per-machine
     description: |
       Pulse width, in microseconds, corresponding to one end of the servo's travel.
 
@@ -1549,6 +1686,7 @@ axes.<letter>.motorN.rc_servo:
     min: SERVO_PULSE_US_MIN
     max: SERVO_PULSE_US_MAX
     default: '2000'
+    tuning: per-machine
     description: |
       Pulse width, in microseconds, corresponding to the other end of the servo's travel.
 
@@ -1557,6 +1695,7 @@ axes.<letter>.motorN.rc_servo:
     min: TIMER_MS_MIN
     max: TIMER_MS_MAX
     default: '20'
+    tuning: typical
     description: |
       Update interval, in milliseconds, for refreshing the servo's PWM position.
 
@@ -1572,6 +1711,7 @@ axes.<letter>.motorN.solenoid:
     min: 1000
     max: 100000
     default: '1000'
+    tuning: typical
     description: |
       PWM frequency driving the solenoid.
 
@@ -1580,6 +1720,7 @@ axes.<letter>.motorN.solenoid:
     min: 0.0f
     max: 100.0f
     default: '0.0'
+    tuning: typical
     description: |
       Duty cycle while off.
 
@@ -1588,6 +1729,7 @@ axes.<letter>.motorN.solenoid:
     min: 0.0f
     max: 100.0f
     default: '100.0'
+    tuning: typical
     description: |
       Duty cycle during the initial pull-in (highest power, to overcome the solenoid's resting inertia).
 
@@ -1596,6 +1738,7 @@ axes.<letter>.motorN.solenoid:
     min: 0.0f
     max: 100.0f
     default: '75.0'
+    tuning: typical
     description: |
       Duty cycle after pull-in, while holding the solenoid engaged -- typically lower than pull_percent, since holding a solenoid needs less power than pulling it in.
 
@@ -1604,18 +1747,21 @@ axes.<letter>.motorN.solenoid:
     min: 0
     max: 3000
     default: '500'
+    tuning: typical
     description: |
       How long the pull_percent duty cycle is applied before switching to hold_percent.
 
   direction_invert:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Inverts which side of the axis's mpos 0.0 counts as "active".
 
   timer_ms:
     type: integer
     default: '50'
+    tuning: typical
     description: |
       Update interval, in milliseconds, for the solenoid's PWM state machine (pull/hold timing).
 
@@ -1659,42 +1805,52 @@ PWM:
     min: 0
     max: MaxToolNumber
     default: '0'
+    tuning: typical
     description: |
       Sets the tool-number range this spindle responds to for M6 Tn tool changes. With a single spindle, the value doesn't matter (conventionally 0). With multiple spindles, give each a distinct number -- ranges are implied by relative order, e.g. a relay spindle at tool_num: 0 and a laser at tool_num: 100 makes M6 T0-T99 select the relay and M6 T100+ select the laser.
 
   speed_map:
     type: std::vector<Configuration::speedEntry>
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: per-machine
     description: |
       Maps GCode S values to actual spindle speeds/PWM duty -- lets the S-to-speed relationship be linearized or clamped to a minimum speed. See the speed-map documentation for the full syntax.
 
   off_on_alarm:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Turns the spindle off whenever an alarm occurs. Worth enabling with a safety door in use, since the parking feature doesn't operate while in alarm state.
 
   atc:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Names an atc_manual:/ATC section (defined elsewhere in the config) to associate with this spindle for automatic tool changes.
 
   m6_macro:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       A macro (one config-file line, same syntax as macros:) to run for this spindle's M6 tool change, instead of the built-in tool-change behavior.
 
   s0_with_disable:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, an M5 (spindle off) also forces the speed signal to S0 (zero) -- by default the speed output stays at its last commanded value even during M5.
 
   disable_with_s0:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, commanding S0 (zero speed) also disables the spindle, the same as M5 -- by default, only M5 itself disables it.
 
@@ -1703,6 +1859,7 @@ PWM:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Time given for the spindle to reach the commanded RPM (per the speed map) before the following GCode line executes. Proportional to the RPM change -- a half-scale speed change only waits half of this value.
 
@@ -1711,6 +1868,7 @@ PWM:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Same as spinup_ms, but applied when the commanded RPM decreases.
 
@@ -1737,6 +1895,7 @@ PWM:
     min: 1
     max: 20000000
     default: '5000'
+    tuning: typical
     description: |
       PWM signal frequency. Resolution trades off against frequency -- 76Hz or less gets the full 20-bit duty-cycle resolution, roughly halving for every doubling of frequency above that, down to 4 levels (2 bits) at the 20MHz ceiling. Not every value in that range is a practical CNC PWM frequency, but the hardware supports the whole span, so it's left open.
 
@@ -1747,42 +1906,52 @@ Laser:
     min: 0
     max: MaxToolNumber
     default: '0'
+    tuning: typical
     description: |
       Sets the tool-number range this spindle responds to for M6 Tn tool changes. With a single spindle, the value doesn't matter (conventionally 0). With multiple spindles, give each a distinct number -- ranges are implied by relative order, e.g. a relay spindle at tool_num: 0 and a laser at tool_num: 100 makes M6 T0-T99 select the relay and M6 T100+ select the laser.
 
   speed_map:
     type: std::vector<Configuration::speedEntry>
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: per-machine
     description: |
       Maps GCode S values to actual spindle speeds/PWM duty -- lets the S-to-speed relationship be linearized or clamped to a minimum speed. See the speed-map documentation for the full syntax.
 
   off_on_alarm:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Turns the spindle off whenever an alarm occurs. Worth enabling with a safety door in use, since the parking feature doesn't operate while in alarm state.
 
   atc:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Names an atc_manual:/ATC section (defined elsewhere in the config) to associate with this spindle for automatic tool changes.
 
   m6_macro:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       A macro (one config-file line, same syntax as macros:) to run for this spindle's M6 tool change, instead of the built-in tool-change behavior.
 
   s0_with_disable:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, an M5 (spindle off) also forces the speed signal to S0 (zero) -- by default the speed output stays at its last commanded value even during M5.
 
   disable_with_s0:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, commanding S0 (zero speed) also disables the spindle, the same as M5 -- by default, only M5 itself disables it.
 
@@ -1812,42 +1981,52 @@ Laser:
     min: 0
     max: MaxToolNumber
     default: '0'
+    tuning: typical
     description: |
       Sets the tool-number range this spindle responds to for M6 Tn tool changes. With a single spindle, the value doesn't matter (conventionally 0). With multiple spindles, give each a distinct number -- ranges are implied by relative order, e.g. a relay spindle at tool_num: 0 and a laser at tool_num: 100 makes M6 T0-T99 select the relay and M6 T100+ select the laser.
 
   speed_map:
     type: std::vector<Configuration::speedEntry>
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: per-machine
     description: |
       Maps GCode S values to actual spindle speeds/PWM duty -- lets the S-to-speed relationship be linearized or clamped to a minimum speed. See the speed-map documentation for the full syntax.
 
   off_on_alarm:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Turns the spindle off whenever an alarm occurs. Worth enabling with a safety door in use, since the parking feature doesn't operate while in alarm state.
 
   atc:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Names an atc_manual:/ATC section (defined elsewhere in the config) to associate with this spindle for automatic tool changes.
 
   m6_macro:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       A macro (one config-file line, same syntax as macros:) to run for this spindle's M6 tool change, instead of the built-in tool-change behavior.
 
   s0_with_disable:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, an M5 (spindle off) also forces the speed signal to S0 (zero) -- by default the speed output stays at its last commanded value even during M5.
 
   disable_with_s0:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, commanding S0 (zero speed) also disables the spindle, the same as M5 -- by default, only M5 itself disables it.
 
@@ -1856,6 +2035,7 @@ Laser:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Time given for the spindle to reach the commanded RPM (per the speed map) before the following GCode line executes. Proportional to the RPM change -- a half-scale speed change only waits half of this value.
 
@@ -1864,6 +2044,7 @@ Laser:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Same as spinup_ms, but applied when the commanded RPM decreases.
 
@@ -1890,6 +2071,7 @@ Laser:
     min: 1
     max: 20000000
     default: '5000'
+    tuning: typical
     description: |
       PWM signal frequency. Resolution trades off against frequency -- 76Hz or less gets the full 20-bit duty-cycle resolution, roughly halving for every doubling of frequency above that, down to 4 levels (2 bits) at the 20MHz ceiling. Not every value in that range is a practical CNC PWM frequency, but the hardware supports the whole span, so it's left open.
 
@@ -1911,42 +2093,52 @@ BESC:
     min: 0
     max: MaxToolNumber
     default: '0'
+    tuning: typical
     description: |
       Sets the tool-number range this spindle responds to for M6 Tn tool changes. With a single spindle, the value doesn't matter (conventionally 0). With multiple spindles, give each a distinct number -- ranges are implied by relative order, e.g. a relay spindle at tool_num: 0 and a laser at tool_num: 100 makes M6 T0-T99 select the relay and M6 T100+ select the laser.
 
   speed_map:
     type: std::vector<Configuration::speedEntry>
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: per-machine
     description: |
       Maps GCode S values to actual spindle speeds/PWM duty -- lets the S-to-speed relationship be linearized or clamped to a minimum speed. See the speed-map documentation for the full syntax.
 
   off_on_alarm:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Turns the spindle off whenever an alarm occurs. Worth enabling with a safety door in use, since the parking feature doesn't operate while in alarm state.
 
   atc:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Names an atc_manual:/ATC section (defined elsewhere in the config) to associate with this spindle for automatic tool changes.
 
   m6_macro:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       A macro (one config-file line, same syntax as macros:) to run for this spindle's M6 tool change, instead of the built-in tool-change behavior.
 
   s0_with_disable:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, an M5 (spindle off) also forces the speed signal to S0 (zero) -- by default the speed output stays at its last commanded value even during M5.
 
   disable_with_s0:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, commanding S0 (zero speed) also disables the spindle, the same as M5 -- by default, only M5 itself disables it.
 
@@ -1955,6 +2147,7 @@ BESC:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Time given for the spindle to reach the commanded RPM (per the speed map) before the following GCode line executes. Proportional to the RPM change -- a half-scale speed change only waits half of this value.
 
@@ -1963,6 +2156,7 @@ BESC:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Same as spinup_ms, but applied when the commanded RPM decreases.
 
@@ -1989,6 +2183,7 @@ BESC:
     min: 1
     max: 20000000
     default: '5000'
+    tuning: typical
     description: |
       PWM signal frequency. Resolution trades off against frequency -- 76Hz or less gets the full 20-bit duty-cycle resolution, roughly halving for every doubling of frequency above that, down to 4 levels (2 bits) at the 20MHz ceiling. Not every value in that range is a practical CNC PWM frequency, but the hardware supports the whole span, so it's left open.
 
@@ -1997,6 +2192,7 @@ BESC:
     min: 500
     max: 3000
     default: '900'
+    tuning: per-machine
     description: |
       Pulse width, in microseconds, corresponding to the ESC's "off" signal. Determine your ESC's actual min pulse from its datasheet/documentation -- typically around 1ms (1000us) or less.
 
@@ -2005,6 +2201,7 @@ BESC:
     min: 500
     max: 3000
     default: '2200'
+    tuning: per-machine
     description: |
       Pulse width, in microseconds, corresponding to the ESC's full-power signal. Typically around 2ms (2000us) or more -- check your ESC's documentation.
 
@@ -2014,42 +2211,52 @@ HBridge:
     min: 0
     max: MaxToolNumber
     default: '0'
+    tuning: typical
     description: |
       Sets the tool-number range this spindle responds to for M6 Tn tool changes. With a single spindle, the value doesn't matter (conventionally 0). With multiple spindles, give each a distinct number -- ranges are implied by relative order, e.g. a relay spindle at tool_num: 0 and a laser at tool_num: 100 makes M6 T0-T99 select the relay and M6 T100+ select the laser.
 
   speed_map:
     type: std::vector<Configuration::speedEntry>
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: per-machine
     description: |
       Maps GCode S values to actual spindle speeds/PWM duty -- lets the S-to-speed relationship be linearized or clamped to a minimum speed. See the speed-map documentation for the full syntax.
 
   off_on_alarm:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Turns the spindle off whenever an alarm occurs. Worth enabling with a safety door in use, since the parking feature doesn't operate while in alarm state.
 
   atc:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Names an atc_manual:/ATC section (defined elsewhere in the config) to associate with this spindle for automatic tool changes.
 
   m6_macro:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       A macro (one config-file line, same syntax as macros:) to run for this spindle's M6 tool change, instead of the built-in tool-change behavior.
 
   s0_with_disable:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, an M5 (spindle off) also forces the speed signal to S0 (zero) -- by default the speed output stays at its last commanded value even during M5.
 
   disable_with_s0:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, commanding S0 (zero speed) also disables the spindle, the same as M5 -- by default, only M5 itself disables it.
 
@@ -2058,6 +2265,7 @@ HBridge:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Time given for the spindle to reach the commanded RPM (per the speed map) before the following GCode line executes. Proportional to the RPM change -- a half-scale speed change only waits half of this value.
 
@@ -2066,6 +2274,7 @@ HBridge:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Same as spinup_ms, but applied when the commanded RPM decreases.
 
@@ -2102,42 +2311,52 @@ OnOff:
     min: 0
     max: MaxToolNumber
     default: '0'
+    tuning: typical
     description: |
       Sets the tool-number range this spindle responds to for M6 Tn tool changes. With a single spindle, the value doesn't matter (conventionally 0). With multiple spindles, give each a distinct number -- ranges are implied by relative order, e.g. a relay spindle at tool_num: 0 and a laser at tool_num: 100 makes M6 T0-T99 select the relay and M6 T100+ select the laser.
 
   speed_map:
     type: std::vector<Configuration::speedEntry>
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: per-machine
     description: |
       Maps GCode S values to actual spindle speeds/PWM duty -- lets the S-to-speed relationship be linearized or clamped to a minimum speed. See the speed-map documentation for the full syntax.
 
   off_on_alarm:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Turns the spindle off whenever an alarm occurs. Worth enabling with a safety door in use, since the parking feature doesn't operate while in alarm state.
 
   atc:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Names an atc_manual:/ATC section (defined elsewhere in the config) to associate with this spindle for automatic tool changes.
 
   m6_macro:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       A macro (one config-file line, same syntax as macros:) to run for this spindle's M6 tool change, instead of the built-in tool-change behavior.
 
   s0_with_disable:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, an M5 (spindle off) also forces the speed signal to S0 (zero) -- by default the speed output stays at its last commanded value even during M5.
 
   disable_with_s0:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, commanding S0 (zero speed) also disables the spindle, the same as M5 -- by default, only M5 itself disables it.
 
@@ -2146,6 +2365,7 @@ OnOff:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Time given for the spindle to reach the commanded RPM (per the speed map) before the following GCode line executes. Proportional to the RPM change -- a half-scale speed change only waits half of this value.
 
@@ -2154,6 +2374,7 @@ OnOff:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Same as spinup_ms, but applied when the commanded RPM decreases.
 
@@ -2182,42 +2403,52 @@ PlasmaSpindle:
     min: 0
     max: MaxToolNumber
     default: '0'
+    tuning: typical
     description: |
       Sets the tool-number range this spindle responds to for M6 Tn tool changes. With a single spindle, the value doesn't matter (conventionally 0). With multiple spindles, give each a distinct number -- ranges are implied by relative order, e.g. a relay spindle at tool_num: 0 and a laser at tool_num: 100 makes M6 T0-T99 select the relay and M6 T100+ select the laser.
 
   speed_map:
     type: std::vector<Configuration::speedEntry>
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: per-machine
     description: |
       Maps GCode S values to actual spindle speeds/PWM duty -- lets the S-to-speed relationship be linearized or clamped to a minimum speed. See the speed-map documentation for the full syntax.
 
   off_on_alarm:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Turns the spindle off whenever an alarm occurs. Worth enabling with a safety door in use, since the parking feature doesn't operate while in alarm state.
 
   atc:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Names an atc_manual:/ATC section (defined elsewhere in the config) to associate with this spindle for automatic tool changes.
 
   m6_macro:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       A macro (one config-file line, same syntax as macros:) to run for this spindle's M6 tool change, instead of the built-in tool-change behavior.
 
   s0_with_disable:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, an M5 (spindle off) also forces the speed signal to S0 (zero) -- by default the speed output stays at its last commanded value even during M5.
 
   disable_with_s0:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, commanding S0 (zero speed) also disables the spindle, the same as M5 -- by default, only M5 itself disables it.
 
@@ -2238,6 +2469,7 @@ PlasmaSpindle:
     min: 0
     max: 3000
     default: '1000'
+    tuning: typical
     description: |
       How long to wait for arc_ok_pin to confirm the arc has started before giving up.
 
@@ -2251,42 +2483,52 @@ ModbusVFD:
     min: 0
     max: MaxToolNumber
     default: '0'
+    tuning: typical
     description: |
       Sets the tool-number range this spindle responds to for M6 Tn tool changes. With a single spindle, the value doesn't matter (conventionally 0). With multiple spindles, give each a distinct number -- ranges are implied by relative order, e.g. a relay spindle at tool_num: 0 and a laser at tool_num: 100 makes M6 T0-T99 select the relay and M6 T100+ select the laser.
 
   speed_map:
     type: std::vector<Configuration::speedEntry>
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: per-machine
     description: |
       Maps GCode S values to actual spindle speeds/PWM duty -- lets the S-to-speed relationship be linearized or clamped to a minimum speed. See the speed-map documentation for the full syntax.
 
   off_on_alarm:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Turns the spindle off whenever an alarm occurs. Worth enabling with a safety door in use, since the parking feature doesn't operate while in alarm state.
 
   atc:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Names an atc_manual:/ATC section (defined elsewhere in the config) to associate with this spindle for automatic tool changes.
 
   m6_macro:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       A macro (one config-file line, same syntax as macros:) to run for this spindle's M6 tool change, instead of the built-in tool-change behavior.
 
   s0_with_disable:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, an M5 (spindle off) also forces the speed signal to S0 (zero) -- by default the speed output stays at its last commanded value even during M5.
 
   disable_with_s0:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       When true, commanding S0 (zero speed) also disables the spindle, the same as M5 -- by default, only M5 itself disables it.
 
@@ -2295,6 +2537,7 @@ ModbusVFD:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Time given for the spindle to reach the commanded RPM (per the speed map) before the following GCode line executes. Proportional to the RPM change -- a half-scale speed change only waits half of this value.
 
@@ -2303,12 +2546,14 @@ ModbusVFD:
     min: 0
     max: 60000
     default: '0'
+    tuning: typical
     description: |
       Same as spinup_ms, but applied when the commanded RPM decreases.
 
   uart_num:
     type: integer
-    default: '-1 (not configured)'
+    default: '-1'
+    default_note: 'not configured'
     description: |
       Which top-level uartN: section this VFD's Modbus link runs over.
 
@@ -2317,6 +2562,7 @@ ModbusVFD:
     min: 0
     max: 247
     default: '1'
+    tuning: typical
     description: |
       Modbus slave address of the VFD -- must match the VFD's own configured value (per https://modbus.org/docs/PI_MBUS_300.pdf). When in doubt, try 1.
 
@@ -2344,61 +2590,71 @@ ModbusVFD:
 
   model:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
     description: |
       VFD model name. Informational (used for support purposes) -- not itself used to select protocol behavior; the cw_cmd/ccw_cmd/etc. fields below are what actually define the protocol.
 
   min_RPM:
     type: integer
-    default: '0xffffffff (uninitialized sentinel)'
+    default: '0xffffffff'
+    default_note: 'uninitialized sentinel'
     description: |
       Minimum spindle RPM, in Hz-derived RPM terms. Normally left unset and retrieved from the VFD itself via get_min_rpm_cmd at startup.
 
   max_RPM:
     type: integer
-    default: '0xffffffff (uninitialized sentinel)'
+    default: '0xffffffff'
+    default_note: 'uninitialized sentinel'
     description: |
       Maximum spindle RPM. Normally left unset and retrieved from the VFD itself via get_max_rpm_cmd at startup.
 
   cw_cmd:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
     description: |
       Modbus command template for clockwise spindle rotation.
 
   ccw_cmd:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
     description: |
       Modbus command template for counter-clockwise spindle rotation.
 
   off_cmd:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
     description: |
       Modbus command template to stop the spindle.
 
   set_rpm_cmd:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
     description: |
       Modbus command template to set the spindle speed.
 
   get_min_rpm_cmd:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
     description: |
       Modbus command template to query the VFD's minimum RPM. If left unset, speed_map must be configured manually instead of being auto-derived.
 
   get_max_rpm_cmd:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
     description: |
       Modbus command template to query the VFD's maximum RPM. If left unset, speed_map must be configured manually instead of being auto-derived.
 
   get_rpm_cmd:
     type: string
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
     description: |
       Modbus command template to query the VFD's current RPM. spinup_ms/ spindown_ms (Spindle::groupDelaySettings()) are always present in config.yaml for a VFD spindle regardless of this field -- what this field changes is whether they're actually used at runtime. When set, use_speed_feedback() returns true and VFDSpindle actively polls this command until it confirms the real target speed, ignoring spinup_ms/ spindown_ms entirely; when left empty, there's no way to confirm real speed, so it falls back to blindly waiting out spinup_ms/spindown_ms instead.
 
@@ -2408,6 +2664,7 @@ kinematics.ParallelDelta:
     min: 50.0
     max: 500.0
     default: '70.0'
+    tuning: per-machine
     description: |
       Length of the crank arm attached to each motor.
 
@@ -2416,6 +2673,7 @@ kinematics.ParallelDelta:
     min: 20.0
     max: 500.0
     default: '179.437'
+    tuning: per-machine
     description: |
       Side length of the fixed base triangle (where the motors/cranks mount).
 
@@ -2424,6 +2682,7 @@ kinematics.ParallelDelta:
     min: 20.0
     max: 500.0
     default: '133.5'
+    tuning: per-machine
     description: |
       Length of the linkage arm connecting each crank to the end effector.
 
@@ -2432,6 +2691,7 @@ kinematics.ParallelDelta:
     min: 20.0
     max: 500.0
     default: '86.603'
+    tuning: per-machine
     description: |
       Side length of the moving end-effector triangle (where the tool mounts).
 
@@ -2440,12 +2700,14 @@ kinematics.ParallelDelta:
     min: 0.05
     max: 20.0
     default: '1.0'
+    tuning: typical
     description: |
       Maximum length of the small linear segments a cartesian move is broken into before being converted to arm angles -- delta kinematics are nonlinear, so moves are approximated as a series of short, nearly-linear segments (the same idea FluidNC uses for tessellating arcs).
 
   use_servos:
     type: boolean
     default: 'false'
+    tuning: typical
     description: |
       Set true when the arms are driven by servos rather than steppers -- servos use a different (self-contained) homing approach.
 
@@ -2454,6 +2716,7 @@ kinematics.ParallelDelta:
     min: -90
     max: 0
     default: '-30.0'
+    tuning: per-machine
     description: |
       Arm angle, in degrees, considered fully "up" (0 is horizontal, positive angles are below horizontal per this file's own convention -- so "up" is negative).
 
@@ -2461,42 +2724,49 @@ kinematics.WallPlotter:
   left_axis:
     type: integer
     default: '0'
+    tuning: typical
     description: |
-      Which machine axis index drives the left cord's length.
+      Which machine axis index drives the left cord's length. NOT bounds-checked against MAX_N_AXIS -- see transform_cartesian_to_motors() below for why an out-of-range or Z-and-above value here is unsafe.
 
   left_anchor_x:
     type: float
     default: '-100'
+    tuning: per-machine
     description: |
       X position of the left cord's fixed anchor point, in the cartesian frame.
 
   left_anchor_y:
     type: float
     default: '100'
+    tuning: per-machine
     description: |
       Y position of the left cord's fixed anchor point.
 
   right_axis:
     type: integer
     default: '1'
+    tuning: typical
     description: |
-      Which machine axis index drives the right cord's length.
+      Which machine axis index drives the right cord's length. NOT bounds-checked -- see left_axis above.
 
   right_anchor_x:
     type: float
     default: '100'
+    tuning: per-machine
     description: |
       X position of the right cord's fixed anchor point.
 
   right_anchor_y:
     type: float
     default: '100'
+    tuning: per-machine
     description: |
       Y position of the right cord's fixed anchor point.
 
   segment_length:
     type: float
     default: '10'
+    tuning: typical
     description: |
       Maximum length of the small linear segments a cartesian move is broken into before being converted to cord lengths (the cord-length transform is nonlinear).
 
@@ -2658,55 +2928,73 @@ user_inputs:
 macros:
   startup_line0:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Legacy Grbl feature (formerly $N0). Runs once, the first time the firmware enters Idle after boot.
 
   startup_line1:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Legacy Grbl feature (formerly $N1). Runs once, the first time the firmware enters Idle after boot, immediately after startup_line0.
 
   macro0:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Runs when macro0_pin (control:) is activated. The switch must read inactive at startup -- deactivate it before clearing the alarm, same as any other control input.
 
   macro1:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Runs when macro1_pin (control:) is activated.
 
   macro2:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Runs when macro2_pin (control:) is activated.
 
   macro3:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Runs when macro3_pin (control:) is activated.
 
   after_homing:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Runs after a homing cycle completes -- i.e. once every axis with homing enabled has been homed.
 
   after_reset:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Runs after the system resets (power-on/startup, or a Ctrl-X real-time reset), but only if the system ends up in Idle state immediately after the reset.
 
   after_unlock:
     type: macro
-    default: '"" (empty)'
+    default: '""'
+    default_note: 'empty'
+    tuning: typical
     description: |
       Runs after a $X unlock command.
 
@@ -2726,60 +3014,70 @@ rgbled:
 
   idle:
     type: string (hex color RRGGBB, or "none")
-    default: '"007F00" (green)'
+    default: '"007F00"'
+    default_note: 'green'
     description: |
       Color shown while machine status is Idle.
 
   alarm:
     type: string (hex color RRGGBB, or "none")
-    default: '"7F0000" (red)'
+    default: '"7F0000"'
+    default_note: 'red'
     description: |
       Color shown while machine status is Alarm.
 
   checkMode:
     type: string (hex color RRGGBB, or "none")
-    default: '"b936bf" (magenta)'
+    default: '"b936bf"'
+    default_note: 'magenta'
     description: |
       Color shown while in Grbl Check Mode ($C).
 
   homing:
     type: string (hex color RRGGBB, or "none")
-    default: '"501f00" (orange-brown)'
+    default: '"501f00"'
+    default_note: 'orange-brown'
     description: |
       Color shown while homing.
 
   cycle:
     type: string (hex color RRGGBB, or "none")
-    default: '"7f4422" (orange)'
+    default: '"7f4422"'
+    default_note: 'orange'
     description: |
       Color shown while running (Cycle state).
 
   hold:
     type: string (hex color RRGGBB, or "none")
-    default: '"777744" (dim yellow)'
+    default: '"777744"'
+    default_note: 'dim yellow'
     description: |
       Color shown while in Feed Hold.
 
   jog:
     type: string (hex color RRGGBB, or "none")
-    default: '"007f3f" (teal)'
+    default: '"007f3f"'
+    default_note: 'teal'
     description: |
       Color shown while jogging.
 
   safetyDoor:
     type: string (hex color RRGGBB, or "none")
-    default: '"3f7f00" (yellow-green)'
+    default: '"3f7f00"'
+    default_note: 'yellow-green'
     description: |
       Color shown while the safety door is open (Door state).
 
   sleep:
     type: string (hex color RRGGBB, or "none")
-    default: '"001F00" (dim green)'
+    default: '"001F00"'
+    default_note: 'dim green'
     description: |
       Color shown while in Sleep state.
 
   configAlarm:
     type: string (hex color RRGGBB, or "none")
-    default: '"7f0000" (red)'
+    default: '"7f0000"'
+    default_note: 'red'
     description: |
       Color shown when a configuration error put the machine into ConfigAlarm state at startup.

--- a/FluidNC/esp32/OLED.h
+++ b/FluidNC/esp32/OLED.h
@@ -118,13 +118,59 @@ public:
     void afterParse() override;
 
     void group(Configuration::HandlerBase& handler) override {
+        // @config report_interval_ms
+        // @default 500
+        // @tuning typical
+        // Interval, in milliseconds, at which the display's status content (DRO, state,
+        // filename/percent) is refreshed.
         handler.item("report_interval_ms", _report_interval_ms, 100, 5000);
+
+        // @config i2c_num
+        // @default 0
+        // @tuning per-machine
+        // Which top-level i2cN: bus this display is wired to.
         handler.item("i2c_num", _i2c_num);
+
+        // @config i2c_address
+        // @default 0x3c
+        // @tuning per-machine
+        // I2C address of the display module. Must match the actual hardware -- common
+        // SSD1306 modules use 0x3C or 0x3D.
         handler.item("i2c_address", _address);
+
+        // @config width
+        // @default 64
+        // @tuning per-machine
+        // Physical panel width, in pixels. Must match the actual display module -- there's
+        // no generic value that works across different panels.
         handler.item("width", _width);
+
+        // @config height
+        // @default 48
+        // @tuning per-machine
+        // Physical panel height, in pixels. Must match the actual display module -- there's
+        // no generic value that works across different panels.
         handler.item("height", _height);
+
+        // @config flip
+        // @default true
+        // @tuning per-machine
+        // Rotates the displayed content 180 degrees. Depends on how the panel is physically
+        // mounted.
         handler.item("flip", _flip);
+
+        // @config mirror
+        // @default false
+        // @tuning per-machine
+        // Mirrors the displayed content horizontally. Depends on how the panel is physically
+        // mounted.
         handler.item("mirror", _mirror);
+
+        // @config radio_delay_ms
+        // @default 0
+        // @tuning per-machine
+        // Delay, in milliseconds, before the display shows radio (WiFi/BT) connection info
+        // after boot -- gives the radio hardware time to come up first.
         handler.item("radio_delay_ms", _radio_delay);
     }
 };

--- a/FluidNC/src/Configuration/ItemDocs.md
+++ b/FluidNC/src/Configuration/ItemDocs.md
@@ -41,7 +41,8 @@ comment and the code have drifted apart), not silently ignore it.
 
 ```c++
 // @config idle_ms
-// @default 255 -- special "never auto-disable" value (Grbl compatibility)
+// @default 255
+// @default_note special "never auto-disable" value (Grbl compatibility)
 // Milliseconds of inactivity before motors are automatically disabled.
 // Any value other than 255 (0-254 or 256+) is a real millisecond delay;
 // motors can also be disabled manually at any time with $MD.
@@ -50,7 +51,8 @@ handler.item("idle_ms", _idleMsecs, 0, 10000000);
 
 ```c++
 // @config engine
-// @default board-dependent (DEFAULT_STEPPING_ENGINE, applied in afterParse())
+// @default (none)
+// @default_note board-dependent (DEFAULT_STEPPING_ENGINE, applied in afterParse())
 // Method used to generate step pulses in firmware...
 handler.item("engine", _engine);
 ```
@@ -58,16 +60,49 @@ handler.item("engine", _engine);
 Rules:
 
 - The `@config <name>` line opens the block.
-- The very next line **must** be `@default <text>`, one line, no
+- The very next line **must** be `@default <literal>`, one line, no
   continuation -- a generator should treat a missing `@default` as an error,
-  the same as a name mismatch. Keep it short (the value, plus a terse
-  qualifier if the bare value would be misleading on its own, as in the two
-  examples above); a fuller explanation of *why* belongs in the description
-  below, not crammed into the `@default` line itself.
-- An optional `@unit <text>` line may follow `@default`, before the
-  description, when the field name's own suffix (`_ms`, `_us`, `_mm`,
-  `_amps`, ...) doesn't already say it plainly enough to be worth restating
-  -- most fields don't need this.
+  the same as a name mismatch. `<literal>` must be a single bare value in the
+  field's own type (a number, `true`/`false`, a bare or quoted string,
+  `NO_PIN`, a hex constant, ...) with nothing else on the line -- no
+  qualifier, no parenthetical, no explanation. When the real default
+  genuinely isn't a fixed literal at all (board-dependent, substituted by
+  other code in `afterParse()`, ...), write the reserved token `(none)`
+  instead of inventing one. This keeps `@default` mechanically parseable in
+  every case: a downstream consumer (e.g. the config wizard's silent-pre-fill
+  logic) can trust it's either a real, directly usable value or the explicit
+  "no such value exists" sentinel, never free text it has to guess how to
+  parse.
+- An optional `@default_note <text>` line may immediately follow `@default`
+  -- one line, no continuation. This is where the qualifier that used to be
+  crammed onto the `@default` line itself now goes: why the literal might be
+  misleading on its own (idle_ms's example above), or, when `@default` is
+  `(none)`, what actually determines the real default (engine's example
+  above). A fuller explanation of *why* still belongs in the description
+  below, not here -- keep this short.
+- An optional `@tuning <typical|per-machine>` line may follow
+  `@default`/`@default_note`, before `@unit`/the description. It answers a
+  narrower question than
+  "does a compiled default exist" (true of nearly every item): is that
+  default likely *correct, or at least safe/harmless, for most machines* --
+  `typical` -- or is it a placeholder/starting point that needs real
+  per-machine data before the config will actually work right --
+  `per-machine`. A physical dimension, a bus/device address, a current
+  rating, or anything else that varies with the specific hardware attached
+  is `per-machine` even when the initializer is a plausible-looking number
+  (e.g. Parallel Delta's `crank_mm`, or a TMC driver's `r_sense_ohms`). A
+  behavior toggle, timing constant, or cosmetic setting whose compiled
+  default is safe to leave alone on nearly any machine is `typical`. Omit
+  the line when genuinely unclassified rather than guessing -- a missing
+  `@tuning` is not an error, unlike a missing `@default`. This exists so a
+  config wizard's "pre-fill vs. force the user to look at it" logic can be
+  generated from source instead of hand-maintained (see
+  FluidNC-config-wizard's `TUNING_CLASSIFICATION_REVIEW.md` for the review
+  that produced the first pass of these).
+- An optional `@unit <text>` line may follow `@default`/`@default_note`/
+  `@tuning`, before the description, when the field name's own suffix
+  (`_ms`, `_us`, `_mm`, `_amps`, ...) doesn't already say it plainly enough
+  to be worth restating -- most fields don't need this.
 - Every plain `//` comment line after that (no intervening code, no blank
   line) is part of the description, in order. A blank comment line (`//`
   alone) is a paragraph break; anything else joins with a single space.
@@ -79,7 +114,8 @@ Rules:
   in the field's own initializer, where one exists, and warns (doesn't fail)
   on an apparent mismatch -- that's a strong signal the annotation drifted
   from a later code change, e.g. someone changed the initializer without
-  updating the comment.
+  updating the comment. Skipped entirely when `@default` is `(none)` -- there's
+  no literal to compare against by definition.
 - Every `handler.item(...)` call gets a `@config`/`@default` block, full
   stop -- the generator treats a call with no matching block as an error.
   This is a change from an earlier version of this convention, which allowed

--- a/FluidNC/src/CoolantControl.cpp
+++ b/FluidNC/src/CoolantControl.cpp
@@ -99,6 +99,7 @@ void CoolantControl::group(Configuration::HandlerBase& handler) {
 
     // @config delay_ms
     // @default 0
+    // @tuning typical
     // Delay, in milliseconds, after M7/M8 turns a coolant output on, before motion resumes
     // -- gives the coolant device time to actually start flowing. Not applied if that
     // coolant output is already on, and not applied to M9 (turning off).

--- a/FluidNC/src/Kinematics/ParallelDelta.cpp
+++ b/FluidNC/src/Kinematics/ParallelDelta.cpp
@@ -62,26 +62,31 @@ namespace Kinematics {
 
         // @config crank_mm
         // @default 70.0
+        // @tuning per-machine
         // Length of the crank arm attached to each motor.
         handler.item("crank_mm", rf, 50.0, 500.0);
 
         // @config base_triangle_mm
         // @default 179.437
+        // @tuning per-machine
         // Side length of the fixed base triangle (where the motors/cranks mount).
         handler.item("base_triangle_mm", f, 20.0, 500.0);
 
         // @config linkage_mm
         // @default 133.5
+        // @tuning per-machine
         // Length of the linkage arm connecting each crank to the end effector.
         handler.item("linkage_mm", re, 20.0, 500.0);
 
         // @config end_effector_triangle_mm
         // @default 86.603
+        // @tuning per-machine
         // Side length of the moving end-effector triangle (where the tool mounts).
         handler.item("end_effector_triangle_mm", e, 20.0, 500.0);
 
         // @config kinematic_segment_len_mm
         // @default 1.0
+        // @tuning typical
         // Maximum length of the small linear segments a cartesian move is broken into
         // before being converted to arm angles -- delta kinematics are nonlinear, so
         // moves are approximated as a series of short, nearly-linear segments (the same
@@ -90,12 +95,14 @@ namespace Kinematics {
 
         // @config use_servos
         // @default false
+        // @tuning typical
         // Set true when the arms are driven by servos rather than steppers -- servos use
         // a different (self-contained) homing approach.
         handler.item("use_servos", _use_servos);
 
         // @config up_degrees
         // @default -30.0
+        // @tuning per-machine
         // Arm angle, in degrees, considered fully "up" (0 is horizontal, positive angles
         // are below horizontal per this file's own convention -- so "up" is negative).
         handler.item("up_degrees", _up_degrees, -90, 0);

--- a/FluidNC/src/Kinematics/WallPlotter.cpp
+++ b/FluidNC/src/Kinematics/WallPlotter.cpp
@@ -13,6 +13,7 @@ namespace Kinematics {
 
         // @config left_axis
         // @default 0
+        // @tuning typical
         // Which machine axis index drives the left cord's length.
         // NOT bounds-checked against MAX_N_AXIS -- see transform_cartesian_to_motors()
         // below for why an out-of-range or Z-and-above value here is unsafe.
@@ -20,32 +21,38 @@ namespace Kinematics {
 
         // @config left_anchor_x
         // @default -100
+        // @tuning per-machine
         // X position of the left cord's fixed anchor point, in the cartesian frame.
         handler.item("left_anchor_x", _left_anchor_x);
 
         // @config left_anchor_y
         // @default 100
+        // @tuning per-machine
         // Y position of the left cord's fixed anchor point.
         handler.item("left_anchor_y", _left_anchor_y);
 
         // @config right_axis
         // @default 1
+        // @tuning typical
         // Which machine axis index drives the right cord's length.
         // NOT bounds-checked -- see left_axis above.
         handler.item("right_axis", _right_axis);
 
         // @config right_anchor_x
         // @default 100
+        // @tuning per-machine
         // X position of the right cord's fixed anchor point.
         handler.item("right_anchor_x", _right_anchor_x);
 
         // @config right_anchor_y
         // @default 100
+        // @tuning per-machine
         // Y position of the right cord's fixed anchor point.
         handler.item("right_anchor_y", _right_anchor_y);
 
         // @config segment_length
         // @default 10
+        // @tuning typical
         // Maximum length of the small linear segments a cartesian move is broken into
         // before being converted to cord lengths (the cord-length transform is nonlinear).
         handler.item("segment_length", _segment_length);

--- a/FluidNC/src/Listeners/RGBLed.h
+++ b/FluidNC/src/Listeners/RGBLed.h
@@ -106,52 +106,62 @@ namespace Listeners {
             handler.item("index", index_);
 
             // @config idle
-            // @default "007F00" (green)
+            // @default "007F00"
+            // @default_note green
             // Color shown while machine status is Idle.
             handleRGBString(handler, "idle", idle);
 
             // @config alarm
-            // @default "7F0000" (red)
+            // @default "7F0000"
+            // @default_note red
             // Color shown while machine status is Alarm.
             handleRGBString(handler, "alarm", alarm);
 
             // @config checkMode
-            // @default "b936bf" (magenta)
+            // @default "b936bf"
+            // @default_note magenta
             // Color shown while in Grbl Check Mode ($C).
             handleRGBString(handler, "checkMode", checkMode);
 
             // @config homing
-            // @default "501f00" (orange-brown)
+            // @default "501f00"
+            // @default_note orange-brown
             // Color shown while homing.
             handleRGBString(handler, "homing", homing);
 
             // @config cycle
-            // @default "7f4422" (orange)
+            // @default "7f4422"
+            // @default_note orange
             // Color shown while running (Cycle state).
             handleRGBString(handler, "cycle", cycle);
 
             // @config hold
-            // @default "777744" (dim yellow)
+            // @default "777744"
+            // @default_note dim yellow
             // Color shown while in Feed Hold.
             handleRGBString(handler, "hold", hold);
 
             // @config jog
-            // @default "007f3f" (teal)
+            // @default "007f3f"
+            // @default_note teal
             // Color shown while jogging.
             handleRGBString(handler, "jog", jog);
 
             // @config safetyDoor
-            // @default "3f7f00" (yellow-green)
+            // @default "3f7f00"
+            // @default_note yellow-green
             // Color shown while the safety door is open (Door state).
             handleRGBString(handler, "safetyDoor", safetyDoor);
 
             // @config sleep
-            // @default "001F00" (dim green)
+            // @default "001F00"
+            // @default_note dim green
             // Color shown while in Sleep state.
             handleRGBString(handler, "sleep", sleep);
 
             // @config configAlarm
-            // @default "7f0000" (red)
+            // @default "7f0000"
+            // @default_note red
             // Color shown when a configuration error put the machine into ConfigAlarm
             // state at startup.
             handleRGBString(handler, "configAlarm", configAlarm);

--- a/FluidNC/src/Machine/Axes.cpp
+++ b/FluidNC/src/Machine/Axes.cpp
@@ -181,6 +181,7 @@ namespace Machine {
 
         // @config homing_runs
         // @default 2
+        // @tuning typical
         // Number of approach/pulloff touches performed per axis during a homing sequence.
         // Default of 2 matches Grbl's convention.
         handler.item("homing_runs", _homing_runs, 1, 5);

--- a/FluidNC/src/Machine/Axis.cpp
+++ b/FluidNC/src/Machine/Axis.cpp
@@ -8,6 +8,7 @@ namespace Machine {
     void Axis::group(Configuration::HandlerBase& handler) {
         // @config steps_per_mm
         // @default 80.0
+        // @tuning per-machine
         // Controller-side step-pulse resolution for this axis -- really "steps per GCode
         // unit," despite the name: in G21 (mm) mode, a one-unit move issues this many step
         // pulses; for a linear (XYZ) axis in G20 (inches) mode, the step count is instead
@@ -18,16 +19,19 @@ namespace Machine {
 
         // @config max_rate_mm_per_min
         // @default 1000.0
+        // @tuning per-machine
         // Maximum feed rate (rapids and feed moves alike are capped here) for this axis.
         handler.item("max_rate_mm_per_min", _maxRate, 0.001, 250000.0);
 
         // @config acceleration_mm_per_sec2
         // @default 25.0
+        // @tuning per-machine
         // Acceleration used for this axis's motion ramps.
         handler.item("acceleration_mm_per_sec2", _acceleration, 0.001, 100000.0);
 
         // @config max_travel_mm
         // @default 1000.0
+        // @tuning per-machine
         // Working length of the axis, measured from its position immediately after homing
         // pull-off. If a second limit switch exists at the far end of travel (for hard
         // limits), make sure this value stays short enough that a soft-limit alarm trips
@@ -36,6 +40,7 @@ namespace Machine {
 
         // @config soft_limits
         // @default false
+        // @tuning typical
         // When true, a move that would exceed max_travel_mm is aborted before it starts;
         // jogs are instead constrained to stop at the travel limit rather than alarming.
         // Relies on accurate machine position, so the axis should be homed first -- always

--- a/FluidNC/src/Machine/Homing.h
+++ b/FluidNC/src/Machine/Homing.h
@@ -68,6 +68,7 @@ namespace Machine {
         void group(Configuration::HandlerBase& handler) override {
             // @config cycle
             // @default 0
+            // @tuning per-machine
             // Which $H (home-all) pass this axis homes in. -1 (set_mpos_only): the axis
             // doesn't move at all -- mpos_mm is just assigned directly, for an axis with no
             // home switch. 0 (the default): excluded from $H, but still homeable
@@ -88,12 +89,14 @@ namespace Machine {
 
             // @config positive_direction
             // @default true
+            // @tuning per-machine
             // Direction this axis moves while homing: true moves toward higher position
             // values, false toward lower.
             handler.item("positive_direction", _positiveDirection);
 
             // @config mpos_mm
             // @default 0.0
+            // @tuning per-machine
             // Machine position assigned to this axis once homing (and pull-off) completes.
             // Set to 0 if the switch location should read as machine-position zero. No
             // range is enforced by this item() call -- it accepts any float.
@@ -101,6 +104,7 @@ namespace Machine {
 
             // @config feed_mm_per_min
             // @default 50.0
+            // @tuning typical
             // Feed rate for the second (precise) touch of the limit switch, after the
             // initial fast approach and pull-off. Usually slow, since the axis is already
             // close to the switch -- a slower second touch tends to be more precise and
@@ -109,18 +113,21 @@ namespace Machine {
 
             // @config seek_mm_per_min
             // @default 200.0
+            // @tuning typical
             // Feed rate for the initial fast approach that finds the limit switch's rough
             // position, before pulling off and re-touching at feed_mm_per_min for precision.
             handler.item("seek_mm_per_min", _seekRate, 1.0, 100000.0);
 
             // @config settle_ms
             // @default 250
+            // @tuning typical
             // Pause, in milliseconds, between homing cycles to let the machine settle
             // mechanically after the previous cycle's motion.
             handler.item("settle_ms", _settle_ms, 0, 1000);
 
             // @config seek_scaler
             // @default 1.1
+            // @tuning typical
             // Multiplied by max_travel_mm to get the maximum distance the initial seek move
             // will travel before failing if it hasn't yet reached the limit switch -- needs
             // to be a bit over 1.0 to allow for the extra distance a prior pull-off adds.
@@ -128,6 +135,7 @@ namespace Machine {
 
             // @config feed_scaler
             // @default 1.1
+            // @tuning typical
             // Multiplied by the motor's own pulloff_mm to get the max distance the axis
             // will travel back toward the switch, after the first pull-off, before the
             // precise second touch fails. A switch with a lot of positional variability (or

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -50,7 +50,8 @@ namespace Machine {
         handler.item("name", _name);
 
         // @config meta
-        // @default "" (empty)
+        // @default ""
+        // @default_note empty
         // Free-form notes about the config file itself, e.g. "B. Dring 2022-03-15 Rev 2".
         handler.item("meta", _meta);
 
@@ -105,6 +106,7 @@ namespace Machine {
 
         // @config arc_tolerance_mm
         // @default 0.002
+        // @tuning typical
         // Maximum deviation, in mm, allowed when tessellating G2/G3 arcs into straight-line
         // segments. Smaller values produce smoother arcs at the cost of more segments (and
         // therefore more planner/computation work). Rarely changed from the default.
@@ -112,6 +114,7 @@ namespace Machine {
 
         // @config junction_deviation_mm
         // @default 0.01
+        // @tuning typical
         // Controls how aggressively the planner slows down at sharp corners between
         // consecutive moves (the Grbl-style "junction deviation" cornering algorithm).
         // Smaller values force more slowdown at corners; larger values allow faster
@@ -121,18 +124,21 @@ namespace Machine {
 
         // @config verbose_errors
         // @default true
+        // @tuning typical
         // Includes descriptive text alongside the numeric error code in error responses.
         // Some GCode senders may not parse the extra text correctly.
         handler.item("verbose_errors", _verboseErrors);
 
         // @config report_inches
         // @default false
+        // @tuning typical
         // Reports position and feed rate values in inches instead of millimeters. This
         // only affects reporting, not how input values in the GCode/config are interpreted.
         handler.item("report_inches", _reportInches);
 
         // @config enable_parking_override_control
         // @default false
+        // @tuning typical
         // Enables the M56 GCode command, which lets a running program toggle the parking-
         // motion override on/off at runtime (M56 P0 disables parking, M56 P1 enables it).
         // This only gates whether M56 has any effect; start.deactivate_parking sets what
@@ -142,6 +148,7 @@ namespace Machine {
 
         // @config use_line_numbers
         // @default false
+        // @tuning typical
         // When true, line numbers written into GCode as N<number> (e.g. N100) are tracked
         // and echoed back in status reports as Ln:100, so a report can be correlated with
         // the source line currently being executed. Reports Ln:0 when the GCode has no line
@@ -150,6 +157,7 @@ namespace Machine {
 
         // @config planner_blocks
         // @default 16
+        // @tuning typical
         // Number of motion blocks held in the look-ahead planner buffer. Leave at the
         // default unless tuning for a special application.
         handler.item("planner_blocks", _planner_blocks, 10, 120);

--- a/FluidNC/src/Machine/MachineConfig.h
+++ b/FluidNC/src/Machine/MachineConfig.h
@@ -60,12 +60,14 @@ namespace Machine {
         void group(Configuration::HandlerBase& handler) {
             // @config must_home
             // @default true
+            // @tuning typical
             // Refuses to accept motion commands until $H (home) has been run at least once
             // since boot. Jogging and settings commands still work while unhomed.
             handler.item("must_home", _mustHome);
 
             // @config deactivate_parking
             // @default false
+            // @tuning typical
             // Sets what the M56 parking-motion override defaults to at boot and after a
             // program ends (only takes effect when enable_parking_override_control is also
             // true): false leaves parking motion active by default; true starts with it
@@ -74,6 +76,7 @@ namespace Machine {
 
             // @config check_limits
             // @default true
+            // @tuning typical
             // Checks limit switches at power-up/reset; if hard limits are enabled and a
             // switch is already active, the machine enters Alarm state instead of Idle.
             handler.item("check_limits", _checkLimits);

--- a/FluidNC/src/Machine/Macros.cpp
+++ b/FluidNC/src/Machine/Macros.cpp
@@ -23,51 +23,69 @@ const MacroEvent macro3Event { 3 };
 // meaning "do nothing").
 
 // @config startup_line0
-// @default "" (empty)
+// @default ""
+// @default_note empty
+// @tuning typical
 // Legacy Grbl feature (formerly $N0). Runs once, the first time the firmware enters Idle
 // after boot.
 Macro Macros::_startup_line0 { "startup_line0" };
 
 // @config startup_line1
-// @default "" (empty)
+// @default ""
+// @default_note empty
+// @tuning typical
 // Legacy Grbl feature (formerly $N1). Runs once, the first time the firmware enters Idle
 // after boot, immediately after startup_line0.
 Macro Macros::_startup_line1 { "startup_line1" };
 
 Macro Macros::_macro[] = {
     // @config macro0
-    // @default "" (empty)
+    // @default ""
+    // @default_note empty
+    // @tuning typical
     // Runs when macro0_pin (control:) is activated. The switch must read inactive at
     // startup -- deactivate it before clearing the alarm, same as any other control input.
     Macro { "Macro0" },
     // @config macro1
-    // @default "" (empty)
+    // @default ""
+    // @default_note empty
+    // @tuning typical
     // Runs when macro1_pin (control:) is activated.
     Macro { "Macro1" },
     // @config macro2
-    // @default "" (empty)
+    // @default ""
+    // @default_note empty
+    // @tuning typical
     // Runs when macro2_pin (control:) is activated.
     Macro { "Macro2" },
     // @config macro3
-    // @default "" (empty)
+    // @default ""
+    // @default_note empty
+    // @tuning typical
     // Runs when macro3_pin (control:) is activated.
     Macro { "Macro3" },
 };
 
 // @config after_homing
-// @default "" (empty)
+// @default ""
+// @default_note empty
+// @tuning typical
 // Runs after a homing cycle completes -- i.e. once every axis with homing enabled has been
 // homed.
 Macro Macros::_after_homing { "after_homing" };
 
 // @config after_reset
-// @default "" (empty)
+// @default ""
+// @default_note empty
+// @tuning typical
 // Runs after the system resets (power-on/startup, or a Ctrl-X real-time reset), but only if
 // the system ends up in Idle state immediately after the reset.
 Macro Macros::_after_reset { "after_reset" };
 
 // @config after_unlock
-// @default "" (empty)
+// @default ""
+// @default_note empty
+// @tuning typical
 // Runs after a $X unlock command.
 Macro Macros::_after_unlock { "after_unlock" };
 

--- a/FluidNC/src/Machine/Motor.cpp
+++ b/FluidNC/src/Machine/Motor.cpp
@@ -37,6 +37,7 @@ namespace Machine {
 
         // @config hard_limits
         // @default false
+        // @tuning typical
         // Treats the switches above as hard limits: activating one immediately stops all
         // motion. Position is considered lost, so rehoming is required afterward.
         handler.item("hard_limits", _hardLimits);

--- a/FluidNC/src/Motors/RcServo.h
+++ b/FluidNC/src/Motors/RcServo.h
@@ -63,23 +63,27 @@ namespace MotorDrivers {
 
             // @config pwm_hz
             // @default 50
+            // @tuning typical
             // Servo PWM pulse repetition rate. 50Hz is the standard analog-servo value;
             // some digital servos can repeat faster.
             handler.item("pwm_hz", _pwm_freq, SERVO_PWM_FREQ_MIN, SERVO_PWM_FREQ_MAX);
 
             // @config min_pulse_us
             // @default 1000
+            // @tuning per-machine
             // Pulse width, in microseconds, corresponding to one end of the servo's travel.
             handler.item("min_pulse_us", _min_pulse_us, SERVO_PULSE_US_MIN, SERVO_PULSE_US_MAX);
 
             // @config max_pulse_us
             // @default 2000
+            // @tuning per-machine
             // Pulse width, in microseconds, corresponding to the other end of the servo's
             // travel.
             handler.item("max_pulse_us", _max_pulse_us, SERVO_PULSE_US_MIN, SERVO_PULSE_US_MAX);
 
             // @config timer_ms
             // @default 20
+            // @tuning typical
             // Update interval, in milliseconds, for refreshing the servo's PWM position.
             handler.item("timer_ms", _timer_ms, TIMER_MS_MIN, TIMER_MS_MAX);
 

--- a/FluidNC/src/Motors/Solenoid.h
+++ b/FluidNC/src/Motors/Solenoid.h
@@ -51,22 +51,26 @@ namespace MotorDrivers {
 
             // @config pwm_hz
             // @default 1000
+            // @tuning typical
             // PWM frequency driving the solenoid.
             handler.item("pwm_hz", _pwm_freq, 1000, 100000);
 
             // @config off_percent
             // @default 0.0
+            // @tuning typical
             // Duty cycle while off.
             handler.item("off_percent", _off_percent, 0.0f, 100.0f);
 
             // @config pull_percent
             // @default 100.0
+            // @tuning typical
             // Duty cycle during the initial pull-in (highest power, to overcome the
             // solenoid's resting inertia).
             handler.item("pull_percent", _pull_percent, 0.0f, 100.0f);
 
             // @config hold_percent
             // @default 75.0
+            // @tuning typical
             // Duty cycle after pull-in, while holding the solenoid engaged -- typically
             // lower than pull_percent, since holding a solenoid needs less power than
             // pulling it in.
@@ -74,17 +78,20 @@ namespace MotorDrivers {
 
             // @config pull_ms
             // @default 500
+            // @tuning typical
             // How long the pull_percent duty cycle is applied before switching to
             // hold_percent.
             handler.item("pull_ms", _pull_ms, 0, 3000);
 
             // @config direction_invert
             // @default false
+            // @tuning typical
             // Inverts which side of the axis's mpos 0.0 counts as "active".
             handler.item("direction_invert", _dir_invert);
 
             // @config timer_ms
             // @default 50
+            // @tuning typical
             // Update interval, in milliseconds, for the solenoid's PWM state machine
             // (pull/hold timing).
             handler.item("timer_ms", _timer_ms);

--- a/FluidNC/src/Motors/TMC2209Driver.h
+++ b/FluidNC/src/Motors/TMC2209Driver.h
@@ -47,7 +47,8 @@ namespace MotorDrivers {
             handler.item("homing_mode", _homing_mode, trinamicModes);
 
             // @config homing_amps
-            // @default 0.0 -- substituted with run_amps if left at 0
+            // @default 0.0
+            // @default_note substituted with run_amps if left at 0
             // Motor current while homing. Leaving this at its default 0 isn't literally
             // "zero current" -- afterParse() detects the default and substitutes run_amps
             // instead, so omitting this field entirely is equivalent to setting it equal to

--- a/FluidNC/src/Motors/TrinamicBase.h
+++ b/FluidNC/src/Motors/TrinamicBase.h
@@ -81,6 +81,7 @@ namespace MotorDrivers {
 
             // @config r_sense_ohms
             // @default 0.0
+            // @tuning per-machine
             // Sense resistor value for the physical driver module, in ohms. The 0.0 default
             // is not a real, functional value -- TrinamicBase itself has no correct generic
             // default, since this is purely a property of the specific module in hand
@@ -91,16 +92,19 @@ namespace MotorDrivers {
 
             // @config run_amps
             // @default 0.5
+            // @tuning per-machine
             // Motor current while running, in amps RMS.
             handler.item("run_amps", _run_current, 0.05, 10.0);
 
             // @config hold_amps
             // @default 0.5
+            // @tuning per-machine
             // Motor current while holding position (not moving), in amps RMS.
             handler.item("hold_amps", _hold_current, 0.05, 10.0);
 
             // @config microsteps
             // @default 16
+            // @tuning per-machine
             // Microstep resolution. Needs to be reflected in the axis's steps_per_mm.
             handler.item("microsteps", _microsteps, 1, 256);
 

--- a/FluidNC/src/Motors/TrinamicUartDriver.h
+++ b/FluidNC/src/Motors/TrinamicUartDriver.h
@@ -33,6 +33,7 @@ namespace MotorDrivers {
         void group(Configuration::HandlerBase& handler) override {
             // @config addr
             // @default 0
+            // @tuning per-machine
             // Hardware UART address of the chip. TMC2208/TMC2225 have a fixed address of 0
             // (this field has no effect on them); TMC2209/TMC2226 set their real address
             // via their MS1/MS2 pins, making them individually addressable (up to 4 chips
@@ -49,6 +50,7 @@ namespace MotorDrivers {
 
             // @config uart_num
             // @default -1
+            // @tuning per-machine
             // Which top-level uartN: section this chip's UART register interface runs
             // over. Required -- afterParse() asserts this is actually set.
             handler.item("uart_num", _uart_num);

--- a/FluidNC/src/Parking.cpp
+++ b/FluidNC/src/Parking.cpp
@@ -193,6 +193,7 @@ void Parking::restore_coolant() {
 void Parking::group(Configuration::HandlerBase& handler) {
     // @config enable
     // @default false
+    // @tuning per-machine
     // Enables the parking feature: opening the safety door (or sending the SafetyDoor
     // real-time command, 0x84) pulls the parking axis out and retracts it to target_mpos_mm
     // instead of just stopping motion. Also gated by enable_parking_override_control/M56 if
@@ -202,30 +203,35 @@ void Parking::group(Configuration::HandlerBase& handler) {
 
     // @config axis
     // @default z
+    // @tuning per-machine
     // Which axis performs the parking retract/return sequence. Typically Z. Homing that
     // axis is required -- parking silently does nothing until it has been homed.
     handler.item("axis", _axis);
 
     // @config target_mpos_mm
     // @default -5.0
+    // @tuning per-machine
     // Machine-position target (not affected by any active offset) for the final parking
     // retract move.
     handler.item("target_mpos_mm", _target_mpos);
 
     // @config rate_mm_per_min
     // @default 800.0
+    // @tuning per-machine
     // Feed rate for the final parking retract move, from the pull-out waypoint to
     // target_mpos_mm.
     handler.item("rate_mm_per_min", _rate);
 
     // @config pullout_distance_mm
     // @default 5.0
+    // @tuning per-machine
     // Distance of the initial slow pull-out move, relative to the position where parking
     // started -- done before the spindle stops and the fast retract to target_mpos_mm.
     handler.item("pullout_distance_mm", _pullout, 0, 3e38);
 
     // @config pullout_rate_mm_per_min
     // @default 250.0
+    // @tuning per-machine
     // Feed rate for the initial pull-out move (and the equivalent slow return move when
     // resuming from park).
     handler.item("pullout_rate_mm_per_min", _pullout_rate);

--- a/FluidNC/src/Probe.cpp
+++ b/FluidNC/src/Probe.cpp
@@ -48,6 +48,7 @@ void Probe::group(Configuration::HandlerBase& handler) {
 
     // @config check_mode_start
     // @default true
+    // @tuning typical
     // Only affects Grbl Check Mode ($C, dry-run parsing with no real motion): while in
     // Check Mode, a probe move reports its position as the move's un-probed target when
     // false, or leaves it at the pre-move start position when true. Has no effect on a real
@@ -56,6 +57,7 @@ void Probe::group(Configuration::HandlerBase& handler) {
 
     // @config hard_stop
     // @default false
+    // @tuning typical
     // On a successful probe trigger, stops with an immediate hard stop instead of
     // decelerating -- avoids the extra travel deceleration needs, at the cost of possibly
     // losing steps (and therefore position accuracy) at higher speeds. Useful with fragile
@@ -64,6 +66,7 @@ void Probe::group(Configuration::HandlerBase& handler) {
 
     // @config probe_hard_limit
     // @default false
+    // @tuning typical
     // When true, the probe pin(s) also act like a hard limit switch during non-probing
     // motion (homing, jog, cycle): triggering it raises an alarm and immediately stops
     // motion, the same as a real hard limit switch would. Guards against accidental probe

--- a/FluidNC/src/SDCard.h
+++ b/FluidNC/src/SDCard.h
@@ -59,6 +59,7 @@ public:
 
         // @config frequency_hz
         // @default 8000000
+        // @tuning typical
         // SPI clock speed used for the SD card. Try a lower value if the card has
         // consistent read/write problems.
         handler.item("frequency_hz", _frequency_hz, 400000, 20000000);

--- a/FluidNC/src/Spindles/BESCSpindle.h
+++ b/FluidNC/src/Spindles/BESCSpindle.h
@@ -69,6 +69,7 @@ namespace Spindles {
 
             // @config min_pulse_us
             // @default 900
+            // @tuning per-machine
             // Pulse width, in microseconds, corresponding to the ESC's "off" signal.
             // Determine your ESC's actual min pulse from its datasheet/documentation --
             // typically around 1ms (1000us) or less.
@@ -76,6 +77,7 @@ namespace Spindles {
 
             // @config max_pulse_us
             // @default 2200
+            // @tuning per-machine
             // Pulse width, in microseconds, corresponding to the ESC's full-power signal.
             // Typically around 2ms (2000us) or more -- check your ESC's documentation.
             handler.item("max_pulse_us", _max_pulse_us, 500, 3000);

--- a/FluidNC/src/Spindles/PWMSpindle.h
+++ b/FluidNC/src/Spindles/PWMSpindle.h
@@ -48,6 +48,7 @@ namespace Spindles {
             // user choose.
             // @config pwm_hz
             // @default 5000
+            // @tuning typical
             // PWM signal frequency. Resolution trades off against frequency -- 76Hz or
             // less gets the full 20-bit duty-cycle resolution, roughly halving for every
             // doubling of frequency above that, down to 4 levels (2 bits) at the 20MHz

--- a/FluidNC/src/Spindles/PlasmaSpindle.h
+++ b/FluidNC/src/Spindles/PlasmaSpindle.h
@@ -52,6 +52,7 @@ namespace Spindles {
 
             // @config arc_wait_ms
             // @default 1000
+            // @tuning typical
             // How long to wait for arc_ok_pin to confirm the arc has started before giving
             // up.
             handler.item("arc_wait_ms", _max_arc_wait, 0, 3000);

--- a/FluidNC/src/Spindles/Spindle.h
+++ b/FluidNC/src/Spindles/Spindle.h
@@ -103,6 +103,7 @@ namespace Spindles {
 
             // @config tool_num
             // @default 0
+            // @tuning typical
             // Sets the tool-number range this spindle responds to for M6 Tn tool changes.
             // With a single spindle, the value doesn't matter (conventionally 0). With
             // multiple spindles, give each a distinct number -- ranges are implied by
@@ -111,7 +112,9 @@ namespace Spindles {
             handler.item("tool_num", _tool, 0, MaxToolNumber);
 
             // @config speed_map
-            // @default "" (empty)
+            // @default ""
+            // @default_note empty
+            // @tuning per-machine
             // Maps GCode S values to actual spindle speeds/PWM duty -- lets the S-to-speed
             // relationship be linearized or clamped to a minimum speed. See the speed-map
             // documentation for the full syntax.
@@ -119,30 +122,37 @@ namespace Spindles {
 
             // @config off_on_alarm
             // @default false
+            // @tuning typical
             // Turns the spindle off whenever an alarm occurs. Worth enabling with a safety
             // door in use, since the parking feature doesn't operate while in alarm state.
             handler.item("off_on_alarm", _off_on_alarm);
 
             // @config atc
-            // @default "" (empty)
+            // @default ""
+            // @default_note empty
+            // @tuning typical
             // Names an atc_manual:/ATC section (defined elsewhere in the config) to
             // associate with this spindle for automatic tool changes.
             handler.item("atc", _atc_name);
 
             // @config m6_macro
-            // @default "" (empty)
+            // @default ""
+            // @default_note empty
+            // @tuning typical
             // A macro (one config-file line, same syntax as macros:) to run for this
             // spindle's M6 tool change, instead of the built-in tool-change behavior.
             handler.item("m6_macro", _m6_macro);
 
             // @config s0_with_disable
             // @default false
+            // @tuning typical
             // When true, an M5 (spindle off) also forces the speed signal to S0 (zero) --
             // by default the speed output stays at its last commanded value even during M5.
             handler.item("s0_with_disable", _zero_speed_with_disable);
 
             // @config disable_with_s0
             // @default false
+            // @tuning typical
             // When true, commanding S0 (zero speed) also disables the spindle, the same as
             // M5 -- by default, only M5 itself disables it.
             handler.item("disable_with_s0", _disable_with_zero_speed);
@@ -155,6 +165,7 @@ namespace Spindles {
         void groupDelaySettings(Configuration::HandlerBase& handler) {
             // @config spinup_ms
             // @default 0
+            // @tuning typical
             // Time given for the spindle to reach the commanded RPM (per the speed
             // map) before the following GCode line executes. Proportional to the RPM
             // change -- a half-scale speed change only waits half of this value.
@@ -162,6 +173,7 @@ namespace Spindles {
 
             // @config spindown_ms
             // @default 0
+            // @tuning typical
             // Same as spinup_ms, but applied when the commanded RPM decreases.
             handler.item("spindown_ms", _spindown_ms, 0, 60000);
         }

--- a/FluidNC/src/Spindles/VFD/ModbusVFD.h
+++ b/FluidNC/src/Spindles/VFD/ModbusVFD.h
@@ -73,58 +73,68 @@ namespace Spindles {
                 // of these same fields with model-appropriate values.
 
                 // @config model
-                // @default "" (empty)
+                // @default ""
+                // @default_note empty
                 // VFD model name. Informational (used for support purposes) -- not itself
                 // used to select protocol behavior; the cw_cmd/ccw_cmd/etc. fields below
                 // are what actually define the protocol.
                 handler.item("model", _model);
 
                 // @config min_RPM
-                // @default 0xffffffff (uninitialized sentinel)
+                // @default 0xffffffff
+                // @default_note uninitialized sentinel
                 // Minimum spindle RPM, in Hz-derived RPM terms. Normally left unset and
                 // retrieved from the VFD itself via get_min_rpm_cmd at startup.
                 handler.item("min_RPM", _minRPM);
 
                 // @config max_RPM
-                // @default 0xffffffff (uninitialized sentinel)
+                // @default 0xffffffff
+                // @default_note uninitialized sentinel
                 // Maximum spindle RPM. Normally left unset and retrieved from the VFD
                 // itself via get_max_rpm_cmd at startup.
                 handler.item("max_RPM", _maxRPM);
 
                 // @config cw_cmd
-                // @default "" (empty)
+                // @default ""
+                // @default_note empty
                 // Modbus command template for clockwise spindle rotation.
                 handler.item("cw_cmd", _cw_cmd);
 
                 // @config ccw_cmd
-                // @default "" (empty)
+                // @default ""
+                // @default_note empty
                 // Modbus command template for counter-clockwise spindle rotation.
                 handler.item("ccw_cmd", _ccw_cmd);
 
                 // @config off_cmd
-                // @default "" (empty)
+                // @default ""
+                // @default_note empty
                 // Modbus command template to stop the spindle.
                 handler.item("off_cmd", _off_cmd);
 
                 // @config set_rpm_cmd
-                // @default "" (empty)
+                // @default ""
+                // @default_note empty
                 // Modbus command template to set the spindle speed.
                 handler.item("set_rpm_cmd", _set_rpm_cmd);
 
                 // @config get_min_rpm_cmd
-                // @default "" (empty)
+                // @default ""
+                // @default_note empty
                 // Modbus command template to query the VFD's minimum RPM. If left unset,
                 // speed_map must be configured manually instead of being auto-derived.
                 handler.item("get_min_rpm_cmd", _get_min_rpm_cmd);
 
                 // @config get_max_rpm_cmd
-                // @default "" (empty)
+                // @default ""
+                // @default_note empty
                 // Modbus command template to query the VFD's maximum RPM. If left unset,
                 // speed_map must be configured manually instead of being auto-derived.
                 handler.item("get_max_rpm_cmd", _get_max_rpm_cmd);
 
                 // @config get_rpm_cmd
-                // @default "" (empty)
+                // @default ""
+                // @default_note empty
                 // Modbus command template to query the VFD's current RPM. spinup_ms/
                 // spindown_ms (Spindle::groupDelaySettings()) are always present in
                 // config.yaml for a VFD spindle regardless of this field -- what this

--- a/FluidNC/src/Spindles/VFDSpindle.cpp
+++ b/FluidNC/src/Spindles/VFDSpindle.cpp
@@ -232,20 +232,23 @@ namespace Spindles {
                 handler.section("uart", _uart, 1);
             } else {
                 // @config uart_num
-                // @default -1 (not configured)
+                // @default -1
+                // @default_note not configured
                 // Which top-level uartN: section this VFD's Modbus link runs over.
                 handler.item("uart_num", _uart_num);
             }
         } else {
             handler.section("uart", _uart, 1);
             // @config uart_num
-            // @default -1 (not configured)
+            // @default -1
+            // @default_note not configured
             // Which top-level uartN: section this VFD's Modbus link runs over.
             handler.item("uart_num", _uart_num);
         }
 
         // @config modbus_id
         // @default 1
+        // @tuning typical
         // Modbus slave address of the VFD -- must match the VFD's own configured value
         // (per https://modbus.org/docs/PI_MBUS_300.pdf). When in doubt, try 1.
         handler.item("modbus_id", _modbus_id, 0, 247);  // per https://modbus.org/docs/PI_MBUS_300.pdf

--- a/FluidNC/src/Status_outputs.h
+++ b/FluidNC/src/Status_outputs.h
@@ -53,6 +53,7 @@ public:
 
         // @config report_interval_ms
         // @default 500
+        // @tuning typical
         // How often, in milliseconds, the output pins are refreshed against current status.
         // Doesn't need to be fast -- an update also happens immediately on every status
         // change regardless of this interval.

--- a/FluidNC/src/Stepping.cpp
+++ b/FluidNC/src/Stepping.cpp
@@ -195,7 +195,8 @@ void IRAM_ATTR Stepping::stopTimer() {
 
 void Stepping::group(Configuration::HandlerBase& handler) {
     // @config engine
-    // @default board-dependent (DEFAULT_STEPPING_ENGINE, applied in afterParse())
+    // @default (none)
+    // @default_note board-dependent (DEFAULT_STEPPING_ENGINE, applied in afterParse())
     // Method used to generate step pulses in firmware. Controller board hardware is
     // designed for either RMT or I2S stepping, so this must match what the board
     // actually wires up -- stepping types cannot be mixed across motors. Choices come
@@ -212,7 +213,9 @@ void Stepping::group(Configuration::HandlerBase& handler) {
     handler.item("engine", _engine);
 
     // @config idle_ms
-    // @default 255 -- special "never auto-disable" value (Grbl compatibility)
+    // @default 255
+    // @default_note special "never auto-disable" value (Grbl compatibility)
+    // @tuning typical
     // Milliseconds of inactivity before motors are automatically disabled. Any value
     // other than 255 (0-254 or 256+) is a real delay. Motors can also be disabled
     // manually at any time with $MD.
@@ -220,6 +223,7 @@ void Stepping::group(Configuration::HandlerBase& handler) {
 
     // @config pulse_us
     // @default 4
+    // @tuning typical
     // Duration, in microseconds, of the "on" part of each step pulse; it typically
     // needs an equal "off" duration, so this caps the max step rate at roughly
     // 1000000/(2*pulse_us + dir_delay_us) steps/sec. Too short a pulse won't be
@@ -228,12 +232,14 @@ void Stepping::group(Configuration::HandlerBase& handler) {
 
     // @config dir_delay_us
     // @default 0
+    // @tuning typical
     // Delay, in microseconds, required between a direction change and the next step
     // pulse. Most drivers don't need this and can leave it at 0.
     handler.item("dir_delay_us", _directionDelayUsecs, 0, 10);
 
     // @config disable_delay_us
     // @default 0
+    // @tuning typical
     // Delay, in microseconds, some motors need between being enabled and being able
     // to take their first step.
     handler.item("disable_delay_us", _disableDelayUsecs, 0, 1000000);  // max 1 second

--- a/FluidNC/src/ToolChangers/atc_manual.h
+++ b/FluidNC/src/ToolChangers/atc_manual.h
@@ -61,6 +61,7 @@ namespace ATCs {
 
             // @config safe_z_mpos_mm
             // @default 50.0
+            // @tuning per-machine
             // Machine-space Z position safe to travel at without hitting the workpiece or
             // fixtures, used while moving to/from the tool-change and tool-setter
             // locations.
@@ -68,11 +69,13 @@ namespace ATCs {
 
             // @config probe_seek_rate_mm_per_min
             // @default 200.0
+            // @tuning per-machine
             // Feed rate for the initial (fast) probe move onto the electronic tool setter.
             handler.item("probe_seek_rate_mm_per_min", _probe_seek_rate, 1, 10000);
 
             // @config probe_feed_rate_mm_per_min
             // @default 80.0
+            // @tuning per-machine
             // Feed rate for the precise (slow) second probe touch on the electronic tool
             // setter.
             handler.item("probe_feed_rate_mm_per_min", _probe_feed_rate, 1, 10000);
@@ -92,6 +95,7 @@ namespace ATCs {
 
             // @config ets_rapid_z_mpos_mm
             // @default 0.0
+            // @tuning per-machine
             // Z position to rapid to before starting the ETS probe approach, giving
             // clearance above the probe before the slower seek/feed moves begin.
             handler.item("ets_rapid_z_mpos_mm", _ets_rapid_z_mpos);

--- a/FluidNC/src/Uart.cpp
+++ b/FluidNC/src/Uart.cpp
@@ -321,18 +321,26 @@ void Uart::group(Configuration::HandlerBase& handler) {
 
     // @config baud
     // @default 115200
-    // UART data baud rate.
+    // @tuning typical
+    // UART data baud rate. What "typical" means here depends heavily on what this
+    // bus actually carries -- a TMC2209 UART chain, an RS485/Modbus VFD link, and a
+    // uart_channel: pendant/DRO each have their own real conventional rate (commonly
+    // 115200, 9600, and a much higher rate respectively), but this one field/default
+    // is shared by all of them, so this is only a reasonable single-context starting
+    // point, not a universal one -- always verify against what's actually on the bus.
     handler.item("baud", _baud, 2400, 10000000);
 
     // @config mode
     // @default 8N1
+    // @tuning typical
     // Data format as a 3-character code: data bits (5-8), parity (N/E/O), stop bits
     // (1/1.5/2) -- e.g. 8N1. Always quote this value in YAML (see the config spec's note on
     // 8E1 being ambiguous with scientific-notation floats to generic YAML parsers).
     handler.item("mode", _dataBits, _parity, _stopBits);
 
     // @config passthrough_baud
-    // @default 0 (not configured)
+    // @default 0
+    // @default_note not configured
     // Baud rate used while this UART is in passthrough mode (e.g. forwarding firmware
     // uploads from FluidTerm). 0 means passthrough is not configured for this UART.
     handler.item("passthrough_baud", _passthrough_baud, 0, 10000000);  // 0 means not configured

--- a/FluidNC/src/UartChannel.h
+++ b/FluidNC/src/UartChannel.h
@@ -57,7 +57,9 @@ public:
     // Configuration methods
     void group(Configuration::HandlerBase& handler) override {
         // @config report_interval_ms
-        // @default 0 (off)
+        // @default 0
+        // @default_note off
+        // @tuning per-machine
         // Interval, in milliseconds, at which a status report is proactively pushed to this
         // channel while moving -- useful for driving a DRO without it having to poll. 0
         // disables proactive reporting. No range is enforced by this item() call itself,
@@ -67,6 +69,7 @@ public:
 
         // @config uart_num
         // @default 0
+        // @tuning per-machine
         // Which previously-defined top-level uartN: section this channel runs over.
         handler.item("uart_num", _uart_num);
 

--- a/tools/build_config_docs.py
+++ b/tools/build_config_docs.py
@@ -40,6 +40,12 @@ SECTIONS = [
     ("uart_channelN", [("UartChannel.h", "UartChannel")], None),
     ("status_outputs", [("Status_outputs.h", "Status_Outputs")], None),
     ("ethernet", [("Machine/EthPhy.h", "EthPhy")], None),
+    (
+        "oled",
+        [("../esp32/OLED.h", "OLED")],
+        "Lives under FluidNC/esp32/ (an ESP32-specific module), not FluidNC/src/ like every "
+        "other section here -- the relative path above deliberately escapes SRC to reach it.",
+    ),
     ("atc_manual", [("ToolChangers/atc_manual.h", "Manual_ATC")], None),
     (
         "extenders.pinextenderN.<i2c_chip>",
@@ -214,12 +220,17 @@ def merge_section(contributors):
 
 def list_mode_section(rel_file, kind_for=None):
     text = (SRC / rel_file).read_text()
-    docs, missing_default = g.parse_doc_blocks(text)
+    docs, missing_default, bad_tuning = g.parse_doc_blocks(text)
     entries = {}
     errors = []
+    bad_tuning_names = {name for name, _ in bad_tuning}
     for name, doc in docs.items():
         if name in missing_default:
             errors.append(f"@config {name} is missing its required @default line")
+            continue
+        if name in bad_tuning_names:
+            value = next(v for n, v in bad_tuning if n == name)
+            errors.append(f"@config {name} has @tuning {value!r} -- must be one of {sorted(g.VALID_TUNING_VALUES)}")
             continue
         kind = "string"
         if kind_for == "pin":
@@ -229,6 +240,10 @@ def list_mode_section(rel_file, kind_for=None):
         elif kind_for is None:  # RGBLed: mixed
             kind = RGBLED_TYPES.get(name, "string (hex color RRGGBB, or \"none\")")
         entry = {"kind": kind, "default": doc["default"]}
+        if doc.get("default_note"):
+            entry["default_note"] = doc["default_note"]
+        if doc.get("tuning"):
+            entry["tuning"] = doc["tuning"]
         if doc["unit"]:
             entry["unit"] = doc["unit"]
         entry["description"] = doc["description"]

--- a/tools/gen_config_docs.py
+++ b/tools/gen_config_docs.py
@@ -47,8 +47,21 @@ ITEM_CALL_RE = re.compile(
 )
 CONFIG_TAG_RE = re.compile(r'^\s*//\s*@config\s+(\S+)\s*$')
 DEFAULT_TAG_RE = re.compile(r'^\s*//\s*@default\s+(.+?)\s*$')
+DEFAULT_NOTE_TAG_RE = re.compile(r'^\s*//\s*@default_note\s+(.+?)\s*$')
+TUNING_TAG_RE = re.compile(r'^\s*//\s*@tuning\s+(\S+)\s*$')
 UNIT_TAG_RE = re.compile(r'^\s*//\s*@unit\s+(.+?)\s*$')
 COMMENT_LINE_RE = re.compile(r'^\s*//(.*)$')
+
+# The only two values @tuning may take -- see ItemDocs.md. Anything else is
+# almost certainly a typo (e.g. "per_machine" instead of "per-machine") and
+# should fail loudly rather than silently pass through as an unrecognized
+# string a downstream consumer might mishandle.
+VALID_TUNING_VALUES = {"typical", "per-machine"}
+
+# Reserved @default value meaning "no fixed literal exists" (board-dependent,
+# code-substituted, ...) -- see ItemDocs.md. Distinct from None/missing,
+# which means the annotation is simply absent (an error, see missing_default).
+NO_LITERAL_DEFAULT = "(none)"
 
 
 def find_group_body(cpp_text: str, class_name: str, method_name: str = "group") -> str:
@@ -85,15 +98,19 @@ def find_group_body(cpp_text: str, class_name: str, method_name: str = "group") 
 
 
 def parse_doc_blocks(body: str):
-    """Return (docs, missing_default) from @config blocks.
+    """Return (docs, missing_default, bad_tuning) from @config blocks.
 
-    docs: {item_name: {"default": str|None, "unit": str|None, "description": str}}
+    docs: {item_name: {"default": str|None, "default_note": str|None, "tuning": str|None, "unit": str|None, "description": str}}
     missing_default: names of @config blocks that had no immediately-following
     @default line -- a required field per ItemDocs.md, reported as an error
     by the caller rather than silently treated as "no default."
+    bad_tuning: (name, value) pairs where @tuning's value wasn't one of
+    VALID_TUNING_VALUES -- reported as an error, same reasoning as
+    missing_default (a typo here should fail loudly, not pass through).
     """
     docs = {}
     missing_default = []
+    bad_tuning = []
     lines = body.splitlines()
     i = 0
     while i < len(lines):
@@ -111,6 +128,20 @@ def parse_doc_blocks(body: str):
                 i += 1
         if default is None:
             missing_default.append(name)
+        default_note = None
+        if i < len(lines):
+            dnm = DEFAULT_NOTE_TAG_RE.match(lines[i])
+            if dnm:
+                default_note = dnm.group(1)
+                i += 1
+        tuning = None
+        if i < len(lines):
+            tm = TUNING_TAG_RE.match(lines[i])
+            if tm:
+                tuning = tm.group(1)
+                i += 1
+                if tuning not in VALID_TUNING_VALUES:
+                    bad_tuning.append((name, tuning))
         unit = None
         if i < len(lines):
             um = UNIT_TAG_RE.match(lines[i])
@@ -136,8 +167,14 @@ def parse_doc_blocks(body: str):
                 current.append(line)
         if current:
             paragraphs.append(" ".join(current))
-        docs[name] = {"default": default, "unit": unit, "description": "\n\n".join(paragraphs)}
-    return docs, missing_default
+        docs[name] = {
+            "default": default,
+            "default_note": default_note,
+            "tuning": tuning,
+            "unit": unit,
+            "description": "\n\n".join(paragraphs),
+        }
+    return docs, missing_default, bad_tuning
 
 
 def parse_item_calls(body: str):
@@ -297,11 +334,15 @@ def build_entry(call, cpp_text, header_text, class_name, docs, enum_lookup, enum
     doc = docs.get(name)
     if doc:
         entry["default"] = doc["default"]
+        if doc.get("default_note"):
+            entry["default_note"] = doc["default_note"]
+        if doc.get("tuning"):
+            entry["tuning"] = doc["tuning"]
         if doc["unit"]:
             entry["unit"] = doc["unit"]
         entry["description"] = doc["description"]
 
-        if default_literal is not None and doc["default"] is not None:
+        if default_literal is not None and doc["default"] is not None and doc["default"] != NO_LITERAL_DEFAULT:
             # Best-effort cross-check: the annotated text should at least
             # mention the literal the initializer shows (e.g. "255" appearing
             # somewhere in "255 -- special ..."). A miss doesn't necessarily
@@ -310,6 +351,8 @@ def build_entry(call, cpp_text, header_text, class_name, docs, enum_lookup, enum
             # not a hard failure. Strip a trailing C++ float-literal suffix
             # (0.002f -> 0.002) first -- otherwise every plain float default
             # would spuriously warn, since the annotation naturally omits it.
+            # Skipped entirely when @default is the (none) sentinel -- see
+            # ItemDocs.md -- there's deliberately no literal to compare.
             literal_for_compare = re.sub(r'(?<=[0-9])[fFlL]$', '', default_literal)
             if literal_for_compare not in doc["default"]:
                 warnings.append(
@@ -356,6 +399,10 @@ def to_yaml(section: str, entries: dict) -> str:
             lines.append(f"    default: {e['default']!r}")
         else:
             lines.append("    default: null  # missing @default -- should have been caught as an error")
+        if "default_note" in e:
+            lines.append(f"    default_note: {e['default_note']!r}")
+        if "tuning" in e:
+            lines.append(f"    tuning: {e['tuning']}")
         if "unit" in e:
             lines.append(f"    unit: {e['unit']!r}")
         if "description" in e:
@@ -382,7 +429,7 @@ def process_class(cpp_file: Path, class_name: str, method_name: str = "group"):
     header_text = header_path.read_text() if header_path.exists() else ""
 
     body = find_group_body(cpp_text, class_name, method_name)
-    docs, missing_default = parse_doc_blocks(body)
+    docs, missing_default, bad_tuning = parse_doc_blocks(body)
     calls = parse_item_calls(body)
     enum_arrays = find_enum_arrays(cpp_text)
 
@@ -414,6 +461,8 @@ def process_class(cpp_file: Path, class_name: str, method_name: str = "group"):
         errors.append(f'handler.item("{name}", ...) has no @config/@default annotation')
     for name in missing_default:
         errors.append(f'@config {name} is missing its required @default line')
+    for name, value in bad_tuning:
+        errors.append(f'@config {name} has @tuning {value!r} -- must be one of {sorted(VALID_TUNING_VALUES)}')
 
     return entries, errors, warnings
 


### PR DESCRIPTION
## Summary
- Adds an optional `@tuning typical|per-machine` tag to the `@config` item-annotation convention (`FluidNC/src/Configuration/ItemDocs.md`), so a config wizard can distinguish "a compiled default exists" from "that default is actually safe to assume for most machines." Tagged every item identified in FluidNC-config-wizard's tuning-classification review.
- Requires `@default` to always be a clean, directly machine-parseable literal (or the reserved `(none)` sentinel when no fixed literal exists at all, e.g. a board-dependent value); adds an optional `@default_note` for the qualifier text that used to be crammed onto the `@default` line itself.
- Extends `tools/gen_config_docs.py`/`tools/build_config_docs.py` to parse and emit both new fields, and regenerates `FluidNC/docs/config_items.yaml`.
- Fixes two drifted values found while tagging: `PlasmaSpindle::arc_wait_ms`'s wizard-side default was `3000` against a real firmware default of `1000`; confirms `s0_with_disable`/`positive_direction` source annotations were already correct (the drift there was isolated to the wizard's own hardcoded copies, not source).
- Confirmed `build-release.py` already generates and ships this file to `bdring/fluidnc-releases` on every release, so no separate release-plumbing changes were needed.

## Test plan
- [x] `python3 tools/build_config_docs.py` regenerates `FluidNC/docs/config_items.yaml` cleanly (exit 0, only pre-existing cosmetic warnings unrelated to this change)
- [x] Verified every `default:` value in the regenerated file is now a bare literal or `(none)`
- [x] Verified against the FluidNC-config-wizard integration: `@tuning`-driven autofill and the BESC/RcServo `min_pulse_us`/`max_pulse_us` bare-name-collision fix both work end-to-end in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)