### PR TITLE
Max open SD files from 3 to 2, to avoid out of memory crashes

### DIFF
--- a/FluidNC/include/Driver/sdspi.h
+++ b/FluidNC/include/Driver/sdspi.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "Driver/fluidnc_gpio.h"
 #include <system_error>
 

--- a/FluidNC/include/Driver/sdspi.h
+++ b/FluidNC/include/Driver/sdspi.h
@@ -5,4 +5,4 @@ bool sd_init_slot(uint32_t freq_hz, pinnum_t cs_pin, pinnum_t cd_pin = INVALID_P
 void sd_unmount();
 void sd_deinit_slot();
 
-std::error_code sd_mount(uint32_t max_files = 3);
+std::error_code sd_mount(uint32_t max_files = 2);


### PR DESCRIPTION
We have seen several reports that v4.0.4 suffered from crashes while accessing SD cards.  I saw some SD failures myself while testing WebUI v2, with an ESP_ERR 101 - out of memory - signature.  Before the crash, the heap was down to about 48K.  The SD card driver can use a lot of memory for data and cluster map buffers, so it is a good idea to limit the number of files that can be open simultaneously.  The limit used to be 2, but a user/contributor convinced me to bump it up to 3 some time ago.  This patch puts it back to 2, which eliminates the failures that I was experiencing.