### PR TITLE
Add TS35 touchscreen display/pendant module

### DIFF
--- a/FluidNC/docs/config_items.yaml
+++ b/FluidNC/docs/config_items.yaml
@@ -740,6 +740,294 @@ oled:
     description: |
       Delay, in milliseconds, before the display shows radio (WiFi/BT) connection info after boot -- gives the radio hardware time to come up first.
 
+# Lives under FluidNC/esp32/ for the same reason as oled just above -- the relative path deliberately escapes SRC to reach it.
+ts35:
+  report_interval_ms:
+    type: integer
+    min: 100
+    max: 5000
+    default: '200'
+    tuning: typical
+    description: |
+      How often the module asks the machine for a status report. This is the channel's own report interval, independent of what other channels use.
+
+  render_interval_ms:
+    type: integer
+    min: 100
+    max: 2000
+    default: '200'
+    tuning: typical
+    description: |
+      Lower bound between screen repaints. Only fields whose text actually changed are redrawn, so raising this costs responsiveness, not bandwidth.
+
+  touch_interval_ms:
+    type: integer
+    min: 20
+    max: 500
+    default: '40'
+    tuning: typical
+    description: |
+      How often the touch controller is sampled. Below about 20 ms the SPI traffic starts competing with the display writes for the same bus.
+
+  controls_enabled:
+    type: boolean
+    default: 'false'
+    tuning: per-machine
+    description: |
+      Master gate for every control that moves the machine or changes its coordinates. Leave it false until the touch calibration below has been verified on the bench: an uncalibrated panel will send taps to the wrong button.
+
+  allow_jog:
+    type: boolean
+    default: 'true'
+    tuning: per-machine
+    description: |
+      Allows the jog buttons, subject to controls_enabled.
+
+  allow_zero:
+    type: boolean
+    default: 'true'
+    tuning: per-machine
+    description: |
+      Allows setting work zero from the screen, subject to controls_enabled. Zeroing uses G10 L20 P0, so it updates the active coordinate system and shows up on the other channels at the next report.
+
+  allow_homing:
+    type: boolean
+    default: 'false'
+    tuning: per-machine
+    description: |
+      Allows starting a homing cycle from the screen.
+
+  allow_unlock:
+    type: boolean
+    default: 'false'
+    tuning: per-machine
+    description: |
+      Allows $X from the Control page. Not needed when allow_alarm_clear is true, which offers the same thing where the alarm is actually shown.
+
+  allow_soft_reset:
+    type: boolean
+    default: 'false'
+    tuning: per-machine
+    description: |
+      Allows sending a soft reset from the Control page.
+
+  allow_alarm_clear:
+    type: boolean
+    default: 'false'
+    tuning: per-machine
+    description: |
+      Shows an alarm banner with an unlock button on every page whenever the machine is in Alarm. The button sends a soft reset and then $X. This is deliberately independent of controls_enabled, because neither command produces motion, so a machine can be recovered from an alarm while the screen is otherwise read-only.
+
+  jog_step_mm:
+    type: float
+    min: 0.001f
+    max: 100.0f
+    default: '0.100'
+    tuning: per-machine
+    description: |
+      Starting jog increment. The STEP button cycles it through 0.01, 0.1, 1, 10 and 100 mm, capped as described under jog_step_max_mm; this value only picks where that ladder starts. The screen's own selection is not written back here, so $CD still reports what the config file asked for.
+
+  jog_feed_xy_mm_min:
+    type: float
+    min: 1.0f
+    max: 100000.0f
+    default: '1000.000'
+    tuning: per-machine
+    description: |
+      Feed rate used for jogs on X and Y.
+
+  jog_feed_z_mm_min:
+    type: float
+    min: 1.0f
+    max: 100000.0f
+    default: '500.000'
+    tuning: per-machine
+    description: |
+      Feed rate used for jogs on Z.
+
+  jog_step_max_mm:
+    type: float
+    min: 0.01f
+    max: 100.0f
+    default: '10.000'
+    tuning: per-machine
+    description: |
+      Largest jog increment applied to X and Y. The STEP button cycles the ladder 0.01, 0.1, 1, 10, 100 mm up to whichever of the two caps is higher, then wraps back to 0.01.
+
+  jog_percent:
+    type: integer
+    min: 1
+    max: 100
+    default: '80'
+    tuning: typical
+    description: |
+      Starting speed for the jog buttons, as a percentage of the two feed rates above. The SPEED button cycles it through 10, 25, 50, 80 and 100, so those feeds are the ceiling rather than the working value; set them to what the machine can actually sustain and steer from the panel. As with jog_step_mm, the screen's selection stays out of the saved config.
+
+  jog_step_max_z_mm:
+    type: float
+    min: 0.01f
+    max: 100.0f
+    default: '10.000'
+    tuning: per-machine
+    description: |
+      Same, for Z. It is separate because Z usually has an order of magnitude less travel than X and Y, and with soft_limits off an increment longer than the travel that is left drives the axis into its hard limit. When the selected step is above this cap, a Z jog moves this much instead and the jog page says so.
+
+  touch_x_min:
+    type: integer
+    min: 0
+    max: 4095
+    default: '300'
+    tuning: per-machine
+    description: |
+      Raw ADC reading at the left edge of the panel. Read the raw values from the Info page while touching the edges and put them here.
+
+  touch_x_max:
+    type: integer
+    min: 0
+    max: 4095
+    default: '3600'
+    tuning: per-machine
+    description: |
+      Raw ADC reading at the right edge of the panel.
+
+  touch_y_min:
+    type: integer
+    min: 0
+    max: 4095
+    default: '300'
+    tuning: per-machine
+    description: |
+      Raw ADC reading at the top edge of the panel.
+
+  touch_y_max:
+    type: integer
+    min: 0
+    max: 4095
+    default: '3600'
+    tuning: per-machine
+    description: |
+      Raw ADC reading at the bottom edge of the panel.
+
+  touch_pressure_threshold:
+    type: integer
+    min: 0
+    max: 4095
+    default: '350'
+    tuning: per-machine
+    description: |
+      Minimum pressure reading for a sample to count as a touch. Raise it if the screen registers phantom taps, lower it if firm taps are missed.
+
+  touch_max_sample_spread:
+    type: integer
+    min: 0
+    max: 4095
+    default: '40'
+    tuning: typical
+    description: |
+      Rejects a reading whose samples disagree by more than this, which is what a finger sliding off the panel looks like.
+
+  touch_samples:
+    type: integer
+    min: 1
+    max: 9
+    default: '5'
+    tuning: typical
+    description: |
+      Samples per reading, median filtered. Odd values give a true median.
+
+  touch_swap_xy:
+    type: boolean
+    default: 'true'
+    tuning: per-machine
+    description: |
+      Swaps the panel's two axes before mapping them to the screen. Needed when the resistive panel is wired at ninety degrees to the LCD scan order.
+
+  touch_invert_x:
+    type: boolean
+    default: 'true'
+    tuning: per-machine
+    description: |
+      Mirrors the horizontal axis of the touch panel.
+
+  touch_invert_y:
+    type: boolean
+    default: 'false'
+    tuning: per-machine
+    description: |
+      Mirrors the vertical axis of the touch panel.
+
+  lcd_clock_hz:
+    type: integer
+    min: 1000000
+    max: 40000000
+    default: '40000000'
+    tuning: typical
+    description: |
+      SPI clock for the display. Reduce it if a long or poorly seated ribbon cable produces visible corruption.
+
+  touch_clock_hz:
+    type: integer
+    min: 100000
+    max: 2000000
+    default: '2000000'
+    tuning: typical
+    description: |
+      SPI clock for the touch controller. The ADS7843/XPT2046 is specified well below the display's clock and should not be run at the same rate.
+
+  invert_display:
+    type: boolean
+    default: 'false'
+    tuning: per-machine
+    description: |
+      Sends the panel's colour inversion command at startup. Some ST7796 panels ship inverted relative to the reference module.
+
+  tft_cs_pin:
+    type: pin
+    default: 'NO_PIN'
+    tuning: per-machine
+    pin_attributes: output
+    description: |
+      Chip select for the display controller. Must be a native MCU pin with output capability; a pin extender cannot keep up with the bus. Required. The SPI bus itself (sck/mosi/miso) is the machine's shared spi: section, same as SDCard.
+
+  tft_dc_pin:
+    type: pin
+    default: 'NO_PIN'
+    tuning: per-machine
+    pin_attributes: output
+    description: |
+      Data/command line of the display controller. Must be a native MCU pin with output capability. Required.
+
+  touch_cs_pin:
+    type: pin
+    default: 'NO_PIN'
+    tuning: per-machine
+    pin_attributes: output
+    description: |
+      Chip select for the touch controller, which shares the bus with the display. Must be a native MCU pin with output capability. Required.
+
+  tft_reset_pin:
+    type: pin
+    default: 'NO_PIN'
+    tuning: per-machine
+    pin_attributes: output
+    description: |
+      Hardware reset line of the display controller. Optional: leave it out on a panel whose reset is tied to the board's own reset.
+
+  backlight_pin:
+    type: pin
+    default: 'NO_PIN'
+    tuning: per-machine
+    pin_attributes: output
+    description: |
+      Switches the backlight. Optional: leave it out on a panel that is lit whenever it is powered.
+
+  backlight_active_low:
+    type: boolean
+    default: 'true'
+    tuning: per-machine
+    description: |
+      Set when the backlight pin is pulled low to light the panel. Boards differ here, sometimes within the same model, so this is worth checking on the bench before assuming the display is dead.
+
 atc_manual:
   safe_z_mpos_mm:
     type: float

