### PR TITLE
Fix xmodem

### DIFF
--- a/FluidNC/esp32/esp32/Platform.h
+++ b/FluidNC/esp32/esp32/Platform.h
@@ -44,12 +44,36 @@ const int BAUD_RATE = 115200;
 
 #include <esp_idf_version.h>
 
+#include "Logging.h"
+
 inline void platform_preinit() {
 #if ESP_IDF_VERSION_MAJOR < 5
     disableCore0WDT();
 #else
-    // Add current task to the watchdog
-    esp_task_wdt_add(NULL);  // NULL means current task
+    // The loop task (running setup()/loop()) must NOT be subscribed to the
+    // TWDT here. FluidNC's watchdog design (see esp32/wdt.cpp,
+    // Driver/watchdog.h) is opt-in: only tasks that explicitly call
+    // add_watchdog_to_task() and then periodically feed_watchdog() are meant
+    // to be monitored. setup() legitimately blocks for long stretches during
+    // network bring-up -- WifiConfig's STA connect retries for up to ~40s,
+    // and EthConfig's link-up wait blocks for up to 5s -- without feeding
+    // any watchdog.
+    //
+    // This branch previously called esp_task_wdt_add(NULL) here, which is
+    // exactly the bug found and fixed on ESP32-S3 (see
+    // esp32/esp32s3/Platform.h): as of Arduino-ESP32 core 3.x / ESP-IDF 5.x,
+    // subscribing the loop task this early tripped a real TWDT timeout --
+    // and killed the board -- during blocking network bring-up. This code
+    // path is currently unreachable on plain ESP32 (which is pinned to
+    // ESP-IDF 4.4, taking the branch above), but is fixed preemptively so it
+    // doesn't silently reintroduce that crash if plain ESP32 is ever moved
+    // to ESP-IDF 5.x, matching what already happened for S3.
+    if (esp_task_wdt_status(NULL) == ESP_OK) {
+        esp_err_t err = esp_task_wdt_delete(NULL);  // NULL means current task
+        if (err != ESP_OK) {
+            log_error("esp_task_wdt_delete failed: " << esp_err_to_name(err));
+        }
+    }
 #endif
 }
 

