### PR TITLE
Fix telnet TX stall detector dropping healthy clients

### DIFF
--- a/FluidNC/src/WebUI/TelnetClient.cpp
+++ b/FluidNC/src/WebUI/TelnetClient.cpp
@@ -38,7 +38,8 @@ namespace WebUI {
         // Drain leftovers from a previous burst even if nothing new is being
         // written (otherwise the tail of a long reply -- typically the final
         // "ok" -- would sit in the ring until the next status report).
-        if (!_disconnected.load() && _txTail != _txHead) {
+        if (!_disconnected.load() &&
+            _txTail.load(std::memory_order_relaxed) != _txHead.load(std::memory_order_relaxed)) {
             flushQueue();
         }
     }
@@ -72,7 +73,9 @@ namespace WebUI {
     }
 
     size_t TelnetClient::queueFree() const {
-        size_t used = (_txHead + TX_QUEUE_SIZE - _txTail) % TX_QUEUE_SIZE;
+        const size_t head = _txHead.load(std::memory_order_relaxed);
+        const size_t tail = _txTail.load(std::memory_order_relaxed);
+        size_t       used = (head + TX_QUEUE_SIZE - tail) % TX_QUEUE_SIZE;
         return TX_QUEUE_SIZE - used - 1;
     }
 
@@ -84,10 +87,12 @@ namespace WebUI {
             xSemaphoreGive(_wifiMutex);
             return false;
         }
+        size_t head = _txHead.load(std::memory_order_relaxed);
         for (size_t i = 0; i < len; ++i) {
-            _txQueue[_txHead] = data[i];
-            _txHead           = (_txHead + 1) % TX_QUEUE_SIZE;
+            _txQueue[head] = data[i];
+            head           = (head + 1) % TX_QUEUE_SIZE;
         }
+        _txHead.store(head, std::memory_order_relaxed);
         xSemaphoreGive(_wifiMutex);
         return true;
     }