--- a/FluidNC/esp32/TS35DisplayDriver.cpp
+++ b/FluidNC/esp32/TS35DisplayDriver.cpp
@@ -1,0 +1,747 @@
+#include "TS35DisplayDriver.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include <Arduino.h>
+#include <pgmspace.h>
+#include <sdkconfig.h>
+
+// Machine::SPIBus opens the shared bus on HSPI_HOST; spi.cpp maps that name the
+// same way for the ESP32-S3, where the constant is spelled SPI2_HOST.
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+#    define HSPI_HOST SPI2_HOST
+#endif
+
+namespace ts35 {
+
+    namespace {
+
+        constexpr std::uint8_t CmdSoftwareReset = 0x01;
+        constexpr std::uint8_t CmdSleepOut      = 0x11;
+        constexpr std::uint8_t CmdInvertOff     = 0x20;
+        constexpr std::uint8_t CmdInvertOn      = 0x21;
+        constexpr std::uint8_t CmdDisplayOn     = 0x29;
+        constexpr std::uint8_t CmdColumnAddress = 0x2A;
+        constexpr std::uint8_t CmdPageAddress   = 0x2B;
+        constexpr std::uint8_t CmdMemoryWrite   = 0x2C;
+        constexpr std::uint8_t CmdMemoryAccess  = 0x36;
+        constexpr std::uint8_t CmdPixelFormat   = 0x3A;
+
+        constexpr std::uint8_t TouchReadX  = 0xD0;
+        constexpr std::uint8_t TouchReadY  = 0x90;
+        constexpr std::uint8_t TouchReadZ1 = 0xB0;
+        constexpr std::uint8_t TouchReadZ2 = 0xC0;
+
+        constexpr std::uint8_t MaximumTouchSamples = 9;
+
+        // One solid-fill burst.  512 bytes keeps the transfer well inside the 4000-byte
+        // maximum that spi_init_bus() configures for the shared bus, and keeps the
+        // scratch buffer small enough to live on the caller's stack, which is where the
+        // SPI driver needs it for DMA.
+        constexpr std::uint32_t PixelsPerBurst = 256;
+
+        // Classic Adafruit_GFX/TFT_eSPI 5x7 font, ASCII 0x20 through 0x7e.  Each
+        // character is stored as five vertical columns, least-significant bit first.
+        static const std::uint8_t Font5x7[] PROGMEM = {
+            0x00, 0x00, 0x00, 0x00, 0x00,  // space
+            0x00, 0x00, 0x5F, 0x00, 0x00,  // !
+            0x00, 0x07, 0x00, 0x07, 0x00,  // "
+            0x14, 0x7F, 0x14, 0x7F, 0x14,  // #
+            0x24, 0x2A, 0x7F, 0x2A, 0x12,  // $
+            0x23, 0x13, 0x08, 0x64, 0x62,  // %
+            0x36, 0x49, 0x56, 0x20, 0x50,  // &
+            0x00, 0x08, 0x07, 0x03, 0x00,  // '
+            0x00, 0x1C, 0x22, 0x41, 0x00,  // (
+            0x00, 0x41, 0x22, 0x1C, 0x00,  // )
+            0x2A, 0x1C, 0x7F, 0x1C, 0x2A,  // *
+            0x08, 0x08, 0x3E, 0x08, 0x08,  // +
+            0x00, 0x80, 0x70, 0x30, 0x00,  // ,
+            0x08, 0x08, 0x08, 0x08, 0x08,  // -
+            0x00, 0x00, 0x60, 0x60, 0x00,  // .
+            0x20, 0x10, 0x08, 0x04, 0x02,  // /
+            0x3E, 0x51, 0x49, 0x45, 0x3E,  // 0
+            0x00, 0x42, 0x7F, 0x40, 0x00,  // 1
+            0x72, 0x49, 0x49, 0x49, 0x46,  // 2
+            0x21, 0x41, 0x49, 0x4D, 0x33,  // 3
+            0x18, 0x14, 0x12, 0x7F, 0x10,  // 4
+            0x27, 0x45, 0x45, 0x45, 0x39,  // 5
+            0x3C, 0x4A, 0x49, 0x49, 0x31,  // 6
+            0x41, 0x21, 0x11, 0x09, 0x07,  // 7
+            0x36, 0x49, 0x49, 0x49, 0x36,  // 8
+            0x46, 0x49, 0x49, 0x29, 0x1E,  // 9
+            0x00, 0x00, 0x14, 0x00, 0x00,  // :
+            0x00, 0x40, 0x34, 0x00, 0x00,  // ;
+            0x00, 0x08, 0x14, 0x22, 0x41,  // <
+            0x14, 0x14, 0x14, 0x14, 0x14,  // =
+            0x00, 0x41, 0x22, 0x14, 0x08,  // >
+            0x02, 0x01, 0x59, 0x09, 0x06,  // ?
+            0x3E, 0x41, 0x5D, 0x59, 0x4E,  // @
+            0x7C, 0x12, 0x11, 0x12, 0x7C,  // A
+            0x7F, 0x49, 0x49, 0x49, 0x36,  // B
+            0x3E, 0x41, 0x41, 0x41, 0x22,  // C
+            0x7F, 0x41, 0x41, 0x41, 0x3E,  // D
+            0x7F, 0x49, 0x49, 0x49, 0x41,  // E
+            0x7F, 0x09, 0x09, 0x09, 0x01,  // F
+            0x3E, 0x41, 0x41, 0x51, 0x73,  // G
+            0x7F, 0x08, 0x08, 0x08, 0x7F,  // H
+            0x00, 0x41, 0x7F, 0x41, 0x00,  // I
+            0x20, 0x40, 0x41, 0x3F, 0x01,  // J
+            0x7F, 0x08, 0x14, 0x22, 0x41,  // K
+            0x7F, 0x40, 0x40, 0x40, 0x40,  // L
+            0x7F, 0x02, 0x1C, 0x02, 0x7F,  // M
+            0x7F, 0x04, 0x08, 0x10, 0x7F,  // N
+            0x3E, 0x41, 0x41, 0x41, 0x3E,  // O
+            0x7F, 0x09, 0x09, 0x09, 0x06,  // P
+            0x3E, 0x41, 0x51, 0x21, 0x5E,  // Q
+            0x7F, 0x09, 0x19, 0x29, 0x46,  // R
+            0x26, 0x49, 0x49, 0x49, 0x32,  // S
+            0x03, 0x01, 0x7F, 0x01, 0x03,  // T
+            0x3F, 0x40, 0x40, 0x40, 0x3F,  // U
+            0x1F, 0x20, 0x40, 0x20, 0x1F,  // V
+            0x3F, 0x40, 0x38, 0x40, 0x3F,  // W
+            0x63, 0x14, 0x08, 0x14, 0x63,  // X
+            0x03, 0x04, 0x78, 0x04, 0x03,  // Y
+            0x61, 0x59, 0x49, 0x4D, 0x43,  // Z
+            0x00, 0x7F, 0x41, 0x41, 0x41,  // [
+            0x02, 0x04, 0x08, 0x10, 0x20,  // backslash
+            0x00, 0x41, 0x41, 0x41, 0x7F,  // ]
+            0x04, 0x02, 0x01, 0x02, 0x04,  // ^
+            0x40, 0x40, 0x40, 0x40, 0x40,  // _
+            0x00, 0x03, 0x07, 0x08, 0x00,  // `
+            0x20, 0x54, 0x54, 0x78, 0x40,  // a
+            0x7F, 0x28, 0x44, 0x44, 0x38,  // b
+            0x38, 0x44, 0x44, 0x44, 0x28,  // c
+            0x38, 0x44, 0x44, 0x28, 0x7F,  // d
+            0x38, 0x54, 0x54, 0x54, 0x18,  // e
+            0x00, 0x08, 0x7E, 0x09, 0x02,  // f
+            0x18, 0xA4, 0xA4, 0x9C, 0x78,  // g
+            0x7F, 0x08, 0x04, 0x04, 0x78,  // h
+            0x00, 0x44, 0x7D, 0x40, 0x00,  // i
+            0x20, 0x40, 0x40, 0x3D, 0x00,  // j
+            0x7F, 0x10, 0x28, 0x44, 0x00,  // k
+            0x00, 0x41, 0x7F, 0x40, 0x00,  // l
+            0x7C, 0x04, 0x78, 0x04, 0x78,  // m
+            0x7C, 0x08, 0x04, 0x04, 0x78,  // n
+            0x38, 0x44, 0x44, 0x44, 0x38,  // o
+            0xFC, 0x18, 0x24, 0x24, 0x18,  // p
+            0x18, 0x24, 0x24, 0x18, 0xFC,  // q
+            0x7C, 0x08, 0x04, 0x04, 0x08,  // r
+            0x48, 0x54, 0x54, 0x54, 0x24,  // s
+            0x04, 0x04, 0x3F, 0x44, 0x24,  // t
+            0x3C, 0x40, 0x40, 0x20, 0x7C,  // u
+            0x1C, 0x20, 0x40, 0x20, 0x1C,  // v
+            0x3C, 0x40, 0x30, 0x40, 0x3C,  // w
+            0x44, 0x28, 0x10, 0x28, 0x44,  // x
+            0x4C, 0x90, 0x90, 0x90, 0x7C,  // y
+            0x44, 0x64, 0x54, 0x4C, 0x44,  // z
+            0x00, 0x08, 0x36, 0x41, 0x00,  // {
+            0x00, 0x00, 0x77, 0x00, 0x00,  // |
+            0x00, 0x41, 0x36, 0x08, 0x00,  // }
+            0x02, 0x01, 0x02, 0x04, 0x02,  // ~
+        };
+
+        static_assert(sizeof(Font5x7) == 95U * 5U, "5x7 font table must cover printable ASCII");
+
+        bool pinIsAssigned(std::int8_t pin) {
+            return pin >= 0;
+        }
+
+    }  // namespace
+
+    TS35DisplayDriver::TS35DisplayDriver() : config_(), lcd_(nullptr), touch_(nullptr), initialized_(false) {}
+
+    TS35DisplayDriver::TS35DisplayDriver(const Config& config) : config_(config), lcd_(nullptr), touch_(nullptr), initialized_(false) {}
+
+    TS35DisplayDriver::~TS35DisplayDriver() {
+        end();
+    }
+
+    void TS35DisplayDriver::setConfig(const Config& config) {
+        end();
+        config_ = config;
+    }
+
+    void TS35DisplayDriver::end() {
+        if (initialized_) {
+            setBacklight(false);
+        }
+        if (lcd_ != nullptr) {
+            spi_bus_remove_device(lcd_);
+            lcd_ = nullptr;
+        }
+        if (touch_ != nullptr) {
+            spi_bus_remove_device(touch_);
+            touch_ = nullptr;
+        }
+        initialized_ = false;
+    }
+
+    bool TS35DisplayDriver::validConfig() const {
+        if (config_.lcdClockHz == 0 || config_.touchClockHz == 0) {
+            return false;
+        }
+
+        const std::int8_t requiredPins[] = {
+            config_.pins.tftCs,
+            config_.pins.tftDc,
+            config_.pins.touchCs,
+        };
+
+        for (std::size_t index = 0; index < sizeof(requiredPins) / sizeof(requiredPins[0]); ++index) {
+            if (!pinIsAssigned(requiredPins[index])) {
+                return false;
+            }
+            for (std::size_t other = index + 1; other < sizeof(requiredPins) / sizeof(requiredPins[0]); ++other) {
+                if (requiredPins[index] == requiredPins[other]) {
+                    return false;
+                }
+            }
+        }
+
+        const std::int8_t optionalPins[] = { config_.pins.tftReset, config_.pins.backlight };
+        for (std::size_t index = 0; index < sizeof(optionalPins) / sizeof(optionalPins[0]); ++index) {
+            if (!pinIsAssigned(optionalPins[index])) {
+                continue;
+            }
+            for (std::size_t other = 0; other < sizeof(requiredPins) / sizeof(requiredPins[0]); ++other) {
+                if (optionalPins[index] == requiredPins[other]) {
+                    return false;
+                }
+            }
+            if (index > 0 && optionalPins[index] == optionalPins[index - 1]) {
+                return false;
+            }
+        }
+
+        const TouchCalibration& touch = config_.touch;
+        return touch.xMin < touch.xMax && touch.yMin < touch.yMax && touch.samples > 0 && touch.samples <= MaximumTouchSamples;
+    }
+
+    bool TS35DisplayDriver::addDevices() {
+        // Manual chip select: the two devices need CS held across a command and its
+        // parameters, and across a whole touch conversion sequence, which is longer
+        // than one spi_transaction_t.
+        spi_device_interface_config_t lcdConfig = {};
+        lcdConfig.clock_speed_hz                = static_cast<int>(config_.lcdClockHz);
+        lcdConfig.mode                          = 0;
+        lcdConfig.spics_io_num                  = -1;
+        lcdConfig.queue_size                    = 1;
+        // Above 26.6 MHz the full-duplex input of a GPIO-matrix pin needs a dummy
+        // phase to stay valid.  Nothing is ever read back from the LCD, so the
+        // driver is told to skip it rather than refuse the clock.
+        lcdConfig.flags = SPI_DEVICE_NO_DUMMY;
+
+        spi_device_interface_config_t touchConfig = {};
+        touchConfig.clock_speed_hz                = static_cast<int>(config_.touchClockHz);
+        touchConfig.mode                          = 0;
+        touchConfig.spics_io_num                  = -1;
+        touchConfig.queue_size                    = 1;
+
+        if (spi_bus_add_device(HSPI_HOST, &lcdConfig, &lcd_) != ESP_OK) {
+            lcd_ = nullptr;
+            return false;
+        }
+        if (spi_bus_add_device(HSPI_HOST, &touchConfig, &touch_) != ESP_OK) {
+            touch_ = nullptr;
+            spi_bus_remove_device(lcd_);
+            lcd_ = nullptr;
+            return false;
+        }
+        return true;
+    }
+
+    bool TS35DisplayDriver::begin() {
+        end();
+
+        if (!validConfig()) {
+            return false;
+        }
+
+        pinMode(config_.pins.tftCs, OUTPUT);
+        pinMode(config_.pins.tftDc, OUTPUT);
+        pinMode(config_.pins.touchCs, OUTPUT);
+        digitalWrite(config_.pins.tftCs, HIGH);
+        digitalWrite(config_.pins.tftDc, HIGH);
+        digitalWrite(config_.pins.touchCs, HIGH);
+
+        if (pinIsAssigned(config_.pins.backlight)) {
+            pinMode(config_.pins.backlight, OUTPUT);
+            const bool offLevel = config_.backlightActiveLow;
+            digitalWrite(config_.pins.backlight, offLevel ? HIGH : LOW);
+        }
+
+        if (pinIsAssigned(config_.pins.tftReset)) {
+            pinMode(config_.pins.tftReset, OUTPUT);
+            digitalWrite(config_.pins.tftReset, HIGH);
+        }
+
+        // The bus itself belongs to the machine's `spi:` section and is already
+        // open by the time modules are initialised; this only attaches to it, and
+        // fails cleanly when the section is missing.
+        if (!addDevices()) {
+            return false;
+        }
+
+        if (pinIsAssigned(config_.pins.tftReset)) {
+            delay(5);
+            digitalWrite(config_.pins.tftReset, LOW);
+            delay(20);
+            digitalWrite(config_.pins.tftReset, HIGH);
+            delay(120);
+        }
+
+        // The values below are the ST7796 sequence carried by the public MKS
+        // DLC32/TFT_eSPI source.  The MADCTL value 0x28 is MV|BGR and exposes the
+        // controller's native 320x480 RAM as 480x320 landscape coordinates.
+        writeCommand(CmdSoftwareReset);
+        delay(120);
+        writeCommand(CmdSleepOut);
+        delay(20);
+
+        const std::uint8_t commandSetOne[] = { 0xC3 };
+        const std::uint8_t commandSetTwo[] = { 0x96 };
+        writeCommand(0xF0, commandSetOne, sizeof(commandSetOne));
+        writeCommand(0xF0, commandSetTwo, sizeof(commandSetTwo));
+
+        const std::uint8_t memoryAccess[] = { 0x28 };
+        const std::uint8_t pixelFormat[]  = { 0x55 };
+        const std::uint8_t inversion[]    = { 0x01 };
+        const std::uint8_t entryMode[]    = { 0xC6 };
+        writeCommand(CmdMemoryAccess, memoryAccess, sizeof(memoryAccess));
+        writeCommand(CmdPixelFormat, pixelFormat, sizeof(pixelFormat));
+        writeCommand(0xB4, inversion, sizeof(inversion));
+        writeCommand(0xB7, entryMode, sizeof(entryMode));
+
+        const std::uint8_t displayOutput[] = { 0x40, 0x8A, 0x00, 0x00, 0x29, 0x19, 0xA5, 0x33 };
+        const std::uint8_t powerTwo[]      = { 0x06 };
+        const std::uint8_t powerThree[]    = { 0xA7 };
+        const std::uint8_t vcom[]          = { 0x18 };
+        writeCommand(0xE8, displayOutput, sizeof(displayOutput));
+        writeCommand(0xC1, powerTwo, sizeof(powerTwo));
+        writeCommand(0xC2, powerThree, sizeof(powerThree));
+        writeCommand(0xC5, vcom, sizeof(vcom));
+
+        const std::uint8_t positiveGamma[] = {
+            0xF0, 0x09, 0x0B, 0x06, 0x04, 0x15, 0x2F, 0x54, 0x42, 0x3C, 0x17, 0x14, 0x18, 0x1B,
+        };
+        const std::uint8_t negativeGamma[] = {
+            0xF0, 0x09, 0x0B, 0x06, 0x04, 0x03, 0x2D, 0x43, 0x42, 0x3B, 0x16, 0x14, 0x17, 0x1B,
+        };
+        writeCommand(0xE0, positiveGamma, sizeof(positiveGamma));
+        writeCommand(0xE1, negativeGamma, sizeof(negativeGamma));
+
+        const std::uint8_t commandSetExitOne[] = { 0x3C };
+        const std::uint8_t commandSetExitTwo[] = { 0x69 };
+        writeCommand(0xF0, commandSetExitOne, sizeof(commandSetExitOne));
+        writeCommand(0xF0, commandSetExitTwo, sizeof(commandSetExitTwo));
+
+        writeCommand(config_.invertDisplay ? CmdInvertOn : CmdInvertOff);
+        delay(120);
+        writeCommand(CmdDisplayOn);
+        delay(20);
+
+        initialized_ = true;
+        fillScreen(0x0000);  // black
+        setBacklight(true);
+        return true;
+    }
+
+    void TS35DisplayDriver::setBacklight(bool on) {
+        if (!pinIsAssigned(config_.pins.backlight)) {
+            return;
+        }
+        const bool activeLevel = !config_.backlightActiveLow;
+        digitalWrite(config_.pins.backlight, on ? activeLevel : !activeLevel);
+    }
+
+    void TS35DisplayDriver::writeBytes(spi_device_handle_t device, const std::uint8_t* data, std::size_t length) {
+        // The SPI driver wants a DMA-capable source, which a stack buffer is and a
+        // caller's const array in flash may not be, so the bytes are copied.
+        std::uint8_t buffer[32];
+        while (length != 0) {
+            const std::size_t chunk = length < sizeof(buffer) ? length : sizeof(buffer);
+            std::memcpy(buffer, data, chunk);
+            spi_transaction_t transaction = {};
+            transaction.length            = chunk * 8U;
+            transaction.tx_buffer         = buffer;
+            spi_device_polling_transmit(device, &transaction);
+            data += chunk;
+            length -= chunk;
+        }
+    }
+
+    void TS35DisplayDriver::beginLcdTransaction() {
+        spi_device_acquire_bus(lcd_, portMAX_DELAY);
+        digitalWrite(config_.pins.touchCs, HIGH);
+        digitalWrite(config_.pins.tftCs, LOW);
+    }
+
+    void TS35DisplayDriver::endLcdTransaction() {
+        digitalWrite(config_.pins.tftCs, HIGH);
+        digitalWrite(config_.pins.tftDc, HIGH);
+        spi_device_release_bus(lcd_);
+    }
+
+    void TS35DisplayDriver::beginTouchTransaction() {
+        spi_device_acquire_bus(touch_, portMAX_DELAY);
+        digitalWrite(config_.pins.tftCs, HIGH);
+        digitalWrite(config_.pins.touchCs, LOW);
+    }
+
+    void TS35DisplayDriver::endTouchTransaction() {
+        digitalWrite(config_.pins.touchCs, HIGH);
+        spi_device_release_bus(touch_);
+    }
+
+    void TS35DisplayDriver::writeCommand(std::uint8_t command, const std::uint8_t* data, std::uint8_t length) {
+        beginLcdTransaction();
+        writeCommandInTransaction(command, data, length);
+        endLcdTransaction();
+    }
+
+    void TS35DisplayDriver::writeCommandInTransaction(std::uint8_t command, const std::uint8_t* data, std::uint8_t length) {
+        digitalWrite(config_.pins.tftDc, LOW);
+        writeBytes(lcd_, &command, 1);
+        if (data != nullptr && length != 0) {
+            digitalWrite(config_.pins.tftDc, HIGH);
+            writeBytes(lcd_, data, length);
+        }
+        digitalWrite(config_.pins.tftDc, HIGH);
+    }
+
+    void TS35DisplayDriver::setAddressWindowInTransaction(std::uint16_t x, std::uint16_t y, std::uint16_t widthValue, std::uint16_t heightValue) {
+        const std::uint16_t xEnd      = static_cast<std::uint16_t>(x + widthValue - 1U);
+        const std::uint16_t yEnd      = static_cast<std::uint16_t>(y + heightValue - 1U);
+        const std::uint8_t  columns[] = {
+            static_cast<std::uint8_t>(x >> 8),
+            static_cast<std::uint8_t>(x),
+            static_cast<std::uint8_t>(xEnd >> 8),
+            static_cast<std::uint8_t>(xEnd),
+        };
+        const std::uint8_t pages[] = {
+            static_cast<std::uint8_t>(y >> 8),
+            static_cast<std::uint8_t>(y),
+            static_cast<std::uint8_t>(yEnd >> 8),
+            static_cast<std::uint8_t>(yEnd),
+        };
+        writeCommandInTransaction(CmdColumnAddress, columns, sizeof(columns));
+        writeCommandInTransaction(CmdPageAddress, pages, sizeof(pages));
+        writeCommandInTransaction(CmdMemoryWrite);
+    }
+
+    void TS35DisplayDriver::writeSolidPixelsInTransaction(std::uint16_t color, std::uint32_t count) {
+        digitalWrite(config_.pins.tftDc, HIGH);
+        const std::uint32_t burstPixels = count < PixelsPerBurst ? count : PixelsPerBurst;
+        std::uint8_t        burst[PixelsPerBurst * 2U];
+        for (std::uint32_t index = 0; index < burstPixels; ++index) {
+            burst[index * 2U]      = static_cast<std::uint8_t>(color >> 8);
+            burst[index * 2U + 1U] = static_cast<std::uint8_t>(color);
+        }
+        while (count != 0) {
+            const std::uint32_t pixels      = count < burstPixels ? count : burstPixels;
+            spi_transaction_t   transaction = {};
+            transaction.length              = pixels * 16U;
+            transaction.tx_buffer           = burst;
+            spi_device_polling_transmit(lcd_, &transaction);
+            count -= pixels;
+        }
+    }
+
+    bool TS35DisplayDriver::clipRect(std::int16_t& x, std::int16_t& y, std::int16_t& widthValue, std::int16_t& heightValue) const {
+        if (widthValue <= 0 || heightValue <= 0) {
+            return false;
+        }
+
+        std::int32_t left   = x;
+        std::int32_t top    = y;
+        std::int32_t right  = left + widthValue;
+        std::int32_t bottom = top + heightValue;
+
+        if (right <= 0 || bottom <= 0 || left >= Width || top >= Height) {
+            return false;
+        }
+        if (left < 0) {
+            left = 0;
+        }
+        if (top < 0) {
+            top = 0;
+        }
+        if (right > Width) {
+            right = Width;
+        }
+        if (bottom > Height) {
+            bottom = Height;
+        }
+
+        x           = static_cast<std::int16_t>(left);
+        y           = static_cast<std::int16_t>(top);
+        widthValue  = static_cast<std::int16_t>(right - left);
+        heightValue = static_cast<std::int16_t>(bottom - top);
+        return widthValue > 0 && heightValue > 0;
+    }
+
+    void TS35DisplayDriver::fillRectInTransaction(
+        std::int16_t x, std::int16_t y, std::int16_t widthValue, std::int16_t heightValue, std::uint16_t color) {
+        if (!clipRect(x, y, widthValue, heightValue)) {
+            return;
+        }
+        setAddressWindowInTransaction(static_cast<std::uint16_t>(x),
+                                      static_cast<std::uint16_t>(y),
+                                      static_cast<std::uint16_t>(widthValue),
+                                      static_cast<std::uint16_t>(heightValue));
+        writeSolidPixelsInTransaction(color, static_cast<std::uint32_t>(widthValue) * static_cast<std::uint32_t>(heightValue));
+    }
+
+    void TS35DisplayDriver::fillScreen(std::uint16_t color) {
+        fillRect(0, 0, Width, Height, color);
+    }
+
+    void TS35DisplayDriver::fillRect(std::int16_t x, std::int16_t y, std::int16_t widthValue, std::int16_t heightValue, std::uint16_t color) {
+        if (!initialized_ || !clipRect(x, y, widthValue, heightValue)) {
+            return;
+        }
+        beginLcdTransaction();
+        setAddressWindowInTransaction(static_cast<std::uint16_t>(x),
+                                      static_cast<std::uint16_t>(y),
+                                      static_cast<std::uint16_t>(widthValue),
+                                      static_cast<std::uint16_t>(heightValue));
+        writeSolidPixelsInTransaction(color, static_cast<std::uint32_t>(widthValue) * static_cast<std::uint32_t>(heightValue));
+        endLcdTransaction();
+    }
+
+    void TS35DisplayDriver::drawRect(std::int16_t x, std::int16_t y, std::int16_t widthValue, std::int16_t heightValue, std::uint16_t color) {
+        if (!initialized_ || widthValue <= 0 || heightValue <= 0) {
+            return;
+        }
+
+        beginLcdTransaction();
+        fillRectInTransaction(x, y, widthValue, 1, color);
+        if (heightValue > 1) {
+            fillRectInTransaction(x, static_cast<std::int16_t>(y + heightValue - 1), widthValue, 1, color);
+        }
+        if (heightValue > 2) {
+            fillRectInTransaction(x, static_cast<std::int16_t>(y + 1), 1, static_cast<std::int16_t>(heightValue - 2), color);
+            if (widthValue > 1) {
+                fillRectInTransaction(static_cast<std::int16_t>(x + widthValue - 1),
+                                      static_cast<std::int16_t>(y + 1),
+                                      1,
+                                      static_cast<std::int16_t>(heightValue - 2),
+                                      color);
+            }
+        }
+        endLcdTransaction();
+    }
+
+    void TS35DisplayDriver::drawGlyphInTransaction(
+        std::int16_t x, std::int16_t y, char character, std::uint16_t foreground, std::uint16_t background, std::uint8_t scale) {
+        std::uint8_t code = static_cast<std::uint8_t>(character);
+        if (code < 0x20 || code > 0x7E) {
+            code = static_cast<std::uint8_t>('?');
+        }
+
+        fillRectInTransaction(x, y, static_cast<std::int16_t>(6U * scale), static_cast<std::int16_t>(8U * scale), background);
+
+        const std::size_t glyphOffset = static_cast<std::size_t>(code - 0x20U) * 5U;
+        for (std::uint8_t row = 0; row < 8; ++row) {
+            std::uint8_t column = 0;
+            while (column < 5) {
+                while (column < 5) {
+                    const std::uint8_t bits = pgm_read_byte(Font5x7 + glyphOffset + column);
+                    if ((bits & (1U << row)) != 0) {
+                        break;
+                    }
+                    ++column;
+                }
+                const std::uint8_t runStart = column;
+                while (column < 5) {
+                    const std::uint8_t bits = pgm_read_byte(Font5x7 + glyphOffset + column);
+                    if ((bits & (1U << row)) == 0) {
+                        break;
+                    }
+                    ++column;
+                }
+                if (runStart < column) {
+                    fillRectInTransaction(static_cast<std::int16_t>(x + static_cast<std::int16_t>(runStart * scale)),
+                                          static_cast<std::int16_t>(y + static_cast<std::int16_t>(row * scale)),
+                                          static_cast<std::int16_t>((column - runStart) * scale),
+                                          scale,
+                                          foreground);
+                }
+            }
+        }
+    }
+
+    void TS35DisplayDriver::drawText(
+        std::int16_t x, std::int16_t y, const char* text, std::uint16_t foreground, std::uint16_t background, std::uint8_t scale) {
+        if (!initialized_ || text == nullptr || scale == 0) {
+            return;
+        }
+
+        const std::int32_t originX = x;
+        std::int32_t       cursorX = x;
+        std::int32_t       cursorY = y;
+        const std::int32_t advance = 6 * static_cast<std::int32_t>(scale);
+        const std::int32_t line    = 8 * static_cast<std::int32_t>(scale);
+
+        beginLcdTransaction();
+        while (*text != '\0') {
+            const char character = *text++;
+            if (character == '\r') {
+                continue;
+            }
+            if (character == '\n') {
+                cursorX = originX;
+                cursorY += line;
+                if (cursorY >= Height) {
+                    break;
+                }
+                continue;
+            }
+
+            if (cursorX >= Width) {
+                break;
+            }
+            if (cursorX + advance > 0 && cursorY + line > 0 && cursorY < Height) {
+                drawGlyphInTransaction(
+                    static_cast<std::int16_t>(cursorX), static_cast<std::int16_t>(cursorY), character, foreground, background, scale);
+            }
+            cursorX += advance;
+        }
+        endLcdTransaction();
+    }
+
+    std::uint16_t TS35DisplayDriver::readAdc12InTransaction(std::uint8_t command) {
+        std::uint8_t      out[3]      = { command, 0x00, 0x00 };
+        std::uint8_t      in[3]       = { 0x00, 0x00, 0x00 };
+        spi_transaction_t transaction = {};
+        transaction.length            = sizeof(out) * 8U;
+        transaction.tx_buffer         = out;
+        transaction.rx_buffer         = in;
+        spi_device_polling_transmit(touch_, &transaction);
+        const std::uint16_t value = static_cast<std::uint16_t>(static_cast<std::uint16_t>(in[1]) << 8) | in[2];
+        return static_cast<std::uint16_t>((value >> 3) & 0x0FFFU);
+    }
+
+    std::uint16_t TS35DisplayDriver::readPressureInTransaction() {
+        const std::uint16_t z1 = readAdc12InTransaction(TouchReadZ1);
+        const std::uint16_t z2 = readAdc12InTransaction(TouchReadZ2);
+        if (z1 == 0) {
+            return 0;
+        }
+        std::int32_t pressure = 4095 + static_cast<std::int32_t>(z1) - static_cast<std::int32_t>(z2);
+        if (pressure < 0) {
+            pressure = 0;
+        } else if (pressure > 0xFFFF) {
+            pressure = 0xFFFF;
+        }
+        return static_cast<std::uint16_t>(pressure);
+    }
+
+    void TS35DisplayDriver::sortSamples(std::uint16_t* samples, std::uint8_t count) {
+        for (std::uint8_t index = 1; index < count; ++index) {
+            const std::uint16_t value = samples[index];
+            std::uint8_t        slot  = index;
+            while (slot > 0 && samples[slot - 1] > value) {
+                samples[slot] = samples[slot - 1];
+                --slot;
+            }
+            samples[slot] = value;
+        }
+    }
+
+    bool TS35DisplayDriver::readTouchRaw(std::uint16_t& rawX, std::uint16_t& rawY, std::uint16_t* pressure) {
+        rawX = 0;
+        rawY = 0;
+        if (pressure != nullptr) {
+            *pressure = 0;
+        }
+        if (!initialized_ || config_.touch.samples == 0 || config_.touch.samples > MaximumTouchSamples) {
+            return false;
+        }
+
+        std::uint16_t      xSamples[MaximumTouchSamples];
+        std::uint16_t      ySamples[MaximumTouchSamples];
+        const std::uint8_t sampleCount = config_.touch.samples;
+
+        beginTouchTransaction();
+        const std::uint16_t pressureBefore = readPressureInTransaction();
+        if (config_.touch.pressureThreshold != 0 && pressureBefore <= config_.touch.pressureThreshold) {
+            endTouchTransaction();
+            if (pressure != nullptr) {
+                *pressure = pressureBefore;
+            }
+            return false;
+        }
+
+        for (std::uint8_t index = 0; index < sampleCount; ++index) {
+            // The public MKS/TFT_eSPI driver clocks several conversions after each
+            // mux change.  Discard one conversion here so the panel capacitance has
+            // settled before the value enters the median filter.
+            readAdc12InTransaction(TouchReadX);
+            xSamples[index] = readAdc12InTransaction(TouchReadX);
+            readAdc12InTransaction(TouchReadY);
+            ySamples[index] = readAdc12InTransaction(TouchReadY);
+        }
+        const std::uint16_t pressureAfter = readPressureInTransaction();
+        endTouchTransaction();
+
+        const std::uint16_t measuredPressure = pressureBefore < pressureAfter ? pressureBefore : pressureAfter;
+        if (pressure != nullptr) {
+            *pressure = measuredPressure;
+        }
+        if (config_.touch.pressureThreshold != 0 && measuredPressure <= config_.touch.pressureThreshold) {
+            return false;
+        }
+
+        sortSamples(xSamples, sampleCount);
+        sortSamples(ySamples, sampleCount);
+        const std::uint16_t xSpread = static_cast<std::uint16_t>(xSamples[sampleCount - 1] - xSamples[0]);
+        const std::uint16_t ySpread = static_cast<std::uint16_t>(ySamples[sampleCount - 1] - ySamples[0]);
+        if (config_.touch.maxSampleSpread != 0 && (xSpread > config_.touch.maxSampleSpread || ySpread > config_.touch.maxSampleSpread)) {
+            return false;
+        }
+
+        rawX = xSamples[sampleCount / 2];
+        rawY = ySamples[sampleCount / 2];
+        return rawX != 0 && rawY != 0 && rawX != 0x0FFF && rawY != 0x0FFF;
+    }
+
+    std::int16_t TS35DisplayDriver::mapCalibrated(
+        std::uint16_t raw, std::uint16_t minimum, std::uint16_t maximum, std::int16_t extent, bool invert) {
+        std::int32_t clamped = raw;
+        if (clamped < minimum) {
+            clamped = minimum;
+        } else if (clamped > maximum) {
+            clamped = maximum;
+        }
+
+        const std::int32_t range  = static_cast<std::int32_t>(maximum) - minimum;
+        std::int32_t       mapped = ((clamped - minimum) * (extent - 1) + range / 2) / range;
+        if (invert) {
+            mapped = (extent - 1) - mapped;
+        }
+        return static_cast<std::int16_t>(mapped);
+    }
+
+    bool TS35DisplayDriver::readTouch(std::int16_t& x, std::int16_t& y) {
+        std::uint16_t rawX = 0;
+        std::uint16_t rawY = 0;
+        if (!readTouchRaw(rawX, rawY)) {
+            return false;
+        }
+
+        const TouchCalibration& calibration = config_.touch;
+        if (calibration.xMin >= calibration.xMax || calibration.yMin >= calibration.yMax) {
+            return false;
+        }
+
+        const std::uint16_t logicalX = calibration.swapXY ? rawY : rawX;
+        const std::uint16_t logicalY = calibration.swapXY ? rawX : rawY;
+        x                            = mapCalibrated(logicalX, calibration.xMin, calibration.xMax, Width, calibration.invertX);
+        y                            = mapCalibrated(logicalY, calibration.yMin, calibration.yMax, Height, calibration.invertY);
+        return true;
+    }
+
+}  // namespace ts35