--- a/FluidNC/esp32/esp32s3/Platform.h
+++ b/FluidNC/esp32/esp32s3/Platform.h
@@ -90,9 +90,17 @@ inline void platform_preinit() {
     // Ethernet link-up wait, which doesn't feed the watchdog. So instead of
     // adding a second subscription, actively remove whatever subscription
     // the framework already created.
-    esp_err_t err = esp_task_wdt_delete(NULL);  // NULL means current task
-    if (err != ESP_OK && err != ESP_ERR_NOT_FOUND) {
-        log_error("esp_task_wdt_delete failed: " << esp_err_to_name(err));
+    // Only call esp_task_wdt_delete() if we're actually subscribed --
+    // esp_task_wdt_delete() logs its own "task not found" error internally
+    // when the current task isn't subscribed, before returning
+    // ESP_ERR_NOT_FOUND to us, so checking first (rather than just tolerating
+    // that return code below) avoids a spurious log line on every boot where
+    // the framework's auto-subscription hasn't happened yet at this point.
+    if (esp_task_wdt_status(NULL) == ESP_OK) {
+        esp_err_t err = esp_task_wdt_delete(NULL);  // NULL means current task
+        if (err != ESP_OK) {
+            log_error("esp_task_wdt_delete failed: " << esp_err_to_name(err));
+        }
     }
 #endif
 }

--- a/FluidNC/esp32/wdt.cpp
+++ b/FluidNC/esp32/wdt.cpp
@@ -59,7 +59,17 @@ void disable_core0_WDT() {
 
 void feed_watchdog() {
 #ifdef CONFIG_ESP_TASK_WDT_EN
-    esp_task_wdt_reset();
+    // esp_task_wdt_reset() logs an error ("task not found") if the current
+    // task isn't subscribed to the TWDT, instead of silently no-opping.
+    // FluidNC's watchdog is opt-in (see add_watchdog_to_task()), and several
+    // call sites call feed_watchdog() defensively from tasks that may or may
+    // not be subscribed (e.g. loopTask, which platform_preinit() deliberately
+    // unsubscribes - see esp32/esp32s3/Platform.h). Check first so those
+    // defensive calls are actually silent, as intended, instead of spamming
+    // the log with harmless "task not found" errors.
+    if (esp_task_wdt_status(NULL) == ESP_OK) {
+        esp_task_wdt_reset();
+    }
 #endif
 }
 

--- a/FluidNC/src/FileCommands.cpp
+++ b/FluidNC/src/FileCommands.cpp
@@ -618,12 +618,23 @@ static Error xmodem_receive(const char* value, AuthenticationLevel auth_level, C
     pollingPaused = false;
     if (len >= 0) {
         log_info("Received " << len << " bytes to file " << outfile->path());
+    } else if (len == -6) {
+        log_info("Reception failed: not enough free space on the target filesystem");
     } else {
         log_info("Reception failed or was canceled");
     }
     std::filesystem::path fname = outfile->fpath();
     delete outfile;
-    HashFS::rehash_file(fname);
+    if (len < 0) {
+        // Don't leave a truncated, incomplete file behind - especially
+        // important for the not-enough-space case, where leaving the
+        // partial file around would eat into the free space a retry needs.
+        std::error_code ec;
+        stdfs::remove(fname, ec);
+        HashFS::delete_file(fname);
+    } else {
+        HashFS::rehash_file(fname);
+    }
 
     return len < 0 ? Error::UploadFailed : Error::Ok;
 }

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -143,6 +143,7 @@ void polling_loop(void* unused) {
         /*feedLoopWDT(), */ vTaskDelay(1);
         // Polling is paused when xmodem is using a channel for binary upload
         if (pollingPaused) {
+            feed_watchdog();
             vTaskDelay(100);
             continue;
         }

--- a/FluidNC/src/xmodem.cpp
+++ b/FluidNC/src/xmodem.cpp
@@ -35,8 +35,8 @@
 #include "xmodem.h"
 #include "Driver/watchdog.h"
 
-static Channel* serialPort;
-static Print*   file;
+static Channel*     serialPort;
+static FileStream*  file;
 
 static int32_t _inbyte(uint16_t timeout) {
     uint8_t data;
@@ -131,7 +131,24 @@ static void flushinput(void) {
 static uint8_t held_packet[1024];
 static size_t  held_packet_len;
 
-static void flush_packet(size_t packet_len, size_t& total_len) {
+// Xmodem has no way to announce the total upload size in advance, so we
+// can't check free space once up front. Instead, before every write we
+// check that there's room for it, and treat a short write (or a write we
+// know in advance won't fit) as a fatal, cleanly-reported error rather
+// than letting the filesystem driver try (and possibly hang/crash) on a
+// write that can't succeed. This is what protects against the crash in
+// https://github.com/bdring/FluidNC/issues/1788: uploading a file larger
+// than the free space on the (usually nearly-full) target filesystem.
+static bool writeChecked(const uint8_t* buf, size_t count) {
+    std::error_code ec;
+    auto            space = stdfs::space(file->fpath(), ec);
+    if (ec || space.available < count) {
+        return false;
+    }
+    return file->write(buf, count) == count;
+}
+
+static bool flush_packet(size_t packet_len, size_t& total_len) {
     if (held_packet_len > 0) {
         // Remove trailing ctrl-z's on the final packet
         size_t count;
@@ -140,19 +157,25 @@ static void flush_packet(size_t packet_len, size_t& total_len) {
                 break;
             }
         }
-        file->write(held_packet, count);
+        if (!writeChecked(held_packet, count)) {
+            return false;
+        }
         total_len += count;
         held_packet_len = 0;
     }
+    return true;
 }
-static void write_packet(uint8_t* buf, size_t packet_len, size_t& total_len) {
+static bool write_packet(uint8_t* buf, size_t packet_len, size_t& total_len) {
     if (held_packet_len > 0) {
-        file->write(held_packet, held_packet_len);
+        if (!writeChecked(held_packet, held_packet_len)) {
+            return false;
+        }
         total_len += held_packet_len;
         held_packet_len = 0;
     }
     memcpy(held_packet, buf, packet_len);
     held_packet_len = packet_len;
+    return true;
 }
 int32_t xmodemReceive(Channel* serial, FileStream* out) {
     serialPort      = serial;
@@ -184,7 +207,13 @@ int32_t xmodemReceive(Channel* serial, FileStream* out) {
                         bufsz = 1024;
                         goto start_recv;
                     case EOT:
-                        flush_packet(bufsz, len);
+                        if (!flush_packet(bufsz, len)) {
+                            flushinput();
+                            _outbyte(CAN);
+                            _outbyte(CAN);
+                            _outbyte(CAN);
+                            return -6; /* not enough free space */
+                        }
                         _outbyte(ACK);
                         flushinput();
                         return len; /* normal end */
@@ -224,7 +253,13 @@ int32_t xmodemReceive(Channel* serial, FileStream* out) {
 
         if (xbuff[1] == (uint8_t)(~xbuff[2]) && (xbuff[1] == packetno || xbuff[1] == packetno - 1) && check(crc, &xbuff[3], bufsz)) {
             if (xbuff[1] == packetno) {
-                write_packet(xbuff + 3, bufsz, len);
+                if (!write_packet(xbuff + 3, bufsz, len)) {
+                    flushinput();
+                    _outbyte(CAN);
+                    _outbyte(CAN);
+                    _outbyte(CAN);
+                    return -6; /* not enough free space */
+                }
                 ++packetno;
                 retrans = MAXRETRANS + 1;
             }

--- a/FluidNC/src/xmodem.cpp
+++ b/FluidNC/src/xmodem.cpp
@@ -33,6 +33,7 @@
  */
 
 #include "xmodem.h"
+#include "Driver/watchdog.h"
 
 static Channel* serialPort;
 static Print*   file;
@@ -171,6 +172,7 @@ int32_t xmodemReceive(Channel* serial, FileStream* out) {
 
     for (;;) {
         for (retry = 0; retry < 16; ++retry) {
+            feed_watchdog();
             if (trychar)
                 _outbyte(trychar);
             if ((c = _inbyte((DLY_1S) << 1)) >= 0) {
@@ -256,6 +258,7 @@ int32_t xmodemTransmit(Channel* serial, FileStream* infile) {
 
     for (;;) {
         for (retry = 0; retry < 16; ++retry) {
+            feed_watchdog();
             if ((c = _inbyte((DLY_1S) << 1)) >= 0) {
                 switch (c) {
                     case 'C':
@@ -312,6 +315,7 @@ int32_t xmodemTransmit(Channel* serial, FileStream* infile) {
                     xbuff[bufsz + 3] = ccks;
                 }
                 for (retry = 0; retry < MAXRETRANS; ++retry) {
+                    feed_watchdog();
                     _outbytes(xbuff, bufsz + 4 + (crc ? 1 : 0));
                     if ((c = _inbyte(DLY_1S)) >= 0) {
                         switch (c) {
@@ -339,6 +343,7 @@ int32_t xmodemTransmit(Channel* serial, FileStream* infile) {
                 return -4; /* xmit error */
             } else {
                 for (retry = 0; retry < 10; ++retry) {
+                    feed_watchdog();
                     _outbyte(EOT);
                     c = _inbyte((DLY_1S) << 1);
                     if (c == ACK || c == -1)


### PR DESCRIPTION
This fixes two xmodem problems
* On an ESP32-S3, xmodem could cause a system crash due to task watchdog starvation
* On any MCU, xmodem could crash if the filesystem fills up during the transfer. #1788 experienced that situation while testing an alternate upload method, but it does not explain the core problem mentioned in its title