@@ -126,11 +131,16 @@ namespace WebUI {
     void TelnetClient::flushQueue() {
         xSemaphoreTake(_wifiMutex, portMAX_DELAY);
         bool progress = false;
-        while (_txTail != _txHead) {
-            size_t contiguous = _txHead > _txTail ? _txHead - _txTail : TX_QUEUE_SIZE - _txTail;
-            int    sent       = trySend(_txQueue.data() + _txTail, contiguous);
+        // Safe to snapshot: queueLine() also holds _wifiMutex, so the head
+        // cannot advance while this loop runs.
+        const size_t head = _txHead.load(std::memory_order_relaxed);
+        size_t       tail = _txTail.load(std::memory_order_relaxed);
+        while (tail != head) {
+            size_t contiguous = head > tail ? head - tail : TX_QUEUE_SIZE - tail;
+            int    sent       = trySend(_txQueue.data() + tail, contiguous);
             if (sent > 0) {
-                _txTail  = (_txTail + (size_t)sent) % TX_QUEUE_SIZE;
+                tail = (tail + (size_t)sent) % TX_QUEUE_SIZE;
+                _txTail.store(tail, std::memory_order_relaxed);
                 progress = true;
                 continue;
             }
@@ -145,13 +155,13 @@ namespace WebUI {
             break;  // sent == 0: socket not ready right now
         }
 
-        if (_txTail == _txHead || progress) {
-            _txStallSince = 0;  // drained, or the peer is draining (just slower than we produce)
+        if (tail == head || progress) {
+            _txStallSince = TX_STALL_NONE;  // drained, or the peer is draining (just slower than we produce)
         } else {
             // Backlog present and the socket accepted nothing this time.
             // Only a sustained no-progress window means a wedged peer.
             const uint32_t now = millis();
-            if (_txStallSince == 0) {
+            if (_txStallSince == TX_STALL_NONE) {
                 _txStallSince = now;
             } else if (now - _txStallSince >= TX_STALL_TIMEOUT_MS) {
                 // Connected but not draining what we send it -- wedged peer.

--- a/FluidNC/src/WebUI/TelnetClient.cpp
+++ b/FluidNC/src/WebUI/TelnetClient.cpp
@@ -34,7 +34,14 @@ namespace WebUI {
 #endif
     }
 
-    void TelnetClient::handle() {}
+    void TelnetClient::handle() {
+        // Drain leftovers from a previous burst even if nothing new is being
+        // written (otherwise the tail of a long reply -- typically the final
+        // "ok" -- would sit in the ring until the next status report).
+        if (!_disconnected.load() && _txTail != _txHead) {
+            flushQueue();
+        }
+    }
 
     void TelnetClient::closeOnDisconnectLocked() {
         if (!_wifiClient->connected()) {
@@ -70,13 +77,18 @@ namespace WebUI {
     }
 
     bool TelnetClient::queueLine(const uint8_t* data, size_t len, size_t reserve) {
+        // Held under _wifiMutex because flushQueue() (which consumes the ring)
+        // can now also run from handle() on the polling task.
+        xSemaphoreTake(_wifiMutex, portMAX_DELAY);
         if (len + reserve > queueFree()) {
+            xSemaphoreGive(_wifiMutex);
             return false;
         }
         for (size_t i = 0; i < len; ++i) {
             _txQueue[_txHead] = data[i];
             _txHead           = (_txHead + 1) % TX_QUEUE_SIZE;
         }
+        xSemaphoreGive(_wifiMutex);
         return true;
     }
 
@@ -113,11 +125,13 @@ namespace WebUI {
     // and go out on the next write().
     void TelnetClient::flushQueue() {
         xSemaphoreTake(_wifiMutex, portMAX_DELAY);
+        bool progress = false;
         while (_txTail != _txHead) {
             size_t contiguous = _txHead > _txTail ? _txHead - _txTail : TX_QUEUE_SIZE - _txTail;
             int    sent       = trySend(_txQueue.data() + _txTail, contiguous);
             if (sent > 0) {
-                _txTail = (_txTail + (size_t)sent) % TX_QUEUE_SIZE;
+                _txTail  = (_txTail + (size_t)sent) % TX_QUEUE_SIZE;
+                progress = true;
                 continue;
             }
             if (sent < 0) {
@@ -131,13 +145,20 @@ namespace WebUI {
             break;  // sent == 0: socket not ready right now
         }
 
-        if (_txTail == _txHead) {
-            _txStallCount = 0;  // fully drained
-        } else if (++_txStallCount >= TX_STALL_LIMIT) {
-            // Connected but not draining what we send it -- wedged peer.
-            // Force it out so the slot can be reused.
-            _wifiClient->stop();
-            closeOnDisconnectLocked();
+        if (_txTail == _txHead || progress) {
+            _txStallSince = 0;  // drained, or the peer is draining (just slower than we produce)
+        } else {
+            // Backlog present and the socket accepted nothing this time.
+            // Only a sustained no-progress window means a wedged peer.
+            const uint32_t now = millis();
+            if (_txStallSince == 0) {
+                _txStallSince = now;
+            } else if (now - _txStallSince >= TX_STALL_TIMEOUT_MS) {
+                // Connected but not draining what we send it -- wedged peer.
+                // Force it out so the slot can be reused.
+                _wifiClient->stop();
+                closeOnDisconnectLocked();
+            }
         }
         xSemaphoreGive(_wifiMutex);
     }

--- a/FluidNC/src/WebUI/TelnetClient.h
+++ b/FluidNC/src/WebUI/TelnetClient.h
@@ -9,6 +9,8 @@
 // so WiFi symbols are visible without arduino:: qualification.
 #include <Arduino.h>
 #include <array>
+#include <atomic>
+#include <cstdint>
 #include <WiFi.h>
 #include <string>
 
@@ -57,15 +59,30 @@ namespace WebUI {
         // the client is only dropped after TX_STALL_TIMEOUT_MS with a backlog
         // and zero bytes accepted by the socket.
         static constexpr uint32_t TX_STALL_TIMEOUT_MS = 5000;
-        uint32_t                  _txStallSince       = 0;  // millis() of first no-progress flush; 0 = healthy
+        // The "no stall in progress" sentinel cannot be 0, because millis()
+        // itself returns 0 -- for one millisecond after boot, and again on
+        // every 49.7-day wrap. A timestamp recorded then would read back as
+        // "healthy" on the next flush and restart the window. UINT32_MAX is
+        // never a value millis() can return.
+        static constexpr uint32_t TX_STALL_NONE       = UINT32_MAX;
+        uint32_t                  _txStallSince       = TX_STALL_NONE;
 
         int32_t     _state = 0;
         std::string _txLine;             // output accumulated until a full line
         uint8_t     _txLastChar = '\0';  // for \n -> \r\n across write() calls
 
         std::array<uint8_t, TX_QUEUE_SIZE> _txQueue {};
-        size_t                             _txHead = 0;
-        size_t                             _txTail = 0;
+        // Atomic because handle() compares them on the polling task without
+        // holding _wifiMutex, while queueLine()/flushQueue() mutate them on
+        // the output task. Relaxed ordering is sufficient: the unlocked read
+        // is only a hint about whether calling flushQueue() is worthwhile,
+        // and flushQueue() re-reads under the mutex before touching the ring,
+        // so a stale hint costs at most one extra poll cycle. Taking the
+        // mutex in handle() instead would serialise the polling task against
+        // every write, thousands of times per second, only to answer a
+        // question that is harmless to get wrong.
+        std::atomic<size_t>                _txHead { 0 };
+        std::atomic<size_t>                _txTail { 0 };
 
         static bool isCriticalLine(const std::string& line);
         size_t      queueFree() const;

--- a/FluidNC/src/WebUI/TelnetClient.h
+++ b/FluidNC/src/WebUI/TelnetClient.h
@@ -46,11 +46,18 @@ namespace WebUI {
         // draining what we send it -- a frozen terminal, a dead network path,
         // a zero TCP window. That alone doesn't fill the ring buffer's
         // TX_CRITICAL_RESERVE headroom, so it isn't caught by queueLine()'s
-        // critical-line disconnect. Count consecutive flushQueue() calls that
-        // fail to fully drain the backlog and force the client out once it's
-        // wedged for TX_STALL_LIMIT of them in a row, freeing the slot.
-        static constexpr int TX_STALL_LIMIT = 10;
-        int                  _txStallCount  = 0;
+        // critical-line disconnect.
+        //
+        // The stall must be measured in TIME, not in flushQueue() calls:
+        // flushQueue() runs once per written line, so a multi-line burst
+        // (e.g. $Errors/List, 35 lines in a few ms) calls it dozens of times
+        // while lwIP is still pushing the first segment out over the air.
+        // Counting those calls as "stalls" kicks a perfectly healthy client
+        // after ~1 KB. Instead: any forward progress resets the timer, and
+        // the client is only dropped after TX_STALL_TIMEOUT_MS with a backlog
+        // and zero bytes accepted by the socket.
+        static constexpr uint32_t TX_STALL_TIMEOUT_MS = 5000;
+        uint32_t                  _txStallSince       = 0;  // millis() of first no-progress flush; 0 = healthy
 
         int32_t     _state = 0;
         std::string _txLine;             // output accumulated until a full line


### PR DESCRIPTION
`4ff0ee4c` (#1777) added a stall detector that closes the socket when the TX ring stops draining. It counts consecutive `flushQueue()` calls that fail to empty the ring, and `flushQueue()` runs once per line written, so a multi-line reply calls it dozens of times within a couple of milliseconds while lwIP is still putting the first segment on the air. `TX_STALL_LIMIT = 10` gets reached in microseconds and the client is dropped even though nothing was wrong with it.

`$Errors/List` reproduces it every time here. It is 35 lines, 2320 bytes. Over telnet the client receives 1021 bytes and the connection closes; the websocket channel delivers all 2320. UGS asks for `$Errors/List` as part of its connect handshake, so telnet effectively dies on connect, with `The command "$Errors/List" has timed out ... within 6000ms`. Same visible symptom as #1776, different cause.

This measures the stall in time instead of in calls. Any byte the socket accepts resets the timer, and the client is only dropped after 5 s with a backlog and zero progress.

Two supporting changes had to come along:

* `handle()` now drains a leftover burst. `flushQueue()` only ran from `write()`, so the tail of a long reply, usually the closing `ok`, sat in the ring until the next status report.
* `queueLine()` takes `_wifiMutex`, since `flushQueue()` consumes the ring from the polling task now and not only from the writer.

Tested on an MKS DLC32 V2.1 (ESP32-D0WD). UGS connects over telnet and stays up through jogging and job streaming. `pio run -e wifi` builds clean, 91.6% flash.

I also run `TX_QUEUE_SIZE` at 8192 locally, but it is not needed for this fix and it costs 5.9 KB of RAM, so I left it out. Happy to send it separately if you want the extra headroom.