--- a/FluidNC/esp32/TS35DisplayDriver.h
+++ b/FluidNC/esp32/TS35DisplayDriver.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <driver/spi_master.h>
+
+namespace ts35 {
+
+    // Minimal, synchronous driver for the passive MKS TS35/TS35-R panel.
+    //
+    // The panel has no processor of its own: an ST7796 LCD and an ADS7843E touch
+    // controller sit on one SPI bus behind independent chip-select signals.  That
+    // bus is the machine's shared one: Machine::SPIBus opens HSPI from the `spi:`
+    // section before any module init() runs, and this driver only adds two devices
+    // to it, exactly as the SD card does.  Every public drawing/touch operation
+    // acquires the bus for its duration.  Calls must be made from normal task
+    // context; none of these methods is safe to call from an ISR.
+    class TS35DisplayDriver {
+    public:
+        enum : std::int16_t {
+            Width  = 480,
+            Height = 320,
+        };
+
+        // Native MCU GPIO numbers, resolved from FluidNC Pin objects by the caller.
+        // -1 means "not wired", which only tftReset and backlight may be.
+        struct Pins {
+            std::int8_t tftCs     = -1;
+            std::int8_t tftDc     = -1;
+            std::int8_t tftReset  = -1;
+            std::int8_t touchCs   = -1;
+            std::int8_t backlight = -1;
+        };
+
+        struct TouchCalibration {
+            // Bounds apply after swapXY.  In other words, xMin/xMax always describe
+            // the raw channel that will become the landscape screen X coordinate.
+            std::uint16_t xMin = 300;
+            std::uint16_t xMax = 3600;
+            std::uint16_t yMin = 300;
+            std::uint16_t yMax = 3600;
+
+            // XPT2046-style Z = 4095 + Z1 - Z2.  Set to zero only for controlled
+            // diagnostics where pressure filtering is intentionally disabled.
+            std::uint16_t pressureThreshold = 350;
+            std::uint16_t maxSampleSpread   = 40;
+            std::uint8_t  samples           = 5;
+
+            bool swapXY  = true;
+            bool invertX = true;
+            bool invertY = false;
+        };
+
+        struct Config {
+            Pins             pins;
+            TouchCalibration touch;
+
+            std::uint32_t lcdClockHz   = 40000000U;
+            std::uint32_t touchClockHz = 2000000U;
+
+            // Public MKS sources disagree across board revisions about GPIO5
+            // polarity, so this is deliberately a runtime setting.
+            bool backlightActiveLow = true;
+            bool invertDisplay      = false;
+        };
+
+        TS35DisplayDriver();
+        explicit TS35DisplayDriver(const Config& config);
+        ~TS35DisplayDriver();
+
+        TS35DisplayDriver(const TS35DisplayDriver&)            = delete;
+        TS35DisplayDriver& operator=(const TS35DisplayDriver&) = delete;
+
+        // Configure before begin().  Any devices from a previous begin() are
+        // removed, so pins and controller state cannot diverge from the new
+        // settings.
+        void setConfig(const Config& config);
+
+        // Attaches the LCD and the touch controller to the already-open shared SPI
+        // bus, hardware-resets the panel, runs the MKS ST7796 sequence, clears the
+        // screen and lights the backlight.  false means the bus was not open or
+        // the configuration was rejected; true only means the sequence was issued,
+        // since the TS35 MISO wiring cannot provide a reliable controller-ID probe.
+        bool begin();
+
+        // Detaches both devices from the shared bus and turns the backlight off.
+        void end();
+
+        void setBacklight(bool on);
+
+        void fillScreen(std::uint16_t color);
+        void fillRect(std::int16_t x, std::int16_t y, std::int16_t width, std::int16_t height, std::uint16_t color);
+        void drawRect(std::int16_t x, std::int16_t y, std::int16_t width, std::int16_t height, std::uint16_t color);
+
+        // Paints the complete 6x8 character cell (5 columns plus spacing) using
+        // the supplied background, so a redraw covers whatever was there before.
+        // scale zero is ignored.
+        void drawText(std::int16_t x, std::int16_t y, const char* text, std::uint16_t foreground, std::uint16_t background, std::uint8_t scale);
+
+        // Returns physical ADC channels before swap/inversion/calibration.  rawX
+        // is command 0xD0 and rawY is command 0x90.  pressure may be null.
+        bool readTouchRaw(std::uint16_t& rawX, std::uint16_t& rawY, std::uint16_t* pressure = nullptr);
+
+        // Returns calibrated landscape coordinates in [0,479] x [0,319].
+        bool readTouch(std::int16_t& x, std::int16_t& y);
+
+    private:
+        Config              config_;
+        spi_device_handle_t lcd_;
+        spi_device_handle_t touch_;
+        bool                initialized_;
+
+        bool validConfig() const;
+        bool addDevices();
+
+        void beginLcdTransaction();
+        void endLcdTransaction();
+        void beginTouchTransaction();
+        void endTouchTransaction();
+
+        static void writeBytes(spi_device_handle_t device, const std::uint8_t* data, std::size_t length);
+
+        void writeCommand(std::uint8_t command, const std::uint8_t* data = nullptr, std::uint8_t length = 0);
+        void writeCommandInTransaction(std::uint8_t command, const std::uint8_t* data = nullptr, std::uint8_t length = 0);
+        void setAddressWindowInTransaction(std::uint16_t x, std::uint16_t y, std::uint16_t width, std::uint16_t height);
+        void writeSolidPixelsInTransaction(std::uint16_t color, std::uint32_t count);
+        void fillRectInTransaction(std::int16_t x, std::int16_t y, std::int16_t width, std::int16_t height, std::uint16_t color);
+        void drawGlyphInTransaction(
+            std::int16_t x, std::int16_t y, char character, std::uint16_t foreground, std::uint16_t background, std::uint8_t scale);
+
+        bool clipRect(std::int16_t& x, std::int16_t& y, std::int16_t& width, std::int16_t& height) const;
+
+        std::uint16_t readAdc12InTransaction(std::uint8_t command);
+        std::uint16_t readPressureInTransaction();
+        static void   sortSamples(std::uint16_t* samples, std::uint8_t count);
+        static std::int16_t mapCalibrated(std::uint16_t raw, std::uint16_t minimum, std::uint16_t maximum, std::int16_t extent, bool invert);
+    };
+
+}  // namespace ts35

