### PR TITLE
Fix SD card crash after WebUI uploads

### DIFF
--- a/FluidNC/src/FluidPath.cpp
+++ b/FluidNC/src/FluidPath.cpp
@@ -26,6 +26,11 @@ namespace {
             _locked = _lock && xSemaphoreTake(_lock, portMAX_DELAY) == pdTRUE;
         }
 
+        SDLock(const SDLock&)            = delete;
+        SDLock& operator=(const SDLock&) = delete;
+        SDLock(SDLock&&)                 = delete;
+        SDLock& operator=(SDLock&&)      = delete;
+
         ~SDLock() {
             if (_locked) {
                 xSemaphoreGive(_lock);

--- a/FluidNC/src/FluidPath.cpp
+++ b/FluidNC/src/FluidPath.cpp
@@ -17,8 +17,8 @@ Volume SD { "sd" };
 Volume LocalFS { "localfs" };
 
 namespace {
-    SemaphoreHandle_t sd_mount_lock = xSemaphoreCreateMutex();
-    SemaphoreHandle_t sd_state_lock = xSemaphoreCreateMutex();
+    SemaphoreHandle_t sd_lifecycle_lock = xSemaphoreCreateMutex();
+    uint32_t          sd_mount_users    = 0;
 
     class SDLock {
     public:
@@ -39,51 +39,34 @@ namespace {
         bool              _locked = false;
     };
 
-    std::weak_ptr<SDMountState> cached_sd_mount;
-
     std::error_code sd_lock_error() {
         return std::make_error_code(std::errc::not_enough_memory);
     }
 }
 
-// SDMountState manages SD card mount/unmount lifecycle
-// It is instantiated as a shared_ptr that is automatically
-// reference-counted.  The constructor is called on the
-// first instance, thus mounting the SD card.  The destructor
-// is called when the count goes to 0.
+// SDMountState manages the SD card mount/unmount lifecycle. FluidPath copies
+// share a state, while independently created paths may have separate states.
+// The protected user count keeps the card mounted until the last state exits.
 SDMountState::SDMountState() {
-    SDLock lock(sd_mount_lock);
+    SDLock lock(sd_lifecycle_lock);
     if (!lock.locked()) {
         throw stdfs::filesystem_error { "Failed to lock SD card mount state", sd_lock_error() };
     }
-    auto ec = sd_mount();
-    if (ec) {
-        throw stdfs::filesystem_error { "Failed to mount SD card", ec };
+
+    if (sd_mount_users == 0) {
+        auto ec = sd_mount();
+        if (ec) {
+            throw stdfs::filesystem_error { "Failed to mount SD card", ec };
+        }
     }
+    ++sd_mount_users;
 }
 
 SDMountState::~SDMountState() {
-    SDLock lock(sd_mount_lock);
-    if (lock.locked()) {
+    SDLock lock(sd_lifecycle_lock);
+    if (lock.locked() && sd_mount_users && --sd_mount_users == 0) {
         sd_unmount();
     }
-}
-
-static std::shared_ptr<SDMountState> acquire_sd_mount() {
-    // The weak pointer and state creation must be one atomic operation.  If two
-    // tasks both create a state, either destructor can unmount the card while
-    // the other task is still using FatFS.
-    SDLock lock(sd_state_lock);
-    if (!lock.locked()) {
-        throw stdfs::filesystem_error { "Failed to lock SD card state", sd_lock_error() };
-    }
-
-    auto mount = cached_sd_mount.lock();
-    if (!mount) {
-        mount           = std::make_shared<SDMountState>();
-        cached_sd_mount = mount;
-    }
-    return mount;
 }
 
 const std::string FluidPath::canonPath(std::string_view filename, const Volume& defaultFs) {
@@ -151,7 +134,7 @@ FluidPath::FluidPath(const std::string_view name, const Volume& fs, std::error_c
             throw stdfs::filesystem_error { "SD card is inaccessible", name, ec };
         }
         try {
-            _sd_mount_state = acquire_sd_mount();
+            _sd_mount_state = std::make_shared<SDMountState>();
         } catch (const stdfs::filesystem_error& ex) {
             if (ecptr) {
                 *ecptr = ex.code();

--- a/FluidNC/src/FluidPath.cpp
+++ b/FluidNC/src/FluidPath.cpp
@@ -16,14 +16,33 @@
 Volume SD { "sd" };
 Volume LocalFS { "localfs" };
 
-static SemaphoreHandle_t sd_mount_lock = nullptr;
+namespace {
+    SemaphoreHandle_t sd_mount_lock = xSemaphoreCreateMutex();
+    SemaphoreHandle_t sd_state_lock = xSemaphoreCreateMutex();
 
-static void ensure_sd_locks() {
-    if (!sd_mount_lock) {
-        sd_mount_lock = xSemaphoreCreateBinary();
-        if (sd_mount_lock) {
-            xSemaphoreGive(sd_mount_lock);
+    class SDLock {
+    public:
+        explicit SDLock(SemaphoreHandle_t lock) : _lock(lock) {
+            _locked = _lock && xSemaphoreTake(_lock, portMAX_DELAY) == pdTRUE;
         }
+
+        ~SDLock() {
+            if (_locked) {
+                xSemaphoreGive(_lock);
+            }
+        }
+
+        bool locked() const { return _locked; }
+
+    private:
+        SemaphoreHandle_t _lock   = nullptr;
+        bool              _locked = false;
+    };
+
+    std::weak_ptr<SDMountState> cached_sd_mount;
+
+    std::error_code sd_lock_error() {
+        return std::make_error_code(std::errc::not_enough_memory);
     }
 }
 
@@ -33,22 +52,38 @@ static void ensure_sd_locks() {
 // first instance, thus mounting the SD card.  The destructor
 // is called when the count goes to 0.
 SDMountState::SDMountState() {
-    ensure_sd_locks();
-    xSemaphoreTake(sd_mount_lock, portMAX_DELAY);
+    SDLock lock(sd_mount_lock);
+    if (!lock.locked()) {
+        throw stdfs::filesystem_error { "Failed to lock SD card mount state", sd_lock_error() };
+    }
     auto ec = sd_mount();
-    xSemaphoreGive(sd_mount_lock);
     if (ec) {
         throw stdfs::filesystem_error { "Failed to mount SD card", ec };
     }
 }
 
 SDMountState::~SDMountState() {
-    // Use 100ms timeout to avoid deadlock if operations are still in progress
-    //    if (xSemaphoreTake(sd_mount_lock, pdMS_TO_TICKS(100)) == pdTRUE) {
-    if (xSemaphoreTake(sd_mount_lock, portMAX_DELAY)) {
+    SDLock lock(sd_mount_lock);
+    if (lock.locked()) {
         sd_unmount();
-        xSemaphoreGive(sd_mount_lock);
     }
+}
+
+static std::shared_ptr<SDMountState> acquire_sd_mount() {
+    // The weak pointer and state creation must be one atomic operation.  If two
+    // tasks both create a state, either destructor can unmount the card while
+    // the other task is still using FatFS.
+    SDLock lock(sd_state_lock);
+    if (!lock.locked()) {
+        throw stdfs::filesystem_error { "Failed to lock SD card state", sd_lock_error() };
+    }
+
+    auto mount = cached_sd_mount.lock();
+    if (!mount) {
+        mount           = std::make_shared<SDMountState>();
+        cached_sd_mount = mount;
+    }
+    return mount;
 }
 
 const std::string FluidPath::canonPath(std::string_view filename, const Volume& defaultFs) {
@@ -104,7 +139,6 @@ const std::string FluidPath::canonPath(std::string_view filename, const Volume& 
 
 FluidPath::FluidPath(const std::string_view name, const Volume& fs, std::error_code* ecptr) : stdfs::path(canonPath(name, fs)) {
     auto mount = *(++begin());  // Use the path iterator to get the first component
-    ensure_sd_locks();
     _isSD = mount == "sd";
 
     if (_isSD) {
@@ -117,14 +151,7 @@ FluidPath::FluidPath(const std::string_view name, const Volume& fs, std::error_c
             throw stdfs::filesystem_error { "SD card is inaccessible", name, ec };
         }
         try {
-            // Try to reuse existing mount state if another FluidPath still owns it
-            static std::weak_ptr<SDMountState> cached_mount;
-            if (auto mount = cached_mount.lock()) {
-                _sd_mount_state = mount;
-            } else {
-                _sd_mount_state = std::make_shared<SDMountState>();
-                cached_mount    = _sd_mount_state;
-            }
+            _sd_mount_state = acquire_sd_mount();
         } catch (const stdfs::filesystem_error& ex) {
             if (ecptr) {
                 *ecptr = ex.code();


### PR DESCRIPTION
Crashes after file uploads via the WebUI had been occurring in FluidNC v4.0.4 and later. Two tasks could try to manage the SD card mount at the same time. One task could unmount the card while another was reading its free-space information, causing a crash in the SPI driver.

This makes SD mount creation thread-safe so every SD operation shares the same mount state.

**Tested:** Uploaded multiple files and refreshed the SD file list repeatedly. The post-upload crash no longer occurs.