--- a/FluidNC/esp32/TS35Model.cpp
+++ b/FluidNC/esp32/TS35Model.cpp
@@ -1,0 +1,740 @@
+#include "TS35Model.h"
+
+#include <cerrno>
+#include <cctype>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+
+namespace ts35 {
+
+    namespace {
+
+        constexpr std::size_t MaxLineCommandLength = 240;
+
+        std::size_t axisIndex(Axis axis) {
+            return static_cast<std::size_t>(axis);
+        }
+
+        bool isValidAxis(Axis axis) {
+            return axisIndex(axis) < AxisCount;
+        }
+
+        char axisLetter(std::size_t index) {
+            static const char letters[AxisCount] = { 'X', 'Y', 'Z', 'A', 'B', 'C' };
+            return index < AxisCount ? letters[index] : '?';
+        }
+
+        std::string trim(const std::string& text) {
+            std::size_t first = 0;
+            while (first < text.size() && std::isspace(static_cast<unsigned char>(text[first]))) {
+                ++first;
+            }
+
+            std::size_t last = text.size();
+            while (last > first && std::isspace(static_cast<unsigned char>(text[last - 1]))) {
+                --last;
+            }
+            return text.substr(first, last - first);
+        }
+
+        std::string upper(const std::string& text) {
+            std::string result(text);
+            for (std::size_t i = 0; i < result.size(); ++i) {
+                result[i] = static_cast<char>(std::toupper(static_cast<unsigned char>(result[i])));
+            }
+            return result;
+        }
+
+        bool startsWithCaseInsensitive(const std::string& text, const char* prefix) {
+            std::size_t index = 0;
+            while (prefix[index] != '\0') {
+                if (index >= text.size()) {
+                    return false;
+                }
+                const unsigned char lhs = static_cast<unsigned char>(text[index]);
+                const unsigned char rhs = static_cast<unsigned char>(prefix[index]);
+                if (std::toupper(lhs) != std::toupper(rhs)) {
+                    return false;
+                }
+                ++index;
+            }
+            return true;
+        }
+
+        std::vector<std::string> split(const std::string& text, char delimiter) {
+            std::vector<std::string> result;
+            std::size_t              start = 0;
+            while (true) {
+                const std::size_t end = text.find(delimiter, start);
+                if (end == std::string::npos) {
+                    result.push_back(text.substr(start));
+                    break;
+                }
+                result.push_back(text.substr(start, end - start));
+                start = end + 1;
+            }
+            return result;
+        }
+
+        bool parseDouble(const std::string& text, double& value) {
+            const std::string cleaned = trim(text);
+            if (cleaned.empty()) {
+                return false;
+            }
+            bool sawDigit = false;
+            for (const unsigned char character : cleaned) {
+                if (std::isdigit(character)) {
+                    sawDigit = true;
+                } else if (character != '+' && character != '-' && character != '.' && character != 'e' && character != 'E') {
+                    return false;
+                }
+            }
+            if (!sawDigit) {
+                return false;
+            }
+
+            errno     = 0;
+            char* end = nullptr;
+            value     = std::strtod(cleaned.c_str(), &end);
+            return errno != ERANGE && end != cleaned.c_str() && *end == '\0' && std::isfinite(value);
+        }
+
+        bool parseUnsigned(const std::string& text, std::uint32_t& value) {
+            const std::string cleaned = trim(text);
+            if (cleaned.empty()) {
+                return false;
+            }
+            for (std::size_t i = 0; i < cleaned.size(); ++i) {
+                if (!std::isdigit(static_cast<unsigned char>(cleaned[i]))) {
+                    return false;
+                }
+            }
+
+            errno                      = 0;
+            char*               end    = nullptr;
+            const unsigned long parsed = std::strtoul(cleaned.c_str(), &end, 10);
+            if (errno == ERANGE || end == cleaned.c_str() || *end != '\0' || parsed > std::numeric_limits<std::uint32_t>::max()) {
+                return false;
+            }
+            value = static_cast<std::uint32_t>(parsed);
+            return true;
+        }
+
+        bool parseInt(const std::string& text, int& value) {
+            const std::string cleaned = trim(text);
+            if (cleaned.empty()) {
+                return false;
+            }
+
+            std::size_t index = (cleaned[0] == '+' || cleaned[0] == '-') ? 1 : 0;
+            if (index == cleaned.size()) {
+                return false;
+            }
+            for (; index < cleaned.size(); ++index) {
+                if (!std::isdigit(static_cast<unsigned char>(cleaned[index]))) {
+                    return false;
+                }
+            }
+
+            errno             = 0;
+            char*      end    = nullptr;
+            const long parsed = std::strtol(cleaned.c_str(), &end, 10);
+            if (errno == ERANGE || end == cleaned.c_str() || *end != '\0' || parsed < std::numeric_limits<int>::min() ||
+                parsed > std::numeric_limits<int>::max()) {
+                return false;
+            }
+            value = static_cast<int>(parsed);
+            return true;
+        }
+
+        bool parseAxisValues(const std::string& text, AxisValues& result) {
+            const std::vector<std::string> words = split(text, ',');
+            if (words.empty() || words.size() > AxisCount) {
+                return false;
+            }
+
+            AxisValues parsed;
+            for (std::size_t i = 0; i < words.size(); ++i) {
+                double value = 0.0;
+                if (!parseDouble(words[i], value)) {
+                    return false;
+                }
+                parsed.value[i] = value;
+                parsed.valid[i] = true;
+            }
+            result = parsed;
+            return true;
+        }
+
+        bool parseTwoDoubles(const std::string& text, double& first, double& second) {
+            const std::vector<std::string> words = split(text, ',');
+            return words.size() == 2 && parseDouble(words[0], first) && parseDouble(words[1], second);
+        }
+
+        bool parseTwoUnsigned(const std::string& text, std::uint32_t& first, std::uint32_t& second) {
+            const std::vector<std::string> words = split(text, ',');
+            return words.size() == 2 && parseUnsigned(words[0], first) && parseUnsigned(words[1], second);
+        }
+
+        bool parseThreeUnsigned(const std::string& text, std::uint32_t& first, std::uint32_t& second, std::uint32_t& third) {
+            const std::vector<std::string> words = split(text, ',');
+            return words.size() == 3 && parseUnsigned(words[0], first) && parseUnsigned(words[1], second) && parseUnsigned(words[2], third);
+        }
+
+        MachineState parseMachineState(const std::string& rawState, int& substate) {
+            const std::size_t colon = rawState.find(':');
+            const std::string name  = upper(trim(rawState.substr(0, colon)));
+            substate                = -1;
+            if (colon != std::string::npos) {
+                int parsed = -1;
+                if (parseInt(rawState.substr(colon + 1), parsed)) {
+                    substate = parsed;
+                }
+            }
+
+            if (name == "IDLE") {
+                return MachineState::Idle;
+            }
+            if (name == "RUN" || name == "CYCLE") {
+                return MachineState::Cycle;
+            }
+            if (name == "HOLD" || name == "HELD") {
+                return MachineState::Hold;
+            }
+            if (name == "JOG") {
+                return MachineState::Jog;
+            }
+            if (name == "ALARM") {
+                return MachineState::Alarm;
+            }
+            if (name == "DOOR" || name == "SAFETYDOOR") {
+                return MachineState::SafetyDoor;
+            }
+            if (name == "CHECK" || name == "CHECKMODE") {
+                return MachineState::Check;
+            }
+            if (name == "HOME" || name == "HOMING") {
+                return MachineState::Homing;
+            }
+            if (name == "SLEEP") {
+                return MachineState::Sleep;
+            }
+            if (name == "CONFIGALARM") {
+                return MachineState::ConfigAlarm;
+            }
+            if (name == "CRITICAL") {
+                return MachineState::Critical;
+            }
+            if (name == "START" || name == "STARTING") {
+                return MachineState::Starting;
+            }
+            return MachineState::Unknown;
+        }
+
+        void synchronizePositions(ModelSnapshot& snapshot, bool sawMpos, bool sawWpos, bool sawWco) {
+            for (std::size_t axis = 0; axis < AxisCount; ++axis) {
+                // A WCO present in this report is authoritative. FluidNC normally emits
+                // only MPos or WPos, with WCO at a slower cadence.
+                if (sawWco && snapshot.wco.valid[axis]) {
+                    if (sawMpos && snapshot.mpos.valid[axis]) {
+                        snapshot.wpos.value[axis] = snapshot.mpos.value[axis] - snapshot.wco.value[axis];
+                        snapshot.wpos.valid[axis] = true;
+                    } else if (sawWpos && snapshot.wpos.valid[axis]) {
+                        snapshot.mpos.value[axis] = snapshot.wpos.value[axis] + snapshot.wco.value[axis];
+                        snapshot.mpos.valid[axis] = true;
+                    } else if (snapshot.mpos.valid[axis]) {
+                        snapshot.wpos.value[axis] = snapshot.mpos.value[axis] - snapshot.wco.value[axis];
+                        snapshot.wpos.valid[axis] = true;
+                    } else if (snapshot.wpos.valid[axis]) {
+                        snapshot.mpos.value[axis] = snapshot.wpos.value[axis] + snapshot.wco.value[axis];
+                        snapshot.mpos.valid[axis] = true;
+                    }
+                    continue;
+                }
+
+                if (sawMpos && sawWpos && snapshot.mpos.valid[axis] && snapshot.wpos.valid[axis]) {
+                    snapshot.wco.value[axis] = snapshot.mpos.value[axis] - snapshot.wpos.value[axis];
+                    snapshot.wco.valid[axis] = true;
+                } else if (sawMpos && snapshot.mpos.valid[axis] && snapshot.wco.valid[axis]) {
+                    snapshot.wpos.value[axis] = snapshot.mpos.value[axis] - snapshot.wco.value[axis];
+                    snapshot.wpos.valid[axis] = true;
+                } else if (sawWpos && snapshot.wpos.valid[axis] && snapshot.wco.valid[axis]) {
+                    snapshot.mpos.value[axis] = snapshot.wpos.value[axis] + snapshot.wco.value[axis];
+                    snapshot.mpos.valid[axis] = true;
+                }
+            }
+        }
+
+        void applyModalWord(const std::string& modalWord, ModalState& modal) {
+            const std::string word = upper(modalWord);
+            if (word == "G54") {
+                modal.coordinateSystem = CoordinateSystem::G54;
+            } else if (word == "G55") {
+                modal.coordinateSystem = CoordinateSystem::G55;
+            } else if (word == "G56") {
+                modal.coordinateSystem = CoordinateSystem::G56;
+            } else if (word == "G57") {
+                modal.coordinateSystem = CoordinateSystem::G57;
+            } else if (word == "G58") {
+                modal.coordinateSystem = CoordinateSystem::G58;
+            } else if (word == "G59") {
+                modal.coordinateSystem = CoordinateSystem::G59;
+            } else if (word == "G59.1") {
+                modal.coordinateSystem = CoordinateSystem::G59_1;
+            } else if (word == "G59.2") {
+                modal.coordinateSystem = CoordinateSystem::G59_2;
+            } else if (word == "G59.3") {
+                modal.coordinateSystem = CoordinateSystem::G59_3;
+            } else if (word == "G20") {
+                modal.units = Units::Inches;
+            } else if (word == "G21") {
+                modal.units = Units::Millimeters;
+            } else if (word == "G90") {
+                modal.distanceMode = DistanceMode::Absolute;
+            } else if (word == "G91") {
+                modal.distanceMode = DistanceMode::Incremental;
+            }
+        }
+
+        std::string formatNumber(double value) {
+            if (value == 0.0) {
+                value = 0.0;  // Normalize negative zero.
+            }
+
+            char      buffer[48];
+            const int written = std::snprintf(buffer, sizeof(buffer), "%.6f", value);
+            if (written <= 0 || static_cast<std::size_t>(written) >= sizeof(buffer)) {
+                return std::string();
+            }
+            std::string result(buffer);
+            while (!result.empty() && result[result.size() - 1] == '0') {
+                result.erase(result.size() - 1);
+            }
+            if (!result.empty() && result[result.size() - 1] == '.') {
+                result.erase(result.size() - 1);
+            }
+            if (result == "-0") {
+                result = "0";
+            }
+            return result;
+        }
+
+        CommandBuildResult commandFailure() {
+            return CommandBuildResult();
+        }
+
+        CommandBuildResult commandSuccess(const std::string& command) {
+            CommandBuildResult result;
+            result.ok      = true;
+            result.command = command;
+            return result;
+        }
+
+    }  // namespace
+
+    AxisValues::AxisValues() : value(), valid() {}
+
+    bool AxisValues::has(Axis axis) const {
+        return isValidAxis(axis) && valid[axisIndex(axis)];
+    }
+
+    double AxisValues::get(Axis axis) const {
+        return has(axis) ? value[axisIndex(axis)] : 0.0;
+    }
+
+    FeedSpindle::FeedSpindle() : feed(0.0), spindle(0.0), valid(false) {}
+
+    Overrides::Overrides() : feed(100), rapid(100), spindle(100), valid(false) {}
+
+    PinState::PinState() : valid(false), raw() {}
+
+    SdProgress::SdProgress() : valid(false), percent(0.0) {}
+
+    BufferState::BufferState() : valid(false), plannerAvailable(0), rxAvailable(0) {}
+
+    LineNumber::LineNumber() : valid(false), value(0) {}
+
+    ModalState::ModalState() : coordinateSystem(CoordinateSystem::Unknown), units(Units::Unknown), distanceMode(DistanceMode::Unknown) {}
+
+    Reply::Reply() : kind(ReplyKind::None), hasCode(false), code(0), text() {}
+
+    ModelSnapshot::ModelSnapshot() :
+        state(MachineState::Unknown), rawState(), stateSubstate(-1), mpos(), wpos(), wco(), fs(), overrides(), pins(), sd(), buffers(),
+        lineNumber(), modal(), lastReply(), sequence(0) {}
+
+    AxisMove::AxisMove(Axis axisValue, double millimetersValue) : axis(axisValue), millimeters(millimetersValue) {}
+
+    CommandBuildResult::CommandBuildResult() : ok(false), command() {}
+
+    CommandBuildResult buildSetWorkZeroCommand(const std::vector<Axis>& axes) {
+        if (axes.empty()) {
+            return commandFailure();
+        }
+
+        std::array<bool, AxisCount> selected = {};
+        for (std::size_t i = 0; i < axes.size(); ++i) {
+            if (!isValidAxis(axes[i])) {
+                return commandFailure();
+            }
+            const std::size_t index = axisIndex(axes[i]);
+            if (selected[index]) {
+                return commandFailure();
+            }
+            selected[index] = true;
+        }
+
+        std::string command("G10 L20 P0");
+        for (std::size_t axis = 0; axis < AxisCount; ++axis) {
+            if (selected[axis]) {
+                command += " ";
+                command += axisLetter(axis);
+                command += "0";
+            }
+        }
+        return commandSuccess(command);
+    }
+
+    CommandBuildResult buildIncrementalJogCommand(const std::vector<AxisMove>& moves, double feedMmPerMinute) {
+        if (moves.empty()) {
+            return commandFailure();
+        }
+        if (!std::isfinite(feedMmPerMinute) || feedMmPerMinute <= 0.0) {
+            return commandFailure();
+        }
+
+        std::array<bool, AxisCount>   selected  = {};
+        std::array<double, AxisCount> distances = {};
+        for (std::size_t i = 0; i < moves.size(); ++i) {
+            if (!isValidAxis(moves[i].axis)) {
+                return commandFailure();
+            }
+            if (!std::isfinite(moves[i].millimeters) || moves[i].millimeters == 0.0) {
+                return commandFailure();
+            }
+            const std::size_t index = axisIndex(moves[i].axis);
+            if (selected[index]) {
+                return commandFailure();
+            }
+            const std::string formatted = formatNumber(moves[i].millimeters);
+            if (formatted == "0") {
+                return commandFailure();
+            }
+            selected[index]  = true;
+            distances[index] = moves[i].millimeters;
+        }
+
+        std::string command("$J=G91 G21");
+        for (std::size_t axis = 0; axis < AxisCount; ++axis) {
+            if (selected[axis]) {
+                command += " ";
+                command += axisLetter(axis);
+                command += formatNumber(distances[axis]);
+            }
+        }
+        command += " F";
+        command += formatNumber(feedMmPerMinute);
+        if (command.size() > MaxLineCommandLength) {
+            return commandFailure();
+        }
+        return commandSuccess(command);
+    }
+
+    TS35Model::TS35Model() : snapshot_() {}
+
+    const ModelSnapshot& TS35Model::snapshot() const {
+        return snapshot_;
+    }
+
+    bool TS35Model::parseLine(const std::string& input, Reply* parsedReply) {
+        const std::string line = trim(input);
+        if (line.empty()) {
+            return false;
+        }
+
+        if (line[0] == '<') {
+            if (line.size() < 3 || line[line.size() - 1] != '>') {
+                return false;
+            }
+            const std::vector<std::string> fields = split(line.substr(1, line.size() - 2), '|');
+            if (fields.empty() || trim(fields[0]).empty()) {
+                return false;
+            }
+
+            ModelSnapshot next = snapshot_;
+            next.rawState      = trim(fields[0]);
+            next.state         = parseMachineState(next.rawState, next.stateSubstate);
+
+            // Pn/SD/Ln are omitted when inactive, unlike slower-cadence WCO and
+            // Ov fields. Reset them for every complete status report.
+            next.pins       = PinState();
+            next.sd         = SdProgress();
+            next.lineNumber = LineNumber();
+
+            bool sawMpos = false;
+            bool sawWpos = false;
+            bool sawWco  = false;
+
+            for (std::size_t i = 1; i < fields.size(); ++i) {
+                const std::string field = trim(fields[i]);
+                const std::size_t colon = field.find(':');
+                if (colon == std::string::npos) {
+                    continue;
+                }
+                const std::string tag   = trim(field.substr(0, colon));
+                const std::string value = trim(field.substr(colon + 1));
+
+                if (tag == "MPos") {
+                    AxisValues parsed;
+                    if (parseAxisValues(value, parsed)) {
+                        next.mpos = parsed;
+                        sawMpos   = true;
+                    }
+                } else if (tag == "WPos") {
+                    AxisValues parsed;
+                    if (parseAxisValues(value, parsed)) {
+                        next.wpos = parsed;
+                        sawWpos   = true;
+                    }
+                } else if (tag == "WCO") {
+                    AxisValues parsed;
+                    if (parseAxisValues(value, parsed)) {
+                        next.wco = parsed;
+                        sawWco   = true;
+                    }
+                } else if (tag == "FS") {
+                    double feed    = 0.0;
+                    double spindle = 0.0;
+                    if (parseTwoDoubles(value, feed, spindle)) {
+                        next.fs.feed    = feed;
+                        next.fs.spindle = spindle;
+                        next.fs.valid   = true;
+                    }
+                } else if (tag == "Ov") {
+                    std::uint32_t feed    = 0;
+                    std::uint32_t rapid   = 0;
+                    std::uint32_t spindle = 0;
+                    if (parseThreeUnsigned(value, feed, rapid, spindle)) {
+                        next.overrides.feed    = feed;
+                        next.overrides.rapid   = rapid;
+                        next.overrides.spindle = spindle;
+                        next.overrides.valid   = true;
+                    }
+                } else if (tag == "Pn") {
+                    next.pins.valid = true;
+                    next.pins.raw   = value;
+                } else if (tag == "SD") {
+                    const std::size_t comma   = value.find(',');
+                    double            percent = 0.0;
+                    if (comma != std::string::npos && parseDouble(value.substr(0, comma), percent)) {
+                        next.sd.valid   = true;
+                        next.sd.percent = percent;
+                    }
+                } else if (tag == "Bf") {
+                    std::uint32_t planner = 0;
+                    std::uint32_t rx      = 0;
+                    if (parseTwoUnsigned(value, planner, rx)) {
+                        next.buffers.valid            = true;
+                        next.buffers.plannerAvailable = planner;
+                        next.buffers.rxAvailable      = rx;
+                    }
+                } else if (tag == "Ln") {
+                    std::uint32_t number = 0;
+                    if (parseUnsigned(value, number)) {
+                        next.lineNumber.valid = true;
+                        next.lineNumber.value = number;
+                    }
+                }
+            }
+
+            synchronizePositions(next, sawMpos, sawWpos, sawWco);
+            next.lastReply.kind    = ReplyKind::Status;
+            next.lastReply.hasCode = false;
+            next.lastReply.code    = 0;
+            next.lastReply.text    = line;
+            next.sequence          = snapshot_.sequence + 1;
+            snapshot_              = next;
+        } else if (startsWithCaseInsensitive(line, "[GC:")) {
+            if (line[line.size() - 1] != ']') {
+                return false;
+            }
+            const std::string body     = line.substr(4, line.size() - 5);
+            std::size_t       position = 0;
+            while (position < body.size()) {
+                while (position < body.size() && std::isspace(static_cast<unsigned char>(body[position]))) {
+                    ++position;
+                }
+                const std::size_t start = position;
+                while (position < body.size() && !std::isspace(static_cast<unsigned char>(body[position]))) {
+                    ++position;
+                }
+                if (position > start) {
+                    applyModalWord(body.substr(start, position - start), snapshot_.modal);
+                }
+            }
+            snapshot_.lastReply.kind    = ReplyKind::Modal;
+            snapshot_.lastReply.hasCode = false;
+            snapshot_.lastReply.code    = 0;
+            snapshot_.lastReply.text    = line;
+            ++snapshot_.sequence;
+        } else if (startsWithCaseInsensitive(line, "[MSG:")) {
+            if (line[line.size() - 1] != ']') {
+                return false;
+            }
+            snapshot_.lastReply.kind    = ReplyKind::Message;
+            snapshot_.lastReply.hasCode = false;
+            snapshot_.lastReply.code    = 0;
+            snapshot_.lastReply.text    = line.substr(5, line.size() - 6);
+            ++snapshot_.sequence;
+        } else if (upper(line) == "OK") {
+            snapshot_.lastReply.kind    = ReplyKind::Ok;
+            snapshot_.lastReply.hasCode = false;
+            snapshot_.lastReply.code    = 0;
+            snapshot_.lastReply.text    = line;
+            ++snapshot_.sequence;
+        } else if (startsWithCaseInsensitive(line, "ERROR:")) {
+            int code                    = 0;
+            snapshot_.lastReply.kind    = ReplyKind::Error;
+            snapshot_.lastReply.hasCode = parseInt(line.substr(6), code);
+            snapshot_.lastReply.code    = snapshot_.lastReply.hasCode ? code : 0;
+            snapshot_.lastReply.text    = line;
+            ++snapshot_.sequence;
+        } else if (startsWithCaseInsensitive(line, "ALARM:")) {
+            int code                    = 0;
+            snapshot_.state             = MachineState::Alarm;
+            snapshot_.rawState          = "Alarm";
+            snapshot_.stateSubstate     = -1;
+            snapshot_.lastReply.kind    = ReplyKind::Alarm;
+            snapshot_.lastReply.hasCode = parseInt(line.substr(6), code);
+            snapshot_.lastReply.code    = snapshot_.lastReply.hasCode ? code : 0;
+            snapshot_.lastReply.text    = line;
+            ++snapshot_.sequence;
+        } else {
+            return false;
+        }
+
+        if (parsedReply != nullptr) {
+            *parsedReply = snapshot_.lastReply;
+        }
+        return true;
+    }
+
+    bool TS35Model::canSendLineCommand(const std::string& command) const {
+        const std::string cleaned = trim(command);
+        if (cleaned.empty() || cleaned.size() > MaxLineCommandLength) {
+            return false;
+        }
+        for (std::size_t i = 0; i < cleaned.size(); ++i) {
+            const unsigned char character = static_cast<unsigned char>(cleaned[i]);
+            if (character < 0x20 || character == 0x7f) {
+                return false;
+            }
+        }
+        return snapshot_.state == MachineState::Idle;
+    }
+
+    bool TS35Model::canSendRealtime(RealtimeAction action) const {
+        switch (action) {
+            case RealtimeAction::FeedHold:
+                return snapshot_.state == MachineState::Cycle || snapshot_.state == MachineState::Jog;
+
+            case RealtimeAction::Resume:
+                return snapshot_.state == MachineState::Hold || snapshot_.state == MachineState::SafetyDoor;
+
+            case RealtimeAction::CancelJog:
+                return snapshot_.state == MachineState::Jog;
+
+            case RealtimeAction::EmergencyReset:
+                switch (snapshot_.state) {
+                    case MachineState::Cycle:
+                    case MachineState::Hold:
+                    case MachineState::Jog:
+                    case MachineState::Alarm:
+                    case MachineState::SafetyDoor:
+                    case MachineState::Check:
+                    case MachineState::Homing:
+                    case MachineState::Sleep:
+                    case MachineState::ConfigAlarm:
+                    case MachineState::Critical:
+                        return true;
+                    default:
+                        return false;
+                }
+        }
+        return false;
+    }
+
+    std::uint8_t TS35Model::realtimeByte(RealtimeAction action) {
+        switch (action) {
+            case RealtimeAction::FeedHold:
+                return static_cast<std::uint8_t>('!');
+            case RealtimeAction::Resume:
+                return static_cast<std::uint8_t>('~');
+            case RealtimeAction::CancelJog:
+                return 0x85;
+            case RealtimeAction::EmergencyReset:
+                return 0x18;
+        }
+        return 0;
+    }
+
+    const char* machineStateName(MachineState state) {
+        switch (state) {
+            case MachineState::Idle:
+                return "Idle";
+            case MachineState::Cycle:
+                return "Cycle";
+            case MachineState::Hold:
+                return "Hold";
+            case MachineState::Jog:
+                return "Jog";
+            case MachineState::Alarm:
+                return "Alarm";
+            case MachineState::SafetyDoor:
+                return "SafetyDoor";
+            case MachineState::Check:
+                return "Check";
+            case MachineState::Homing:
+                return "Homing";
+            case MachineState::Sleep:
+                return "Sleep";
+            case MachineState::ConfigAlarm:
+                return "ConfigAlarm";
+            case MachineState::Critical:
+                return "Critical";
+            case MachineState::Starting:
+                return "Starting";
+            case MachineState::Unknown:
+            default:
+                return "Unknown";
+        }
+    }
+
+    const char* coordinateSystemName(CoordinateSystem coordinateSystem) {
+        switch (coordinateSystem) {
+            case CoordinateSystem::G54:
+                return "G54";
+            case CoordinateSystem::G55:
+                return "G55";
+            case CoordinateSystem::G56:
+                return "G56";
+            case CoordinateSystem::G57:
+                return "G57";
+            case CoordinateSystem::G58:
+                return "G58";
+            case CoordinateSystem::G59:
+                return "G59";
+            case CoordinateSystem::G59_1:
+                return "G59.1";
+            case CoordinateSystem::G59_2:
+                return "G59.2";
+            case CoordinateSystem::G59_3:
+                return "G59.3";
+            case CoordinateSystem::Unknown:
+            default:
+                return "Unknown";
+        }
+    }
+
+}  // namespace ts35

--- a/FluidNC/esp32/TS35Model.h
+++ b/FluidNC/esp32/TS35Model.h
@@ -1,0 +1,229 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Report parsing and command building, kept free of Arduino, ESP-IDF, FreeRTOS
+// and FluidNC dependencies so that the protocol rules stay separate from the
+// panel and from the module wiring.
+namespace ts35 {
+
+    constexpr std::size_t AxisCount = 6;
+
+    enum class Axis : std::uint8_t {
+        X = 0,
+        Y,
+        Z,
+        A,
+        B,
+        C,
+    };
+
+    enum class MachineState : std::uint8_t {
+        Unknown = 0,
+        Idle,
+        Cycle,
+        Hold,
+        Jog,
+        Alarm,
+        SafetyDoor,
+        Check,
+        Homing,
+        Sleep,
+        ConfigAlarm,
+        Critical,
+        Starting,
+    };
+
+    enum class CoordinateSystem : std::uint8_t {
+        Unknown = 0,
+        G54,
+        G55,
+        G56,
+        G57,
+        G58,
+        G59,
+        G59_1,
+        G59_2,
+        G59_3,
+    };
+
+    enum class Units : std::uint8_t {
+        Unknown = 0,
+        Millimeters,
+        Inches,
+    };
+
+    enum class DistanceMode : std::uint8_t {
+        Unknown = 0,
+        Absolute,
+        Incremental,
+    };
+
+    enum class ReplyKind : std::uint8_t {
+        None = 0,
+        Status,
+        Modal,
+        Ok,
+        Error,
+        Alarm,
+        Message,
+    };
+
+    struct AxisValues {
+        std::array<double, AxisCount> value;
+        std::array<bool, AxisCount>   valid;
+
+        AxisValues();
+        bool   has(Axis axis) const;
+        double get(Axis axis) const;
+    };
+
+    struct FeedSpindle {
+        double feed;
+        double spindle;
+        bool   valid;
+
+        FeedSpindle();
+    };
+
+    struct Overrides {
+        std::uint32_t feed;
+        std::uint32_t rapid;
+        std::uint32_t spindle;
+        bool          valid;
+
+        Overrides();
+    };
+
+    // The Pn: field is shown verbatim, so the individual switch letters are not
+    // broken out here.
+    struct PinState {
+        bool        valid;
+        std::string raw;
+
+        PinState();
+    };
+
+    struct SdProgress {
+        bool   valid;
+        double percent;
+
+        SdProgress();
+    };
+
+    struct BufferState {
+        bool          valid;
+        std::uint32_t plannerAvailable;
+        std::uint32_t rxAvailable;
+
+        BufferState();
+    };
+
+    struct LineNumber {
+        bool          valid;
+        std::uint32_t value;
+
+        LineNumber();
+    };
+
+    struct ModalState {
+        CoordinateSystem coordinateSystem;
+        Units            units;
+        DistanceMode     distanceMode;
+
+        ModalState();
+    };
+
+    struct Reply {
+        ReplyKind   kind;
+        bool        hasCode;
+        int         code;
+        std::string text;
+
+        Reply();
+    };
+
+    struct ModelSnapshot {
+        MachineState state;
+        std::string  rawState;
+        int          stateSubstate;
+
+        AxisValues    mpos;
+        AxisValues    wpos;
+        AxisValues    wco;
+        FeedSpindle   fs;
+        Overrides     overrides;
+        PinState      pins;
+        SdProgress    sd;
+        BufferState   buffers;
+        LineNumber    lineNumber;
+        ModalState    modal;
+        Reply         lastReply;
+        std::uint64_t sequence;
+
+        ModelSnapshot();
+    };
+
+    struct AxisMove {
+        Axis   axis;
+        double millimeters;
+
+        AxisMove(Axis axisValue, double millimetersValue);
+    };
+
+    struct CommandBuildResult {
+        bool        ok;
+        std::string command;
+
+        CommandBuildResult();
+    };
+
+    // Produces a line without CR/LF.  P0 means the currently active coordinate
+    // system, so the touchscreen never needs to guess whether G54, G55, etc. is
+    // active.  The selected axes are emitted in deterministic X,Y,Z,A,B,C order.
+    CommandBuildResult buildSetWorkZeroCommand(const std::vector<Axis>& axes);
+
+    // Produces "$J=G91 G21 ... F..." without CR/LF.  Distances and feed are always
+    // expressed in millimeters, independent of the currently active G20/G21 mode.
+    CommandBuildResult buildIncrementalJogCommand(const std::vector<AxisMove>& moves, double feedMmPerMinute);
+
+    enum class RealtimeAction : std::uint8_t {
+        FeedHold = 0,
+        Resume,
+        CancelJog,
+        EmergencyReset,
+    };
+
+    class TS35Model {
+    public:
+        TS35Model();
+
+        const ModelSnapshot& snapshot() const;
+
+        // Parses one complete GRBL/FluidNC line. CR/LF and surrounding whitespace
+        // are accepted. On false, the snapshot and optional parsedReply are left
+        // unchanged.
+        bool parseLine(const std::string& line, Reply* parsedReply = nullptr);
+
+        // Line commands are intentionally gated to Idle. This also rejects empty,
+        // multiline, control-character, and excessively long commands.
+        bool canSendLineCommand(const std::string& command) const;
+
+        // Realtime actions have their own state policy and are never serialized as
+        // line commands. EmergencyReset is explicitly named because Ctrl-X resets
+        // controller execution; it is not the same operation as CancelJog (0x85).
+        bool                canSendRealtime(RealtimeAction action) const;
+        static std::uint8_t realtimeByte(RealtimeAction action);
+
+    private:
+        ModelSnapshot snapshot_;
+    };
+
+    const char* machineStateName(MachineState state);
+    const char* coordinateSystemName(CoordinateSystem coordinateSystem);
+
+}  // namespace ts35

--- a/FluidNC/esp32/TS35Module.cpp
+++ b/FluidNC/esp32/TS35Module.cpp
@@ -1,0 +1,1299 @@
+#include "TS35Module.h"
+
+#include "Configuration/HandlerBase.h"
+#include "Logging.h"
+#include "Machine/MachineConfig.h"
+#include "RealtimeCmd.h"
+#include "Serial.h"
+
+#include <Arduino.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+namespace ts35 {
+
+    namespace {
+
+        constexpr uint32_t ConfirmationWindowMs = 3000;
+        constexpr uint32_t CommandCooldownMs    = 350;
+        constexpr uint32_t RealtimeCooldownMs   = 90;
+
+        // Gap between the soft reset and the $X of the UNLOCK button. A FluidNC soft
+        // reset does not restart the ESP32, but it does discard channel input; sending
+        // the $X together with it would only get it thrown away in the flush.
+        constexpr uint32_t AlarmClearGapMs = 1200;
+
+        const char* alarmHint(int32_t code) {
+            switch (code) {
+                case 1:
+                    return "HARD LIMIT";
+                case 2:
+                    return "SOFT LIMIT";
+                case 3:
+                    return "ABORT DURING MOTION";
+                case 4:
+                case 5:
+                    return "PROBE FAILED";
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                    return "HOMING FAILED";
+                case 10:
+                    return "SPINDLE CONTROL";
+                default:
+                    return "";
+            }
+        }
+
+        // Ladder 0.01 -> 0.1 -> 1 -> 10 -> 100 mm, truncated by jog_step_max_mm. A
+        // jog_step_mm that is not on the ladder lands on the next rung above it.
+        // The step is formatted in four characters so all five rungs are the same
+        // width on screen, which means dropping the leading zero: ".010", not "0.010".
+        void formatJogStep(char* out, size_t length, float step) {
+            if (step < 0.995f) {
+                std::snprintf(out, length, ".%03d", static_cast<int>(step * 1000.0f + 0.5f));
+            } else if (step < 9.995f) {
+                std::snprintf(out, length, "%.2f", static_cast<double>(step));
+            } else if (step < 99.95f) {
+                std::snprintf(out, length, "%.1f", static_cast<double>(step));
+            } else {
+                std::snprintf(out, length, "%4.0f", static_cast<double>(step));
+            }
+        }
+
+        // Speed as a fraction of the configured feed rate rather than in mm/min: the
+        // operator thinks in "slower", not in an absolute number, and the same choice
+        // then applies to both XY and Z, which have different feed rates.
+        int32_t nextJogPercent(int32_t current) {
+            static constexpr int32_t ladder[] = { 10, 25, 50, 80, 100 };
+            for (const int32_t percent : ladder) {
+                if (percent > current) {
+                    return percent;
+                }
+            }
+            return ladder[0];
+        }
+
+        float nextJogStep(float current, float maximum) {
+            static constexpr float ladder[] = { 0.01f, 0.1f, 1.0f, 10.0f, 100.0f };
+            for (const float step : ladder) {
+                if (step > current + 1e-4f && step <= maximum + 1e-4f) {
+                    return step;
+                }
+            }
+            return ladder[0];
+        }
+
+        // The display driver needs native GPIO numbers, but the numbers come from Pin
+        // objects so that a GPIO already taken by a step, dir or limit pin is reported
+        // as a configuration error instead of being driven behind the machine's back.
+        int8_t nativeOutputPin(const Pin& pin) {
+            if (pin.undefined()) {
+                return -1;
+            }
+            return static_cast<int8_t>(pin.getNative(Pin::Capabilities::Output | Pin::Capabilities::Native));
+        }
+
+        void formatAxis(char* output, size_t length, const AxisValues& values, Axis axis) {
+            if (!values.has(axis)) {
+                std::snprintf(output, length, "%11s", "---.---");
+                return;
+            }
+            const double value = values.get(axis);
+            if (std::fabs(value) >= 1000000.0) {
+                std::snprintf(output, length, "%11s", "OVERFLOW");
+                return;
+            }
+            std::snprintf(output, length, "% 11.3f", value);
+        }
+
+    }  // namespace
+
+    void TS35Module::group(Configuration::HandlerBase& handler) {
+        // @config report_interval_ms
+        // @default 200
+        // @tuning typical
+        // How often the module asks the machine for a status report. This is the
+        // channel's own report interval, independent of what other channels use.
+        handler.item("report_interval_ms", _report_interval_ms, 100, 5000);
+
+        // @config render_interval_ms
+        // @default 200
+        // @tuning typical
+        // Lower bound between screen repaints. Only fields whose text actually
+        // changed are redrawn, so raising this costs responsiveness, not bandwidth.
+        handler.item("render_interval_ms", _render_interval_ms, 100, 2000);
+
+        // @config touch_interval_ms
+        // @default 40
+        // @tuning typical
+        // How often the touch controller is sampled. Below about 20 ms the SPI
+        // traffic starts competing with the display writes for the same bus.
+        handler.item("touch_interval_ms", _touch_interval_ms, 20, 500);
+
+        // @config controls_enabled
+        // @default false
+        // @tuning per-machine
+        // Master gate for every control that moves the machine or changes its
+        // coordinates. Leave it false until the touch calibration below has been
+        // verified on the bench: an uncalibrated panel will send taps to the wrong
+        // button.
+        handler.item("controls_enabled", _controls_enabled);
+
+        // @config allow_jog
+        // @default true
+        // @tuning per-machine
+        // Allows the jog buttons, subject to controls_enabled.
+        handler.item("allow_jog", _allow_jog);
+
+        // @config allow_zero
+        // @default true
+        // @tuning per-machine
+        // Allows setting work zero from the screen, subject to controls_enabled.
+        // Zeroing uses G10 L20 P0, so it updates the active coordinate system and
+        // shows up on the other channels at the next report.
+        handler.item("allow_zero", _allow_zero);
+
+        // @config allow_homing
+        // @default false
+        // @tuning per-machine
+        // Allows starting a homing cycle from the screen.
+        handler.item("allow_homing", _allow_homing);
+
+        // @config allow_unlock
+        // @default false
+        // @tuning per-machine
+        // Allows $X from the Control page. Not needed when allow_alarm_clear is
+        // true, which offers the same thing where the alarm is actually shown.
+        handler.item("allow_unlock", _allow_unlock);
+
+        // @config allow_soft_reset
+        // @default false
+        // @tuning per-machine
+        // Allows sending a soft reset from the Control page.
+        handler.item("allow_soft_reset", _allow_soft_reset);
+
+        // @config allow_alarm_clear
+        // @default false
+        // @tuning per-machine
+        // Shows an alarm banner with an unlock button on every page whenever the
+        // machine is in Alarm. The button sends a soft reset and then $X. This is
+        // deliberately independent of controls_enabled, because neither command
+        // produces motion, so a machine can be recovered from an alarm while the
+        // screen is otherwise read-only.
+        handler.item("allow_alarm_clear", _allow_alarm_clear);
+
+        // @config jog_step_mm
+        // @default 0.100
+        // @tuning per-machine
+        // Starting jog increment. The STEP button cycles it through 0.01, 0.1, 1,
+        // 10 and 100 mm, capped as described under jog_step_max_mm; this value only
+        // picks where that ladder starts. The screen's own selection is not written
+        // back here, so $CD still reports what the config file asked for.
+        handler.item("jog_step_mm", _jog_step_mm, 0.001f, 100.0f);
+
+        // @config jog_feed_xy_mm_min
+        // @default 1000.000
+        // @tuning per-machine
+        // Feed rate used for jogs on X and Y.
+        handler.item("jog_feed_xy_mm_min", _jog_feed_xy_mm_min, 1.0f, 100000.0f);
+
+        // @config jog_feed_z_mm_min
+        // @default 500.000
+        // @tuning per-machine
+        // Feed rate used for jogs on Z.
+        handler.item("jog_feed_z_mm_min", _jog_feed_z_mm_min, 1.0f, 100000.0f);
+
+        // @config jog_step_max_mm
+        // @default 10.000
+        // @tuning per-machine
+        // Largest jog increment applied to X and Y. The STEP button cycles the
+        // ladder 0.01, 0.1, 1, 10, 100 mm up to whichever of the two caps is
+        // higher, then wraps back to 0.01.
+        handler.item("jog_step_max_mm", _jog_step_max_mm, 0.01f, 100.0f);
+
+        // @config jog_percent
+        // @default 80
+        // @tuning typical
+        // Starting speed for the jog buttons, as a percentage of the two feed
+        // rates above. The SPEED button cycles it through 10, 25, 50, 80 and 100,
+        // so those feeds are the ceiling rather than the working value; set them to
+        // what the machine can actually sustain and steer from the panel. As with
+        // jog_step_mm, the screen's selection stays out of the saved config.
+        handler.item("jog_percent", _jog_percent, 1, 100);
+
+        // @config jog_step_max_z_mm
+        // @default 10.000
+        // @tuning per-machine
+        // Same, for Z. It is separate because Z usually has an order of magnitude
+        // less travel than X and Y, and with soft_limits off an increment longer
+        // than the travel that is left drives the axis into its hard limit. When
+        // the selected step is above this cap, a Z jog moves this much instead and
+        // the jog page says so.
+        handler.item("jog_step_max_z_mm", _jog_step_max_z_mm, 0.01f, 100.0f);
+
+        // @config touch_x_min
+        // @default 300
+        // @tuning per-machine
+        // Raw ADC reading at the left edge of the panel. Read the raw values from
+        // the Info page while touching the edges and put them here.
+        handler.item("touch_x_min", _touch_x_min, 0, 4095);
+
+        // @config touch_x_max
+        // @default 3600
+        // @tuning per-machine
+        // Raw ADC reading at the right edge of the panel.
+        handler.item("touch_x_max", _touch_x_max, 0, 4095);
+
+        // @config touch_y_min
+        // @default 300
+        // @tuning per-machine
+        // Raw ADC reading at the top edge of the panel.
+        handler.item("touch_y_min", _touch_y_min, 0, 4095);
+
+        // @config touch_y_max
+        // @default 3600
+        // @tuning per-machine
+        // Raw ADC reading at the bottom edge of the panel.
+        handler.item("touch_y_max", _touch_y_max, 0, 4095);
+
+        // @config touch_pressure_threshold
+        // @default 350
+        // @tuning per-machine
+        // Minimum pressure reading for a sample to count as a touch. Raise it if
+        // the screen registers phantom taps, lower it if firm taps are missed.
+        handler.item("touch_pressure_threshold", _touch_pressure_threshold, 0, 4095);
+
+        // @config touch_max_sample_spread
+        // @default 40
+        // @tuning typical
+        // Rejects a reading whose samples disagree by more than this, which is what
+        // a finger sliding off the panel looks like.
+        handler.item("touch_max_sample_spread", _touch_max_sample_spread, 0, 4095);
+
+        // @config touch_samples
+        // @default 5
+        // @tuning typical
+        // Samples per reading, median filtered. Odd values give a true median.
+        handler.item("touch_samples", _touch_samples, 1, 9);
+
+        // @config touch_swap_xy
+        // @default true
+        // @tuning per-machine
+        // Swaps the panel's two axes before mapping them to the screen. Needed when
+        // the resistive panel is wired at ninety degrees to the LCD scan order.
+        handler.item("touch_swap_xy", _touch_swap_xy);
+
+        // @config touch_invert_x
+        // @default true
+        // @tuning per-machine
+        // Mirrors the horizontal axis of the touch panel.
+        handler.item("touch_invert_x", _touch_invert_x);
+
+        // @config touch_invert_y
+        // @default false
+        // @tuning per-machine
+        // Mirrors the vertical axis of the touch panel.
+        handler.item("touch_invert_y", _touch_invert_y);
+
+        // @config lcd_clock_hz
+        // @default 40000000
+        // @tuning typical
+        // SPI clock for the display. Reduce it if a long or poorly seated ribbon
+        // cable produces visible corruption.
+        handler.item("lcd_clock_hz", _lcd_clock_hz, 1000000, 40000000);
+
+        // @config touch_clock_hz
+        // @default 2000000
+        // @tuning typical
+        // SPI clock for the touch controller. The ADS7843/XPT2046 is specified well
+        // below the display's clock and should not be run at the same rate.
+        handler.item("touch_clock_hz", _touch_clock_hz, 100000, 2000000);
+
+        // @config invert_display
+        // @default false
+        // @tuning per-machine
+        // Sends the panel's colour inversion command at startup. Some ST7796 panels
+        // ship inverted relative to the reference module.
+        handler.item("invert_display", _invert_display);
+
+        // @config tft_cs_pin
+        // @default NO_PIN
+        // @tuning per-machine
+        // @pin_attributes output
+        // Chip select for the display controller. Must be a native MCU pin with
+        // output capability; a pin extender cannot keep up with the bus. Required.
+        // The SPI bus itself (sck/mosi/miso) is the machine's shared spi: section,
+        // same as SDCard.
+        handler.item("tft_cs_pin", _tft_cs_pin);
+
+        // @config tft_dc_pin
+        // @default NO_PIN
+        // @tuning per-machine
+        // @pin_attributes output
+        // Data/command line of the display controller. Must be a native MCU pin
+        // with output capability. Required.
+        handler.item("tft_dc_pin", _tft_dc_pin);
+
+        // @config touch_cs_pin
+        // @default NO_PIN
+        // @tuning per-machine
+        // @pin_attributes output
+        // Chip select for the touch controller, which shares the bus with the
+        // display. Must be a native MCU pin with output capability. Required.
+        handler.item("touch_cs_pin", _touch_cs_pin);
+
+        // @config tft_reset_pin
+        // @default NO_PIN
+        // @tuning per-machine
+        // @pin_attributes output
+        // Hardware reset line of the display controller. Optional: leave it out on
+        // a panel whose reset is tied to the board's own reset.
+        handler.item("tft_reset_pin", _tft_reset_pin);
+
+        // @config backlight_pin
+        // @default NO_PIN
+        // @tuning per-machine
+        // @pin_attributes output
+        // Switches the backlight. Optional: leave it out on a panel that is lit
+        // whenever it is powered.
+        handler.item("backlight_pin", _backlight_pin);
+
+        // @config backlight_active_low
+        // @default true
+        // @tuning per-machine
+        // Set when the backlight pin is pulled low to light the panel. Boards differ
+        // here, sometimes within the same model, so this is worth checking on the
+        // bench before assuming the display is dead.
+        handler.item("backlight_active_low", _backlight_active_low);
+    }
+
+    void TS35Module::validate() {
+        if (_touch_x_min >= _touch_x_max || _touch_y_min >= _touch_y_max) {
+            log_error("TS35 touch min must be less than max");
+            _configuration_valid = false;
+        }
+        if ((_touch_samples % 2) == 0) {
+            log_warn("TS35 touch_samples should be odd for median filtering");
+        }
+        // Pin objects claim their GPIO as they are parsed, so a collision with a
+        // step, dir or limit pin is already an error by the time we get here. What
+        // is left to check is that the three mandatory ones were given at all.
+        if (_tft_cs_pin.undefined() || _tft_dc_pin.undefined() || _touch_cs_pin.undefined()) {
+            log_error("TS35 needs tft_cs_pin, tft_dc_pin and touch_cs_pin");
+            _configuration_valid = false;
+        }
+    }
+
+    void TS35Module::afterParse() {
+        // The two jog knobs are edited from the panel, so the running values are
+        // kept apart from the configured ones; $CD then still writes out the config
+        // file's numbers rather than whatever was last selected on screen.
+        _jog_step  = _jog_step_mm;
+        _jog_speed = _jog_percent;
+        if (_controls_enabled) {
+            log_warn("TS35 controls enabled; validate touch calibration before powering motors");
+        }
+    }
+
+    void TS35Module::init() {
+        if (!_configuration_valid) {
+            return;
+        }
+
+        // The panel hangs off the machine's shared SPI bus, which Main.cpp opens
+        // from the spi: section well before any module is initialised.
+        if (config->_spi == nullptr || !config->_spi->defined()) {
+            log_error("TS35 needs an spi: section with sck_pin, miso_pin and mosi_pin");
+            return;
+        }
+
+        TS35DisplayDriver::Config displayConfig;
+        displayConfig.pins.tftCs              = nativeOutputPin(_tft_cs_pin);
+        displayConfig.pins.tftDc              = nativeOutputPin(_tft_dc_pin);
+        displayConfig.pins.tftReset           = nativeOutputPin(_tft_reset_pin);
+        displayConfig.pins.touchCs            = nativeOutputPin(_touch_cs_pin);
+        displayConfig.pins.backlight          = nativeOutputPin(_backlight_pin);
+        displayConfig.touch.xMin              = static_cast<uint16_t>(_touch_x_min);
+        displayConfig.touch.xMax              = static_cast<uint16_t>(_touch_x_max);
+        displayConfig.touch.yMin              = static_cast<uint16_t>(_touch_y_min);
+        displayConfig.touch.yMax              = static_cast<uint16_t>(_touch_y_max);
+        displayConfig.touch.pressureThreshold = static_cast<uint16_t>(_touch_pressure_threshold);
+        displayConfig.touch.maxSampleSpread   = static_cast<uint16_t>(_touch_max_sample_spread);
+        displayConfig.touch.samples           = static_cast<uint8_t>(_touch_samples);
+        displayConfig.touch.swapXY            = _touch_swap_xy;
+        displayConfig.touch.invertX           = _touch_invert_x;
+        displayConfig.touch.invertY           = _touch_invert_y;
+        displayConfig.lcdClockHz              = static_cast<uint32_t>(_lcd_clock_hz);
+        displayConfig.touchClockHz            = static_cast<uint32_t>(_touch_clock_hz);
+        displayConfig.invertDisplay           = _invert_display;
+        displayConfig.backlightActiveLow      = _backlight_active_low;
+
+        _display.setConfig(displayConfig);
+        if (!_display.begin()) {
+            log_error("TS35 display initialization failed");
+            return;
+        }
+
+        _display_ready = true;
+        _display.drawText(132, 116, "FLUIDNC TS35", White, Black, 3);
+        _display.drawText(192, 154, "STARTING", Cyan, Black, 2);
+
+        allChannels.registration(this);
+        _registered = true;
+        setReportInterval(static_cast<uint32_t>(_report_interval_ms));
+
+        log_info("TS35 touchscreen channel, controls " << (_controls_enabled ? "enabled" : "read-only"));
+    }
+
+    void TS35Module::deinit() {
+        if (_registered) {
+            allChannels.deregistration(this);
+            _registered = false;
+        }
+        if (_display_ready) {
+            _display.end();
+            _display_ready = false;
+        }
+    }
+
+    size_t TS35Module::write(uint8_t data) {
+        const char character = static_cast<char>(data);
+        if (character == '\r') {
+            return 1;
+        }
+        if (character == '\n') {
+            if (!_discarding_report && !_report_line.empty()) {
+                Reply reply;
+                if (_model.parseLine(_report_line, &reply)) {
+                    if (reply.kind == ReplyKind::Alarm) {
+                        _last_alarm_code = reply.hasCode ? reply.code : -1;
+                    }
+                    _page_dirty = _page_dirty || reply.kind == ReplyKind::Modal || reply.kind == ReplyKind::Alarm;
+                }
+            }
+            _report_line.clear();
+            _discarding_report = false;
+            return 1;
+        }
+        if (_discarding_report) {
+            return 1;
+        }
+        if (_report_line.size() >= 1024) {
+            _report_line.clear();
+            _discarding_report = true;
+            return 1;
+        }
+        _report_line.push_back(character);
+        return 1;
+    }
+
+    Error TS35Module::pollLine(char* line) {
+        autoReport();
+        if (_display_ready) {
+            const uint32_t now = millis();
+            serviceAlarmClear(now);
+            serviceTouch(now);
+            serviceRender(now);
+        }
+        return Channel::pollLine(line);
+    }
+
+    void TS35Module::serviceTouch(uint32_t now) {
+        if (now - _last_touch_ms < static_cast<uint32_t>(_touch_interval_ms)) {
+            return;
+        }
+        _last_touch_ms = now;
+
+        int16_t    x       = 0;
+        int16_t    y       = 0;
+        const bool pressed = _display.readTouch(x, y);
+
+        if (_page == Page::Info) {
+            uint16_t rawX = 0;
+            uint16_t rawY = 0;
+            uint16_t rawZ = 0;
+            if (_display.readTouchRaw(rawX, rawY, &rawZ)) {
+                _last_touch_raw_x = rawX;
+                _last_touch_raw_y = rawY;
+                _last_touch_z     = rawZ;
+            }
+        }
+
+        if (pressed) {
+            _last_touch_x = x;
+            _last_touch_y = y;
+            if (!_touch_down) {
+                _touch_down    = true;
+                _touch_start_x = x;
+                _touch_start_y = y;
+            }
+            return;
+        }
+
+        if (_touch_down) {
+            _touch_down            = false;
+            const int16_t releaseX = _last_touch_x;
+            const int16_t releaseY = _last_touch_y;
+            if (std::abs(releaseX - _touch_start_x) <= 35 && std::abs(releaseY - _touch_start_y) <= 35) {
+                handleTap(releaseX, releaseY, now);
+            }
+        }
+    }
+
+    void TS35Module::handleTap(int16_t x, int16_t y, uint32_t now) {
+        if (handleAlarmBannerTap(x, y, now)) {
+            return;
+        }
+        if (y >= NavTop) {
+            const int pageIndex = std::max(0, std::min(PageCount - 1, static_cast<int>(x / NavWidth)));
+            if (static_cast<Page>(pageIndex) != _page) {
+                _page         = static_cast<Page>(pageIndex);
+                _layout_dirty = true;
+            }
+            _page_dirty = true;
+            clearConfirmation();
+            return;
+        }
+
+        switch (_page) {
+            case Page::Jog:
+                handleJogTap(x, y, now);
+                break;
+            case Page::Zero:
+                handleZeroTap(x, y, now);
+                break;
+            case Page::Control:
+                handleControlTap(x, y, now);
+                break;
+            case Page::Dro:
+            case Page::Info:
+                break;
+        }
+    }
+
+    bool TS35Module::controlsAvailable(uint32_t now) {
+        if (!_controls_enabled) {
+            setNotice("CONTROLS DISABLED IN YAML", now);
+            return false;
+        }
+        return true;
+    }
+
+    void TS35Module::handleJogTap(int16_t x, int16_t y, uint32_t now) {
+        // Step and speed move nothing, so they stay adjustable even while the
+        // controls are locked: the jog can be set up before it is unlocked.
+        if (hit(x, y, JogStepX, JogActionY, JogStepW, JogActionH)) {
+            _jog_step = nextJogStep(_jog_step, std::max(_jog_step_max_mm, _jog_step_max_z_mm));
+            return;
+        }
+        if (hit(x, y, JogSpeedX, JogActionY, JogSpeedW, JogActionH)) {
+            _jog_speed = nextJogPercent(_jog_speed);
+            return;
+        }
+        if (!controlsAvailable(now) || !_allow_jog) {
+            return;
+        }
+
+        Axis   axis     = Axis::X;
+        double distance = 0.0;
+        double feed     = _jog_feed_xy_mm_min;
+        bool   selected = true;
+
+        if (hit(x, y, JogLeftX, JogRowY[0], JogBtnW, JogBtnH)) {
+            axis     = Axis::X;
+            distance = -_jog_step;
+        } else if (hit(x, y, JogRightX, JogRowY[0], JogBtnW, JogBtnH)) {
+            axis     = Axis::X;
+            distance = _jog_step;
+        } else if (hit(x, y, JogLeftX, JogRowY[1], JogBtnW, JogBtnH)) {
+            axis     = Axis::Y;
+            distance = -_jog_step;
+        } else if (hit(x, y, JogRightX, JogRowY[1], JogBtnW, JogBtnH)) {
+            axis     = Axis::Y;
+            distance = _jog_step;
+        } else if (hit(x, y, JogLeftX, JogRowY[2], JogBtnW, JogBtnH)) {
+            axis     = Axis::Z;
+            distance = -_jog_step;
+            feed     = _jog_feed_z_mm_min;
+        } else if (hit(x, y, JogRightX, JogRowY[2], JogBtnW, JogBtnH)) {
+            axis     = Axis::Z;
+            distance = _jog_step;
+            feed     = _jog_feed_z_mm_min;
+        } else if (hit(x, y, JogCancelX, JogActionY, JogCancelW, JogActionH)) {
+            sendRealtime(TS35Model::realtimeByte(RealtimeAction::CancelJog), now);
+            return;
+        } else {
+            selected = false;
+        }
+
+        if (selected && distance != 0.0) {
+            // The step is shared by all six buttons, but the travel is not. Cap it
+            // by the requested axis; renderJog() shows the effective Z value so the
+            // reduction is never silent.
+            const double cap       = axis == Axis::Z ? _jog_step_max_z_mm : _jog_step_max_mm;
+            const double magnitude = std::min(std::fabs(distance), cap);
+            distance               = distance < 0.0 ? -magnitude : magnitude;
+
+            // The percentage applies to both axes. The floor of 1 avoids a jog with
+            // a zero feed rate, which the firmware would reject.
+            feed = std::max(1.0, feed * static_cast<double>(_jog_speed) / 100.0);
+        }
+
+        if (selected) {
+            std::vector<AxisMove> moves;
+            moves.push_back(AxisMove(axis, distance));
+            const CommandBuildResult command = buildIncrementalJogCommand(moves, feed);
+            if (command.ok) {
+                enqueueLine(command.command, now);
+            }
+        }
+    }
+
+    void TS35Module::handleZeroTap(int16_t x, int16_t y, uint32_t now) {
+        if (!controlsAvailable(now) || !_allow_zero) {
+            return;
+        }
+        if (hit(x, y, ZeroX[0], ZeroY[0], ZeroBtnW, ZeroBtnH)) {
+            requestConfirmation(ConfirmAction::ZeroX, "ZERO X", now);
+        } else if (hit(x, y, ZeroX[1], ZeroY[0], ZeroBtnW, ZeroBtnH)) {
+            requestConfirmation(ConfirmAction::ZeroY, "ZERO Y", now);
+        } else if (hit(x, y, ZeroX[0], ZeroY[1], ZeroBtnW, ZeroBtnH)) {
+            requestConfirmation(ConfirmAction::ZeroZ, "ZERO Z", now);
+        } else if (hit(x, y, ZeroX[1], ZeroY[1], ZeroBtnW, ZeroBtnH)) {
+            requestConfirmation(ConfirmAction::ZeroXYZ, "ZERO XYZ", now);
+        }
+    }
+
+    void TS35Module::handleControlTap(int16_t x, int16_t y, uint32_t now) {
+        if (!controlsAvailable(now)) {
+            return;
+        }
+
+        const ModelSnapshot& snapshot = _model.snapshot();
+        if (hit(x, y, CtrlWideX[0], CtrlTopY, CtrlWideW, CtrlTopH)) {
+            sendRealtime(TS35Model::realtimeByte(RealtimeAction::FeedHold), now);
+        } else if (hit(x, y, CtrlWideX[1], CtrlTopY, CtrlWideW, CtrlTopH)) {
+            sendRealtime(TS35Model::realtimeByte(RealtimeAction::Resume), now);
+        } else if (hit(x, y, CtrlWideX[2], CtrlTopY, CtrlWideW, CtrlTopH)) {
+            sendRealtime(TS35Model::realtimeByte(RealtimeAction::CancelJog), now);
+        } else if (hit(x, y, CtrlOvrX[0], CtrlOvrY, CtrlOvrW, CtrlOvrH)) {
+            sendRealtime(static_cast<uint8_t>(Cmd::FeedOvrCoarseMinus), now);
+        } else if (hit(x, y, CtrlOvrX[1], CtrlOvrY, CtrlOvrW, CtrlOvrH)) {
+            sendRealtime(static_cast<uint8_t>(Cmd::FeedOvrReset), now);
+        } else if (hit(x, y, CtrlOvrX[2], CtrlOvrY, CtrlOvrW, CtrlOvrH)) {
+            sendRealtime(static_cast<uint8_t>(Cmd::FeedOvrCoarsePlus), now);
+        } else if (hit(x, y, CtrlRapidX, CtrlOvrY, CtrlRapidW, CtrlOvrH)) {
+            sendRealtime(static_cast<uint8_t>(Cmd::RapidOvrReset), now);
+        } else if (hit(x, y, CtrlWideX[0], CtrlBotY, CtrlWideW, CtrlBotH) && _allow_homing && snapshot.state == MachineState::Idle) {
+            requestConfirmation(ConfirmAction::Home, "HOME", now);
+        } else if (hit(x, y, CtrlWideX[1], CtrlBotY, CtrlWideW, CtrlBotH) && _allow_unlock && snapshot.state == MachineState::Alarm) {
+            requestConfirmation(ConfirmAction::Unlock, "UNLOCK", now);
+        } else if (hit(x, y, CtrlWideX[2], CtrlBotY, CtrlWideW, CtrlBotH) && _allow_soft_reset) {
+            requestConfirmation(ConfirmAction::SoftReset, "SOFT RESET", now);
+        }
+    }
+
+    void TS35Module::requestConfirmation(ConfirmAction action, const char* label, uint32_t now) {
+        if (_confirm_action == action && static_cast<int32_t>(_confirm_expires_ms - now) > 0) {
+            clearConfirmation();
+            executeConfirmed(action, now);
+            return;
+        }
+        _confirm_action     = action;
+        _confirm_expires_ms = now + ConfirmationWindowMs;
+        std::string prompt("TOUCH AGAIN: ");
+        prompt += label;
+        setNotice(prompt.c_str(), now, ConfirmationWindowMs);
+    }
+
+    void TS35Module::executeConfirmed(ConfirmAction action, uint32_t now) {
+        std::vector<Axis> axes;
+        switch (action) {
+            case ConfirmAction::ZeroX:
+                axes.push_back(Axis::X);
+                break;
+            case ConfirmAction::ZeroY:
+                axes.push_back(Axis::Y);
+                break;
+            case ConfirmAction::ZeroZ:
+                axes.push_back(Axis::Z);
+                break;
+            case ConfirmAction::ZeroXYZ:
+                axes.push_back(Axis::X);
+                axes.push_back(Axis::Y);
+                axes.push_back(Axis::Z);
+                break;
+            case ConfirmAction::Home:
+                enqueueLine("$H", now);
+                return;
+            case ConfirmAction::Unlock:
+                enqueueLine("$X", now, true);
+                return;
+            case ConfirmAction::SoftReset:
+                sendRealtime(TS35Model::realtimeByte(RealtimeAction::EmergencyReset), now);
+                return;
+            case ConfirmAction::None:
+                return;
+        }
+
+        const CommandBuildResult command = buildSetWorkZeroCommand(axes);
+        if (command.ok && enqueueLine(command.command, now)) {
+            setNotice("ZERO SENT; WAITING FOR WCO", now, 3000);
+        }
+    }
+
+    bool TS35Module::enqueueLine(const std::string& command, uint32_t now, bool allowAlarm) {
+        if (!_controls_enabled || now - _last_command_ms < CommandCooldownMs) {
+            return false;
+        }
+        const ModelSnapshot& snapshot = _model.snapshot();
+        if (allowAlarm) {
+            if (command != "$X" || snapshot.state != MachineState::Alarm) {
+                setNotice("COMMAND BLOCKED BY MACHINE STATE", now);
+                return false;
+            }
+        } else if (!_model.canSendLineCommand(command)) {
+            setNotice("COMMAND REQUIRES IDLE", now);
+            return false;
+        }
+        push(command);
+        push(static_cast<uint8_t>('\n'));
+        _last_command_ms = now;
+        setNotice("COMMAND SENT", now);
+        return true;
+    }
+
+    bool TS35Module::sendRealtime(uint8_t command, uint32_t now) {
+        if (!_controls_enabled || now - _last_realtime_ms < RealtimeCooldownMs) {
+            return false;
+        }
+
+        bool allowed = false;
+        if (command >= static_cast<uint8_t>(Cmd::FeedOvrReset) && command <= static_cast<uint8_t>(Cmd::CoolantMistOvrToggle)) {
+            // The override commands apply in any state the controller has reported.
+            allowed = _model.snapshot().state != MachineState::Unknown && _model.snapshot().state != MachineState::Starting;
+        } else if (command == TS35Model::realtimeByte(RealtimeAction::EmergencyReset)) {
+            allowed = _allow_soft_reset && _model.canSendRealtime(RealtimeAction::EmergencyReset);
+        } else {
+            const std::array<RealtimeAction, 3> actions = { RealtimeAction::FeedHold, RealtimeAction::Resume, RealtimeAction::CancelJog };
+            for (const RealtimeAction action : actions) {
+                if (command == TS35Model::realtimeByte(action)) {
+                    allowed = _model.canSendRealtime(action);
+                    break;
+                }
+            }
+        }
+        if (!allowed) {
+            setNotice("CONTROL DOES NOT APPLY IN THIS STATE", now);
+            return false;
+        }
+        push(command);
+        _last_realtime_ms = now;
+        setNotice("REALTIME SENT", now, 1200);
+        return true;
+    }
+
+    void TS35Module::serviceRender(uint32_t now) {
+        bool layoutJustDrawn = false;
+        if (_layout_dirty || _clearing) {
+            if (!_clearing) {
+                beginScreenClear();
+            }
+            clearNextBand();
+            if (_clearing) {
+                return;  // nothing may be drawn on top of a half-wiped screen
+            }
+            renderPageFurniture();
+            _layout_dirty   = false;
+            layoutJustDrawn = true;
+        }
+
+        if (!layoutJustDrawn && !_page_dirty && now - _last_render_ms < static_cast<uint32_t>(_render_interval_ms)) {
+            return;
+        }
+        _page_dirty     = false;
+        _last_render_ms = now;
+
+        renderHeader();
+        if (renderAlarmBanner()) {
+            // The banner is an overlay across the middle of the screen. The page
+            // body and the notice line both draw inside the band it occupies, so
+            // while it is up they are left alone; dropping it repaints the page.
+            return;
+        }
+        switch (_page) {
+            case Page::Dro:
+                renderDro();
+                break;
+            case Page::Jog:
+                renderJog();
+                break;
+            case Page::Zero:
+                renderZero(now);
+                break;
+            case Page::Control:
+                renderControl();
+                break;
+            case Page::Info:
+                renderInfo();
+                break;
+        }
+        renderNotice(now);
+    }
+
+    void TS35Module::beginScreenClear() {
+        _clearing           = true;
+        _clear_y            = 0;
+        _alarm_banner_shown = false;
+        _rendered_header.clear();
+        _rendered_notice.clear();
+        _rendered_alarm.clear();
+        resetPageRenderCache();
+    }
+
+    // Wiping 480x320 at 16 bpp is 307200 bytes on the wire, tens of milliseconds
+    // that pollLine() would spend inside the shared channel polling loop. The wipe
+    // is therefore spread over consecutive polls, one band at a time, and nothing
+    // else is drawn until the last band is done.
+    void TS35Module::clearNextBand() {
+        const int16_t height = std::min<int16_t>(ClearBandHeight, static_cast<int16_t>(ScreenHeight - _clear_y));
+        _display.fillRect(0, _clear_y, ScreenWidth, height, Black);
+        _clear_y = static_cast<int16_t>(_clear_y + height);
+        if (_clear_y >= ScreenHeight) {
+            _clearing = false;
+        }
+    }
+
+    void TS35Module::renderPageFurniture() {
+        for (int page = 0; page < PageCount; ++page) {
+            const bool selected = static_cast<int>(_page) == page;
+            drawButton(page * NavWidth, NavTop, NavWidth, NavHeight, pageName(static_cast<Page>(page)), true, selected);
+        }
+
+        switch (_page) {
+            case Page::Dro:
+                _display.drawText(16, 58, "X", Cyan, Black, 4);
+                _display.drawText(16, 124, "Y", Cyan, Black, 4);
+                _display.drawText(16, 190, "Z", Cyan, Black, 4);
+                break;
+            case Page::Jog: {
+                const bool               jogOk     = _controls_enabled && _allow_jog;
+                static const char* const minus[3]  = { "X -", "Y -", "Z -" };
+                static const char* const plus[3]   = { "X +", "Y +", "Z +" };
+                static const char* const letter[3] = { "X", "Y", "Z" };
+                for (int row = 0; row < 3; ++row) {
+                    drawButton(JogLeftX, JogRowY[row], JogBtnW, JogBtnH, minus[row], jogOk);
+                    drawButton(JogRightX, JogRowY[row], JogBtnW, JogBtnH, plus[row], jogOk);
+                    _display.drawText(JogReadLetterX, JogRowY[row] + 15, letter[row], Cyan, Black, 2);
+                }
+                // CANCEL sits in the middle: it is the button reached for in a
+                // hurry, and the middle is where a thumb lands without aiming.
+                drawButton(JogCancelX, JogActionY, JogCancelW, JogActionH, "CANCEL", jogOk);
+            } break;
+            case Page::Zero: {
+                const bool zeroOk = _controls_enabled && _allow_zero;
+                drawButton(ZeroX[0], ZeroY[0], ZeroBtnW, ZeroBtnH, "ZERO X", zeroOk);
+                drawButton(ZeroX[1], ZeroY[0], ZeroBtnW, ZeroBtnH, "ZERO Y", zeroOk);
+                drawButton(ZeroX[0], ZeroY[1], ZeroBtnW, ZeroBtnH, "ZERO Z", zeroOk);
+                drawButton(ZeroX[1], ZeroY[1], ZeroBtnW, ZeroBtnH, "ZERO XYZ", zeroOk);
+            } break;
+            case Page::Control:
+                drawButton(CtrlWideX[0], CtrlTopY, CtrlWideW, CtrlTopH, "HOLD", _controls_enabled);
+                drawButton(CtrlWideX[1], CtrlTopY, CtrlWideW, CtrlTopH, "RESUME", _controls_enabled);
+                drawButton(CtrlWideX[2], CtrlTopY, CtrlWideW, CtrlTopH, "CANCEL JOG", _controls_enabled);
+                drawButton(CtrlOvrX[0], CtrlOvrY, CtrlOvrW, CtrlOvrH, "F -10", _controls_enabled);
+                drawButton(CtrlOvrX[1], CtrlOvrY, CtrlOvrW, CtrlOvrH, "F 100", _controls_enabled);
+                drawButton(CtrlOvrX[2], CtrlOvrY, CtrlOvrW, CtrlOvrH, "F +10", _controls_enabled);
+                drawButton(CtrlRapidX, CtrlOvrY, CtrlRapidW, CtrlOvrH, "R 100", _controls_enabled);
+                drawButton(CtrlWideX[0], CtrlBotY, CtrlWideW, CtrlBotH, "HOME", _controls_enabled && _allow_homing);
+                drawButton(CtrlWideX[1], CtrlBotY, CtrlWideW, CtrlBotH, "UNLOCK", _controls_enabled && _allow_unlock);
+                drawButton(CtrlWideX[2], CtrlBotY, CtrlWideW, CtrlBotH, "RESET", _controls_enabled && _allow_soft_reset);
+                break;
+            case Page::Info:
+                break;
+        }
+    }
+
+    void TS35Module::renderHeader() {
+        const ModelSnapshot& snapshot = _model.snapshot();
+        const uint16_t       color    = stateColor(snapshot.state);
+        char                 title[48];
+        std::snprintf(title,
+                      sizeof(title),
+                      "FLUIDNC %-12s %-5s",
+                      machineStateName(snapshot.state),
+                      coordinateSystemName(snapshot.modal.coordinateSystem));
+        std::string signature(title);
+        signature += _controls_enabled ? "|CONTROL" : "|READONLY";
+        if (_rendered_header == signature && _rendered_header_color == color) {
+            return;
+        }
+        _rendered_header       = signature;
+        _rendered_header_color = color;
+        _display.fillRect(0, 0, ScreenWidth, 38, color);
+        _display.drawText(10, 10, title, White, color, 2);
+        if (!_controls_enabled) {
+            _display.drawText(378, 10, "READ ONLY", Yellow, color, 1);
+        }
+    }
+
+    void TS35Module::renderDro() {
+        const ModelSnapshot&      snapshot = _model.snapshot();
+        const std::array<Axis, 3> axes     = { Axis::X, Axis::Y, Axis::Z };
+        for (size_t index = 0; index < axes.size(); ++index) {
+            const int16_t y = static_cast<int16_t>(48 + index * 66);
+            char          value[32];
+            formatAxis(value, sizeof(value), snapshot.wpos, axes[index]);
+            drawCachedText(_rendered_axes[index], value, 11, 82, y + 8, White, Black, 5);
+        }
+
+        char         footer[96];
+        const double feed = snapshot.fs.valid ? snapshot.fs.feed : 0.0;
+        const double rpm  = snapshot.fs.valid ? snapshot.fs.spindle : 0.0;
+        std::snprintf(footer,
+                      sizeof(footer),
+                      "WPOS %s   F %.0f   S %.0f   PIN %s",
+                      unitsName(snapshot.modal.units),
+                      feed,
+                      rpm,
+                      snapshot.pins.raw.empty() ? "-" : snapshot.pins.raw.c_str());
+        drawCachedText(_rendered_footer, footer, 77, 10, DroFooterY, LightGray, Black, 1);
+    }
+
+    void TS35Module::renderJog() {
+        const ModelSnapshot& snapshot = _model.snapshot();
+        const bool           jogOk    = _controls_enabled && _allow_jog;
+
+        char value[32];
+        for (int row = 0; row < 3; ++row) {
+            static const Axis axes[3] = { Axis::X, Axis::Y, Axis::Z };
+            formatAxis(value, sizeof(value), snapshot.wpos, axes[row]);
+            drawCachedText(_rendered_axes[row], value, 11, JogReadValueX, JogRowY[row] + 15, White, Black, 2);
+        }
+
+        // These two buttons carry their own value, so they are redrawn when it
+        // changes instead of having a separate text field beside them.
+        char step[16];
+        formatJogStep(step, sizeof(step), _jog_step);
+        char stepLabel[24];
+        std::snprintf(stepLabel, sizeof(stepLabel), "STEP %s", step);
+        if (_rendered_step != stepLabel) {
+            _rendered_step = stepLabel;
+            drawButton(JogStepX, JogActionY, JogStepW, JogActionH, stepLabel, true);
+        }
+
+        char speedLabel[24];
+        std::snprintf(speedLabel, sizeof(speedLabel), "SPEED %ld%%", static_cast<long>(_jog_speed));
+        if (_rendered_speed != speedLabel) {
+            _rendered_speed = speedLabel;
+            drawButton(JogSpeedX, JogActionY, JogSpeedW, JogActionH, speedLabel, jogOk);
+        }
+
+        char zNote[40] = "";
+        if (_jog_step > _jog_step_max_z_mm) {
+            char zStep[16];
+            formatJogStep(zStep, sizeof(zStep), _jog_step_max_z_mm);
+            std::snprintf(zNote, sizeof(zNote), "Z CAPPED AT %s MM", zStep);
+        }
+        drawCachedText(_rendered_step_z, zNote, 24, JogStepX, JogNoteY, Orange, Black, 1);
+    }
+
+    void TS35Module::renderZero(uint32_t now) {
+        const bool confirming = _confirm_action != ConfirmAction::None && static_cast<int32_t>(_confirm_expires_ms - now) > 0;
+        drawCachedText(_rendered_zero_hint,
+                       confirming ? "TOUCH AGAIN TO CONFIRM" : "ZERO USES G10 L20 P0 ON THE ACTIVE WCS",
+                       74,
+                       18,
+                       ZeroHintY,
+                       confirming ? Yellow : LightGray,
+                       Black,
+                       1);
+    }
+
+    void TS35Module::renderControl() {
+        const ModelSnapshot& snapshot = _model.snapshot();
+        char                 overrides[80];
+        if (snapshot.overrides.valid) {
+            std::snprintf(overrides,
+                          sizeof(overrides),
+                          "OVERRIDE  FEED %u%%  RAPID %u%%  SPINDLE %u%%",
+                          static_cast<unsigned>(snapshot.overrides.feed),
+                          static_cast<unsigned>(snapshot.overrides.rapid),
+                          static_cast<unsigned>(snapshot.overrides.spindle));
+        } else {
+            std::snprintf(overrides, sizeof(overrides), "OVERRIDE NOT REPORTED YET");
+        }
+        drawCachedText(_rendered_overrides, overrides, 74, 18, CtrlOverrideY, LightGray, Black, 1);
+    }
+
+    void TS35Module::renderInfo() {
+        const ModelSnapshot& snapshot = _model.snapshot();
+
+        char line[96];
+        std::snprintf(line, sizeof(line), "TOUCH MAP: X %d  Y %d", static_cast<int>(_last_touch_x), static_cast<int>(_last_touch_y));
+        drawCachedText(_rendered_info[0], line, 38, 18, 58, Cyan, Black, 2);
+        std::snprintf(line,
+                      sizeof(line),
+                      "TOUCH RAW: X %u  Y %u  Z %u",
+                      static_cast<unsigned>(_last_touch_raw_x),
+                      static_cast<unsigned>(_last_touch_raw_y),
+                      static_cast<unsigned>(_last_touch_z));
+        drawCachedText(_rendered_info[1], line, 38, 18, 88, White, Black, 2);
+        std::snprintf(line,
+                      sizeof(line),
+                      "CAL X %ld..%ld  Y %ld..%ld",
+                      static_cast<long>(_touch_x_min),
+                      static_cast<long>(_touch_x_max),
+                      static_cast<long>(_touch_y_min),
+                      static_cast<long>(_touch_y_max));
+        drawCachedText(_rendered_info[2], line, 38, 18, 124, LightGray, Black, 2);
+        std::snprintf(line,
+                      sizeof(line),
+                      "MODAL %s  %s  %s",
+                      coordinateSystemName(snapshot.modal.coordinateSystem),
+                      unitsName(snapshot.modal.units),
+                      snapshot.modal.distanceMode == DistanceMode::Absolute ?
+                          "G90" :
+                          (snapshot.modal.distanceMode == DistanceMode::Incremental ? "G91" : "?"));
+        drawCachedText(_rendered_info[3], line, 38, 18, 160, White, Black, 2);
+        std::snprintf(line,
+                      sizeof(line),
+                      "BF %u/%u  LN %u  SD %.1f%%",
+                      static_cast<unsigned>(snapshot.buffers.plannerAvailable),
+                      static_cast<unsigned>(snapshot.buffers.rxAvailable),
+                      static_cast<unsigned>(snapshot.lineNumber.value),
+                      snapshot.sd.valid ? snapshot.sd.percent : 0.0);
+        drawCachedText(_rendered_info[4], line, 38, 18, 196, White, Black, 2);
+        drawCachedText(_rendered_info[5],
+                       _controls_enabled ? "CONTROLS: ENABLED" : "CONTROLS: DISABLED IN YAML",
+                       38,
+                       18,
+                       234,
+                       _controls_enabled ? Green : Yellow,
+                       Black,
+                       2);
+    }
+
+    bool TS35Module::renderAlarmBanner() {
+        const bool active = _allow_alarm_clear && _model.snapshot().state == MachineState::Alarm;
+        if (!active) {
+            if (_alarm_banner_shown) {
+                // The banner covers usable page area, so leaving the alarm means
+                // the whole page has to be repainted.
+                _alarm_banner_shown = false;
+                _alarm_clear        = AlarmClear::None;
+                _last_alarm_code    = -1;
+                _rendered_alarm.clear();
+                _layout_dirty = true;
+                _page_dirty   = true;
+            }
+            return false;
+        }
+
+        char headline[32];
+        if (_last_alarm_code >= 0) {
+            std::snprintf(headline, sizeof(headline), "ALARM %ld", static_cast<long>(_last_alarm_code));
+        } else {
+            std::snprintf(headline, sizeof(headline), "ALARM");
+        }
+
+        const char* detail = "TOUCH UNLOCK TO CLEAR";
+        if (_alarm_clear == AlarmClear::ResetSent) {
+            detail = "RESET SENT; $X FOLLOWS";
+        } else {
+            const char* hint = alarmHint(_last_alarm_code);
+            if (hint[0] != '\0') {
+                detail = hint;
+            }
+        }
+
+        std::string signature(headline);
+        signature += '|';
+        signature += detail;
+        if (_alarm_banner_shown && _rendered_alarm == signature) {
+            return true;
+        }
+
+        if (!_alarm_banner_shown) {
+            _display.fillRect(0, AlarmTop, ScreenWidth, AlarmHeight, Red);
+            _display.drawRect(0, AlarmTop, ScreenWidth, AlarmHeight, White);
+            drawButton(AlarmButtonX, AlarmButtonY, AlarmButtonW, AlarmButtonH, "UNLOCK", true);
+            _alarm_banner_shown = true;
+        }
+        _rendered_alarm = signature;
+        _display.fillRect(8, AlarmTop + 8, AlarmButtonX - 20, 60, Red);
+        _display.drawText(12, AlarmTop + 10, headline, White, Red, 2);
+        _display.drawText(12, AlarmTop + 40, detail, Yellow, Red, 2);
+        return true;
+    }
+
+    void TS35Module::serviceAlarmClear(uint32_t now) {
+        if (_alarm_clear != AlarmClear::ResetSent) {
+            return;
+        }
+        if (static_cast<int32_t>(_alarm_clear_at_ms - now) > 0) {
+            return;
+        }
+        _alarm_clear = AlarmClear::None;
+        if (_model.snapshot().state != MachineState::Alarm) {
+            return;  // the reset alone already cleared it; nothing left to unlock
+        }
+        push(std::string_view("$X\n"));
+        _last_command_ms = now;
+    }
+
+    bool TS35Module::handleAlarmBannerTap(int16_t x, int16_t y, uint32_t now) {
+        if (!_alarm_banner_shown) {
+            return false;
+        }
+        if (y < AlarmTop || y >= AlarmTop + AlarmHeight) {
+            return false;
+        }
+        if (!hit(x, y, AlarmButtonX, AlarmButtonY, AlarmButtonW, AlarmButtonH)) {
+            return true;  // a touch inside the banner must not leak to the page under it
+        }
+        if (_alarm_clear != AlarmClear::None || now - _last_realtime_ms < RealtimeCooldownMs) {
+            return true;
+        }
+        // Soft reset now, $X after AlarmClearGapMs. Neither one moves the machine,
+        // so the sequence does not depend on _controls_enabled.
+        push(TS35Model::realtimeByte(RealtimeAction::EmergencyReset));
+        _last_realtime_ms  = now;
+        _alarm_clear       = AlarmClear::ResetSent;
+        _alarm_clear_at_ms = now + AlarmClearGapMs;
+        return true;
+    }
+
+    void TS35Module::renderNotice(uint32_t now) {
+        if (!_notice.empty() && static_cast<int32_t>(_notice_expires_ms - now) <= 0) {
+            _notice.clear();
+            if (_confirm_action != ConfirmAction::None && static_cast<int32_t>(_confirm_expires_ms - now) <= 0) {
+                clearConfirmation();
+            }
+        }
+        const bool visible = !_notice.empty();
+        drawCachedText(_rendered_notice, visible ? _notice.c_str() : "", 78, 6, NoticeY, visible ? Yellow : Black, visible ? Navy : Black, 1);
+    }
+
+    void TS35Module::drawCachedText(std::string& rendered,
+                                    const char*  text,
+                                    size_t       characters,
+                                    int16_t      x,
+                                    int16_t      y,
+                                    uint16_t     foreground,
+                                    uint16_t     background,
+                                    uint8_t      scale) {
+        std::string field(text == nullptr ? "" : text);
+        if (field.size() > characters) {
+            field.resize(characters);
+        } else if (field.size() < characters) {
+            field.append(characters - field.size(), ' ');
+        }
+        if (rendered == field) {
+            return;
+        }
+        rendered = field;
+        _display.drawText(x, y, rendered.c_str(), foreground, background, scale);
+    }
+
+    void TS35Module::resetPageRenderCache() {
+        for (std::string& axis : _rendered_axes) {
+            axis.clear();
+        }
+        _rendered_footer.clear();
+        _rendered_step.clear();
+        _rendered_step_z.clear();
+        _rendered_speed.clear();
+        _rendered_zero_hint.clear();
+        _rendered_overrides.clear();
+        for (std::string& line : _rendered_info) {
+            line.clear();
+        }
+    }
+
+    void TS35Module::drawButton(int16_t x, int16_t y, int16_t width, int16_t height, const char* label, bool enabled, bool selected) {
+        const uint16_t fill = selected ? Blue : (enabled ? DarkGray : Black);
+        const uint16_t edge = selected ? Cyan : (enabled ? LightGray : DarkGray);
+        const uint16_t text = enabled ? White : LightGray;
+        _display.fillRect(x + 1, y + 1, width - 2, height - 2, fill);
+        _display.drawRect(x, y, width, height, edge);
+        const int16_t textWidth = static_cast<int16_t>(std::strlen(label) * 12);
+        const int16_t textX     = std::max<int16_t>(x + 5, x + (width - textWidth) / 2);
+        const int16_t textY     = y + (height - 14) / 2;
+        _display.drawText(textX, textY, label, text, fill, 2);
+    }
+
+    void TS35Module::setNotice(const char* text, uint32_t now, uint32_t durationMs) {
+        _notice            = text;
+        _notice_expires_ms = now + durationMs;
+    }
+
+    void TS35Module::clearConfirmation() {
+        _confirm_action     = ConfirmAction::None;
+        _confirm_expires_ms = 0;
+    }
+
+    bool TS35Module::hit(int16_t x, int16_t y, int16_t left, int16_t top, int16_t width, int16_t height) {
+        return x >= left && x < left + width && y >= top && y < top + height;
+    }
+
+    uint16_t TS35Module::stateColor(MachineState state) {
+        switch (state) {
+            case MachineState::Idle:
+                return DarkGreen;
+            case MachineState::Cycle:
+            case MachineState::Jog:
+            case MachineState::Homing:
+                return Blue;
+            case MachineState::Hold:
+            case MachineState::SafetyDoor:
+                return Orange;
+            case MachineState::Alarm:
+            case MachineState::ConfigAlarm:
+            case MachineState::Critical:
+                return Red;
+            default:
+                return DarkGray;
+        }
+    }
+
+    const char* TS35Module::pageName(Page page) {
+        switch (page) {
+            case Page::Dro:
+                return "DRO";
+            case Page::Jog:
+                return "JOG";
+            case Page::Zero:
+                return "ZERO";
+            case Page::Control:
+                return "CTRL";
+            case Page::Info:
+                return "INFO";
+        }
+        return "?";
+    }
+
+    const char* TS35Module::unitsName(Units units) {
+        switch (units) {
+            case Units::Millimeters:
+                return "MM";
+            case Units::Inches:
+                return "IN";
+            default:
+                return "?";
+        }
+    }
+
+    namespace {
+        ConfigurableModuleFactory::InstanceBuilder<TS35Module> registration("ts35");
+    }
+
+}  // namespace ts35

--- a/FluidNC/esp32/TS35Module.h
+++ b/FluidNC/esp32/TS35Module.h
@@ -1,0 +1,269 @@
+#pragma once
+
+#include "Channel.h"
+#include "Module.h"
+#include "Pin.h"
+#include "TS35DisplayDriver.h"
+#include "TS35Model.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace ts35 {
+
+    class TS35Module : public Channel, public ConfigurableModule {
+    public:
+        explicit TS35Module(const char* name) : Channel(name), ConfigurableModule(name) {}
+
+        TS35Module(const TS35Module&)            = delete;
+        TS35Module(TS35Module&&)                 = delete;
+        TS35Module& operator=(const TS35Module&) = delete;
+        TS35Module& operator=(TS35Module&&)      = delete;
+
+        void init() override;
+        void deinit() override;
+
+        size_t write(uint8_t data) override;
+        Error  pollLine(char* line) override;
+
+        // The command is metadata only; it never starts, pauses, or modifies a job.
+
+        void validate() override;
+        void afterParse() override;
+        void group(Configuration::HandlerBase& handler) override;
+
+    private:
+        enum class Page : uint8_t { Dro = 0, Jog, Zero, Control, Info };
+        static constexpr int PageCount = 5;
+        enum class AlarmClear : uint8_t { None = 0, ResetSent };
+        enum class ConfirmAction : uint8_t { None = 0, ZeroX, ZeroY, ZeroZ, ZeroXYZ, Home, Unlock, SoftReset };
+
+        static constexpr int16_t ScreenWidth  = 480;
+        static constexpr int16_t ScreenHeight = 320;
+        static constexpr int16_t NavTop       = 280;
+        static constexpr int16_t NavHeight    = 40;
+        static constexpr int16_t NavWidth     = ScreenWidth / PageCount;
+
+        // One slice of a full-screen wipe, see clearNextBand().
+        static constexpr int16_t ClearBandHeight = 32;
+
+        // The strip between the page body and the tab bar belongs to the notice
+        // line alone, so nothing else may be placed on those rows.
+        static constexpr int16_t NoticeY = 268;
+
+        // Jog page. The left and right columns are the axis buttons, the middle is
+        // the readout, and the strip along the bottom holds the three actions.
+        static constexpr int16_t JogBtnW        = 125;
+        static constexpr int16_t JogBtnH        = 44;
+        static constexpr int16_t JogLeftX       = 18;
+        static constexpr int16_t JogRightX      = 337;
+        static constexpr int16_t JogRowY[3]     = { 52, 104, 156 };
+        static constexpr int16_t JogReadLetterX = 150;
+        static constexpr int16_t JogReadValueX  = 172;
+        static constexpr int16_t JogActionY     = 208;
+        static constexpr int16_t JogActionH     = 46;
+        static constexpr int16_t JogStepX       = 12;
+        static constexpr int16_t JogStepW       = 148;
+        static constexpr int16_t JogCancelX     = 166;
+        static constexpr int16_t JogCancelW     = 148;
+        static constexpr int16_t JogSpeedX      = 320;
+        static constexpr int16_t JogSpeedW      = 142;
+        static constexpr int16_t JogNoteY       = 256;
+
+        // DRO page.
+        static constexpr int16_t DroFooterY = 247;
+
+        // Zero page: two columns of two buttons, plus the hint line under them.
+        static constexpr int16_t ZeroBtnW  = 205;
+        static constexpr int16_t ZeroBtnH  = 72;
+        static constexpr int16_t ZeroX[2]  = { 20, 255 };
+        static constexpr int16_t ZeroY[2]  = { 62, 156 };
+        static constexpr int16_t ZeroHintY = 245;
+
+        // Control page: three wide buttons, a row of override buttons, then three
+        // more wide buttons.
+        static constexpr int16_t CtrlTopY      = 58;
+        static constexpr int16_t CtrlTopH      = 54;
+        static constexpr int16_t CtrlOvrY      = 142;
+        static constexpr int16_t CtrlOvrH      = 45;
+        static constexpr int16_t CtrlBotY      = 211;
+        static constexpr int16_t CtrlBotH      = 43;
+        static constexpr int16_t CtrlWideW     = 135;
+        static constexpr int16_t CtrlWideX[3]  = { 18, 172, 326 };
+        static constexpr int16_t CtrlOvrW      = 100;
+        static constexpr int16_t CtrlOvrX[3]   = { 18, 135, 252 };
+        static constexpr int16_t CtrlRapidX    = 369;
+        static constexpr int16_t CtrlRapidW    = 92;
+        static constexpr int16_t CtrlOverrideY = 124;
+
+        // Alarm banner: the band just above the tab bar, drawn on any page.
+        static constexpr int16_t AlarmTop     = 192;
+        static constexpr int16_t AlarmHeight  = 84;
+        static constexpr int16_t AlarmButtonX = 300;
+        static constexpr int16_t AlarmButtonY = 218;
+        static constexpr int16_t AlarmButtonW = 170;
+        static constexpr int16_t AlarmButtonH = 48;
+
+        static constexpr uint16_t Black     = 0x0000;
+        static constexpr uint16_t White     = 0xffff;
+        static constexpr uint16_t Red       = 0xf800;
+        static constexpr uint16_t Green     = 0x07e0;
+        static constexpr uint16_t DarkGreen = 0x03e0;
+        static constexpr uint16_t Blue      = 0x001f;
+        static constexpr uint16_t Yellow    = 0xffe0;
+        static constexpr uint16_t Cyan      = 0x07ff;
+        static constexpr uint16_t DarkGray  = 0x4208;
+        static constexpr uint16_t LightGray = 0x9cd3;
+        static constexpr uint16_t Navy      = 0x000f;
+        static constexpr uint16_t Orange    = 0xfd20;
+
+        // Configuration.
+        int32_t _report_interval_ms = 200;
+        int32_t _render_interval_ms = 200;
+        int32_t _touch_interval_ms  = 40;
+
+        bool _controls_enabled = false;
+        bool _allow_jog        = true;
+        bool _allow_zero       = true;
+        bool _allow_homing     = false;
+        bool _allow_unlock     = false;
+        bool _allow_soft_reset = false;
+        // Independent of _controls_enabled: neither the soft reset nor the $X moves
+        // the machine.
+        bool _allow_alarm_clear = false;
+
+        float   _jog_step_mm        = 0.1f;
+        float   _jog_feed_xy_mm_min = 1000.0f;
+        float   _jog_feed_z_mm_min  = 500.0f;
+        int32_t _jog_percent        = 80;
+        float   _jog_step_max_mm    = 10.0f;
+        float   _jog_step_max_z_mm  = 10.0f;
+
+        int32_t _touch_x_min              = 300;
+        int32_t _touch_x_max              = 3600;
+        int32_t _touch_y_min              = 300;
+        int32_t _touch_y_max              = 3600;
+        int32_t _touch_pressure_threshold = 350;
+        int32_t _touch_max_sample_spread  = 40;
+        int32_t _touch_samples            = 5;
+        bool    _touch_swap_xy            = true;
+        bool    _touch_invert_x           = true;
+        bool    _touch_invert_y           = false;
+
+        int32_t _lcd_clock_hz   = 40000000;
+        int32_t _touch_clock_hz = 2000000;
+        bool    _invert_display = false;
+
+        // Chip selects, data/command and the two optional lines. The bus behind
+        // them is the machine's shared spi: section, opened by Machine::SPIBus.
+        Pin  _tft_cs_pin;
+        Pin  _tft_dc_pin;
+        Pin  _tft_reset_pin;
+        Pin  _touch_cs_pin;
+        Pin  _backlight_pin;
+        bool _backlight_active_low = true;
+
+        bool _configuration_valid = true;
+        bool _registered          = false;
+        bool _display_ready       = false;
+
+        TS35DisplayDriver _display;
+        TS35Model         _model;
+        std::string       _report_line;
+        bool              _discarding_report = false;
+
+        // Selected on the panel, seeded from _jog_step_mm and _jog_percent. Kept
+        // apart from those so that $CD does not save the screen's current pick.
+        float   _jog_step  = 0.1f;
+        int32_t _jog_speed = 80;
+
+        Page     _page           = Page::Dro;
+        bool     _page_dirty     = true;
+        bool     _layout_dirty   = true;
+        bool     _clearing       = false;
+        int16_t  _clear_y        = 0;
+        uint32_t _last_render_ms = 0;
+        uint32_t _last_touch_ms  = 0;
+
+        std::string                _rendered_header;
+        uint16_t                   _rendered_header_color = White;
+        std::array<std::string, 3> _rendered_axes;
+        std::string                _rendered_footer;
+        std::string                _rendered_step;
+        std::string                _rendered_step_z;
+        std::string                _rendered_speed;
+        std::string                _rendered_zero_hint;
+        std::string                _rendered_overrides;
+        std::array<std::string, 6> _rendered_info;
+        std::string                _rendered_notice;
+        std::string                _rendered_alarm;
+
+        bool     _touch_down       = false;
+        int16_t  _touch_start_x    = 0;
+        int16_t  _touch_start_y    = 0;
+        int16_t  _last_touch_x     = -1;
+        int16_t  _last_touch_y     = -1;
+        uint16_t _last_touch_raw_x = 0;
+        uint16_t _last_touch_raw_y = 0;
+        uint16_t _last_touch_z     = 0;
+
+        AlarmClear _alarm_clear        = AlarmClear::None;
+        uint32_t   _alarm_clear_at_ms  = 0;
+        bool       _alarm_banner_shown = false;
+        int32_t    _last_alarm_code    = -1;
+
+        ConfirmAction _confirm_action     = ConfirmAction::None;
+        uint32_t      _confirm_expires_ms = 0;
+        std::string   _notice;
+        uint32_t      _notice_expires_ms = 0;
+        uint32_t      _last_command_ms   = 0;
+        uint32_t      _last_realtime_ms  = 0;
+
+        void serviceTouch(uint32_t now);
+        void serviceRender(uint32_t now);
+        void handleTap(int16_t x, int16_t y, uint32_t now);
+        void handleJogTap(int16_t x, int16_t y, uint32_t now);
+        void handleZeroTap(int16_t x, int16_t y, uint32_t now);
+        void handleControlTap(int16_t x, int16_t y, uint32_t now);
+
+        void beginScreenClear();
+        void clearNextBand();
+        void renderPageFurniture();
+        void renderHeader();
+        void renderDro();
+        void renderJog();
+        void renderZero(uint32_t now);
+        void renderControl();
+        void renderInfo();
+        void renderNotice(uint32_t now);
+        bool renderAlarmBanner();
+        void serviceAlarmClear(uint32_t now);
+        bool handleAlarmBannerTap(int16_t x, int16_t y, uint32_t now);
+        void drawButton(int16_t x, int16_t y, int16_t width, int16_t height, const char* label, bool enabled, bool selected = false);
+        void drawCachedText(std::string& rendered,
+                            const char*  text,
+                            size_t       characters,
+                            int16_t      x,
+                            int16_t      y,
+                            uint16_t     foreground,
+                            uint16_t     background,
+                            uint8_t      scale);
+        void resetPageRenderCache();
+
+        bool controlsAvailable(uint32_t now);
+        bool enqueueLine(const std::string& command, uint32_t now, bool allowAlarm = false);
+        bool sendRealtime(uint8_t command, uint32_t now);
+        void requestConfirmation(ConfirmAction action, const char* label, uint32_t now);
+        void executeConfirmed(ConfirmAction action, uint32_t now);
+        void setNotice(const char* text, uint32_t now, uint32_t durationMs = 2500);
+        void clearConfirmation();
+
+        static bool        hit(int16_t x, int16_t y, int16_t left, int16_t top, int16_t width, int16_t height);
+        static uint16_t    stateColor(MachineState state);
+        static const char* pageName(Page page);
+        static const char* unitsName(Units units);
+    };
+
+}  // namespace ts35

--- a/tools/build_config_docs.py
+++ b/tools/build_config_docs.py
@@ -46,6 +46,12 @@ SECTIONS = [
         "Lives under FluidNC/esp32/ (an ESP32-specific module), not FluidNC/src/ like every "
         "other section here -- the relative path above deliberately escapes SRC to reach it.",
     ),
+    (
+        "ts35",
+        [("../esp32/TS35Module.cpp", "TS35Module")],
+        "Lives under FluidNC/esp32/ for the same reason as oled just above -- the relative "
+        "path deliberately escapes SRC to reach it.",
+    ),
     ("atc_manual", [("ToolChangers/atc_manual.h", "Manual_ATC")], None),
     (
         "extenders.pinextenderN.<i2c_chip>",


### PR DESCRIPTION
## Hardware

An **MKS TS35-R V2.0**: a 3.5" 480x320 TFT with an ST7796 controller and an ADS7843E resistive touch controller, both on one SPI bus behind separate chip selects. The panel has no processor of its own. It plugs into the EXP1/EXP2 headers of an **MKS DLC32 V2.1 (ESP32-D0WD)**.

**That is the only combination this has run on.** No other board, no other panel, no ESP32-S3. The ST7796 init sequence comes from the public MKS/TFT_eSPI sources for this panel; other ST7796 modules may well need different gamma or inversion settings, and I have no way to check.

## How it fits

It is a `Channel`, like the OLED for output and like the UART pendant and the ESP-NOW remote for input — the shape the config docs already describe when they talk about a display/pendant that reads reports and sends commands back.

## Pages

A tab bar along the bottom switches between five pages. The header shows the machine state, coloured by state, plus the active WCS and a READ ONLY marker when the controls are off. A one-line notice strip above the tab bar carries transient messages.

- **DRO** — X/Y/Z work position in large digits, and a footer with units, feed, spindle RPM and the raw `Pn:` field.
- **JOG** — six axis buttons (X/Y/Z, minus and plus), the live position between them, and a bottom row of STEP / CANCEL / SPEED. STEP cycles 0.01 → 0.1 → 1 → 10 → 100 mm, truncated by `jog_step_max_mm`; SPEED cycles 10/25/50/80/100 % of the configured jog feeds. Z has its own cap (`jog_step_max_z_mm`) and the page says `Z CAPPED AT ... MM` when the selected step is larger than it. Jogs go out as `$J=G91 G21 ...`, always in millimetres regardless of the active G20/G21. CANCEL sends jog cancel (0x85), and sits in the middle of the row because it is the button reached for in a hurry.
- **ZERO** — ZERO X / Y / Z / XYZ, sent as `G10 L20 P0`, so it lands on the active coordinate system and shows up on the other channels at the next report.
- **CONTROL** — HOLD, RESUME, CANCEL JOG; a row of feed and rapid overrides (F-10, F100, F+10, R100), which change a cut that is already running; and HOME, UNLOCK, RESET. The page also displays the override percentages the controller reports.
- **INFO** — mapped and raw touch coordinates, the calibration currently in effect, the modal state, buffer/line/SD counters, and whether the controls are enabled. This is the page used to calibrate the panel.

An alarm banner appears over the middle of any page while the machine is in Alarm, showing the alarm number, a short hint for the common codes, and an UNLOCK button that sends a soft reset and then `$X`.

## Safety gating

`controls_enabled` is false by default and gates everything that moves the machine, because an uncalibrated resistive panel puts taps on the wrong button. Under it are six `allow_*` items: `allow_jog` and `allow_zero` default true; `allow_homing`, `allow_unlock` and `allow_soft_reset` default false. `allow_alarm_clear` is deliberately independent of `controls_enabled`, since neither the soft reset nor the `$X` produces motion, so a machine can be recovered from an alarm while the screen is otherwise read-only.

Zero, home, unlock and soft reset each need a second tap inside a three-second window; the notice line reads `TOUCH AGAIN: ...` while it waits.

## Integration details

- The panel uses the machine's shared `spi:` bus. `Machine::SPIBus` opens it long before modules are initialised; the module adds an LCD device and a touch device to that bus and logs an error and stops if there is no `spi:` section.
- The five GPIOs are `Pin` objects defaulting to `NO_PIN`, so a collision with a step, dir or limit pin is reported as a configuration error instead of being driven quietly.
- A full-screen wipe is spread over consecutive polls, one 32-row band at a time, so switching pages does not hold the shared channel polling loop for the length of a 307200-byte transfer.
- `docs/config_items.yaml` is regenerated for the 35 new items, and `tools/build_config_docs.py` gets the matching `ts35` entry in its `SECTIONS` table. `--fail-on-drift` passes.

## Minimum config

The pin numbers below are **an example** — they are the DLC32 V2.1 EXP1/EXP2 wiring. On any other board they will be different.

```yaml
spi:
  miso_pin: gpio.19
  mosi_pin: gpio.23
  sck_pin: gpio.18

ts35:
  tft_cs_pin: gpio.25
  tft_dc_pin: gpio.33
  touch_cs_pin: gpio.26
  tft_reset_pin: gpio.27
  backlight_pin: gpio.5
  controls_enabled: true
```

`tft_reset_pin` and `backlight_pin` are optional. `backlight_active_low` defaults to true, which is right for this panel; MKS sources disagree across revisions, so it is a setting rather than a constant.

Bring it up with `controls_enabled` left at its default first, read the raw touch values off the INFO page while touching the panel edges, put them in `touch_x_min` / `touch_x_max` / `touch_y_min` / `touch_y_max`, and only then turn the controls on.

## What is not here

- **No automated tests.** There is no harness in the repo for a display module: `[tests_common].build_src_filter` lists files under `FluidNC/src` one by one, and nothing under `FluidNC/esp32` is in it. `TS35Model` is deliberately free of Arduino, ESP-IDF and FluidNC dependencies, so it is the piece that could be tested on a host, but wiring that up is a separate change and I have not made it.
- **No board other than the DLC32 V2.1 tested**, and no panel other than the TS35-R V2.0. Nothing excludes the files from the ESP32-S3 build, but I have not run it there.
- On the ESP32 an SPI host has three device slots. The SD card takes one and this takes two, so those three are used up on a board that has both.
- Screen geometry is fixed at 480x320, which is what this module is.

## Out of scope

Two things running on my machine were left out of this PR: a page that runs a job from the screen, including probe routines, and a buzzer driven from the same panel header. Both are further from the "display and pendant" job than the rest, so they are not here. If either is of interest they can come as separate PRs.