### PR TITLE
Run informational commands during a job: two-task command dispatch

### DIFF
--- a/FluidNC/src/Channel.cpp
+++ b/FluidNC/src/Channel.cpp
@@ -127,8 +127,13 @@ void Channel::queue_push(uint8_t byte) {
             _queue_at_line_start = true;
         }
     } else if (_queue_at_line_start && _queue.size() >= _queue_limit) {
-        _queue_discarding      = true;
-        _queue_at_line_start   = false;
+        // No room for another line.  A newline here is an empty line - drop it
+        // and stay at a line boundary so the next line gets a fresh check;
+        // otherwise discard the whole incoming line through its newline.
+        if (!is_newline) {
+            _queue_discarding    = true;
+            _queue_at_line_start = false;
+        }
         log_now                = !_queue_overflow_logged;
         _queue_overflow_logged = true;
     } else {

--- a/FluidNC/src/Channel.cpp
+++ b/FluidNC/src/Channel.cpp
@@ -106,7 +106,40 @@ void Channel::flushRx() {
     while (_queue.size()) {
         _queue.pop();
     }
+    _queue_at_line_start   = true;
+    _queue_discarding      = false;
+    _queue_overflow_logged = false;
     xSemaphoreGive(_queue_mutex);
+}
+
+// Enqueue one non-realtime byte.  Drop policy is whole-line: if a new line
+// starts while _queue is already at _queue_limit, the whole line is discarded
+// through its newline.  A line already in progress finishes, so _queue never
+// holds a partial line.  Worst-case size is _queue_limit + one maxLine line.
+void Channel::queue_push(uint8_t byte) {
+    bool is_newline = byte == '\n' || byte == '\r';
+    bool log_now    = false;
+
+    xSemaphoreTake(_queue_mutex, portMAX_DELAY);
+    if (_queue_discarding) {
+        if (is_newline) {
+            _queue_discarding    = false;  // over-limit line consumed; re-check at the next one
+            _queue_at_line_start = true;
+        }
+    } else if (_queue_at_line_start && _queue.size() >= _queue_limit) {
+        _queue_discarding      = true;
+        _queue_at_line_start   = false;
+        log_now                = !_queue_overflow_logged;
+        _queue_overflow_logged = true;
+    } else {
+        _queue.push(byte);
+        _queue_at_line_start = is_newline;
+    }
+    xSemaphoreGive(_queue_mutex);
+
+    if (log_now) {
+        log_debug("Input queue full on " << _name << "; dropping lines");
+    }
 }
 
 size_t Channel::queued_bytes() const {
@@ -124,6 +157,12 @@ bool Channel::try_pop_queued_byte(uint8_t& byte) {
     }
     byte = _queue.front();
     _queue.pop();
+    if (_queue.empty()) {
+        // Fully drained: reset framing state and re-arm the overflow warning.
+        _queue_at_line_start   = true;
+        _queue_discarding      = false;
+        _queue_overflow_logged = false;
+    }
     xSemaphoreGive(_queue_mutex);
     return true;
 }
@@ -297,9 +336,7 @@ void Channel::push(uint8_t byte) {
     if (is_realtime_command(byte)) {
         handleRealtimeCharacter(byte);
     } else {
-        xSemaphoreTake(_queue_mutex, portMAX_DELAY);
-        _queue.push(byte);
-        xSemaphoreGive(_queue_mutex);
+        queue_push(byte);
     }
 }
 static int  _cnt = 10;
@@ -328,9 +365,7 @@ Error       Channel::pollLine(char* line) {
             continue;
         }
         if (!line) {
-            xSemaphoreTake(_queue_mutex, portMAX_DELAY);
-            _queue.push(ch);
-            xSemaphoreGive(_queue_mutex);
+            queue_push((uint8_t)ch);
             continue;
         }
         // Fall through if line is non-null and it is not a realtime character

--- a/FluidNC/src/Channel.h
+++ b/FluidNC/src/Channel.h
@@ -61,6 +61,21 @@ protected:
     mutable SemaphoreHandle_t _queue_mutex = xSemaphoreCreateMutex();
     std::queue<uint8_t>       _queue;
 
+    // _queue holds non-realtime input bytes seen by pollLine(nullptr) until a
+    // pollLine(line) call consumes them.  A channel that is polled for realtime
+    // characters but never for lines - e.g. any non-job channel while a job is
+    // running - would otherwise grow _queue without bound.  Bound it at a few
+    // lines of slack (~4).  When a new line arrives with the queue already at
+    // the bound, that whole line is discarded through its newline; a line
+    // already in progress is allowed to finish, so the queue never holds a
+    // partial line.  State below is touched only under _queue_mutex.
+    static constexpr size_t _queue_limit        = 4 * maxLine;
+    bool                    _queue_at_line_start = true;   // last queued byte ended a line (or queue empty)
+    bool                    _queue_discarding    = false;  // dropping the rest of an over-limit line
+    bool                    _queue_overflow_logged = false;  // one debug line per overflow episode
+    // Enqueue one non-realtime input byte, applying the whole-line drop policy.
+    void queue_push(uint8_t byte);
+
     uint32_t _reportInterval = 0;
     int32_t  _nextReportTime = 0;
 

--- a/FluidNC/src/Error.cpp
+++ b/FluidNC/src/Error.cpp
@@ -70,6 +70,7 @@ const std::map<Error, const char*> ErrorNames = {
     { Error::Eof, "End of file" },
     { Error::Reset, "System Reset" },
     { Error::NoData, "No Data" },
+    { Error::Deferred, "Deferred" },
     { Error::AnotherInterfaceBusy, "Another interface is busy" },
     { Error::BadPinSpecification, "Bad Pin Specification" },
     { Error::BadRuntimeConfigSetting, "Bad Runtime Config Setting" },

--- a/FluidNC/src/Error.h
+++ b/FluidNC/src/Error.h
@@ -75,6 +75,7 @@ enum class Error : uint8_t {
     Eof                          = 112,  // Not necessarily an error
     Reset                        = 113,
     NoData                       = 114,  // Not necessarily an error
+    Deferred                     = 115,  // Internal: handed to cmd_queue, ack comes later
     AnotherInterfaceBusy         = 120,
     JogCancelled                 = 130,
     BadPinSpecification          = 150,

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -211,8 +211,8 @@ void collapseGCode(char* line) {
         // where the sequence of lines is potentially never-ending.  A sender that handles
         // files on the host system could apply the % semantics.
 
-        if (Job::active()) {
-            Job::channel()->percent();
+        if (Channel* jc = Job::channel()) {
+            jc->percent();
         }
         // Do not pass the % to the GCode interpreter
         *line = '\0';
@@ -1950,8 +1950,8 @@ Error gc_execute_line(const char* input_line) {
         case ProgramFlow::CompletedM30:
             protocol_buffer_synchronize();  // Sync and finish all remaining buffered motions before moving on.
 
-            if (Job::active()) {
-                Job::channel()->end();
+            if (Channel* jc = Job::channel()) {
+                jc->end();
             }
             // Upon program complete, only a subset of g-codes reset to certain defaults, according to
             // LinuxCNC's program end descriptions and testing. Only modal groups [G-code 1,2,3,5,7,12]

--- a/FluidNC/src/Job.cpp
+++ b/FluidNC/src/Job.cpp
@@ -4,16 +4,45 @@
 #include "Job.h"
 #include <map>
 #include <vector>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 std::vector<JobSource*> job;
 
 Channel* Job::leader = nullptr;
 
+// Guards `job` and `leader`.  See the note in Job.h.
+static SemaphoreHandle_t s_job_mutex = xSemaphoreCreateMutex();
+
+namespace {
+    struct JobLock {
+        JobLock() { xSemaphoreTake(s_job_mutex, portMAX_DELAY); }
+        ~JobLock() { xSemaphoreGive(s_job_mutex); }
+    };
+
+    // Unlocked internals; the caller holds s_job_mutex.
+    bool active_nl() {
+        return !job.empty();
+    }
+    void save_nl() {
+        if (active_nl()) {
+            job.back()->save();
+        }
+    }
+    void restore_nl() {
+        if (active_nl()) {
+            job.back()->restore();
+        }
+    }
+}
+
 bool Job::active() {
-    return !job.empty();
+    JobLock lock;
+    return active_nl();
 }
 
 JobSource* Job::source() {
+    JobLock lock;
     return job.empty() ? nullptr : job.back();
 }
 
@@ -21,55 +50,65 @@ JobSource* Job::source() {
 // before trying to open a nested SD file.  The reason for that is because
 // the number of simultaneously-open SD files is limited to conserve RAM.
 void Job::save() {
-    if (active()) {
-        job.back()->save();
-    }
+    JobLock lock;
+    save_nl();
 }
 void Job::restore() {
-    if (active()) {
-        job.back()->restore();
-    }
+    JobLock lock;
+    restore_nl();
 }
 void Job::nest(Channel* in_channel, Channel* out_channel) {
+    JobLock lock;
     auto source = new JobSource(in_channel);
     if (out_channel && job.empty()) {
         leader = out_channel;
     }
     job.push_back(source);
 }
+// Caller holds s_job_mutex.
 void Job::pop() {
     auto source = job.back();
     job.pop_back();
     delete source;
-    if (!active()) {
+    if (job.empty()) {
         leader = nullptr;
     }
 }
 void Job::unnest() {
-    if (active()) {
+    JobLock lock;
+    if (active_nl()) {
         pop();
-        restore();
+        restore_nl();
     }
 }
 
 void Job::abort() {
+    JobLock lock;
     // Kill all active jobs
-    while (active()) {
+    while (active_nl()) {
         pop();
     }
 }
 
 bool Job::get_param(const std::string& name, float& value) {
-    return job.back()->get_param(name, value);
+    JobLock lock;
+    return active_nl() && job.back()->get_param(name, value);
 }
 bool Job::set_param(const std::string& name, float value) {
-    return job.back()->set_param(name, value);
+    JobLock lock;
+    return active_nl() && job.back()->set_param(name, value);
 }
 bool Job::param_exists(const std::string& name) {
-    return job.back()->param_exists(name);
+    JobLock lock;
+    return active_nl() && job.back()->param_exists(name);
 }
 Channel* Job::channel() {
-    return job.back()->channel();
+    JobLock lock;
+    return job.empty() ? nullptr : job.back()->channel();
+}
+Channel* Job::leader_channel() {
+    JobLock lock;
+    return job.empty() ? nullptr : leader;
 }
 
 const std::vector<JobSource*>& Job::jobs_stack() {

--- a/FluidNC/src/Job.h
+++ b/FluidNC/src/Job.h
@@ -40,11 +40,19 @@ public:
     ~JobSource() { delete _channel; }
 };
 
+// The job stack is mutated from two tasks: nest() runs on the protocol task
+// (via execute_line -> $SD/Run / macro run), while unnest()/abort() run on the
+// polling task.  Every method below takes an internal mutex, so individual
+// calls are atomic; callers that need a consistent value across several fields
+// should use one call (e.g. channel(), which returns nullptr when idle) rather
+// than active() followed by a second call.
 class Job {
 private:
-    static void pop();
+    static void pop();  // caller holds the job mutex
 
 public:
+    // Prefer leader_channel() for a locked read; the bare pointer is retained
+    // for existing call sites and is written only under the job mutex.
     static Channel* leader;
 
     static bool active();
@@ -54,14 +62,16 @@ public:
     static void       nest(Channel* in_channel, Channel* out_channel);
     static void       unnest();
     static void       abort();
-    static JobSource* source();
+    static JobSource* source();  // nullptr when no job is active
 
     static bool     get_param(const std::string& name, float& value);
     static bool     set_param(const std::string& name, float value);
     static bool     param_exists(const std::string& name);
-    static Channel* channel();
+    static Channel* channel();         // top-of-stack channel, or nullptr when idle
+    static Channel* leader_channel();  // job leader, or nullptr when idle
 
-    // Expose access to jobs stack for listing local parameters
+    // Snapshot of the stack for $Local/Params listing.  Not safe against a
+    // concurrent unnest()/abort(); only meaningful for interactive use.
     static const std::vector<JobSource*>& jobs_stack();
 };
 

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -1025,37 +1025,37 @@ static Error list_parameters(const char* value, AuthenticationLevel auth_level, 
 // to performing some system state change.  Each command is responsible
 // for decoding its own value string, if it needs one.
 void make_user_commands() {
-    new UserCommand("GD", "GPIO/Dump", showGPIOs, anyState);
+    new ReportCommand("GD", "GPIO/Dump", showGPIOs, anyState);
     new UserCommand("GI", "GPIO/Input", setGPIOInput, anyState);
     new UserCommand("GO", "GPIO/Output", setGPIOOutput, anyState);
     new UserCommand("G+", "GPIO/On", writeGPIOOn, anyState);
     new UserCommand("G-", "GPIO/Off", writeGPIOOff, anyState);
-    new UserCommand("GR", "GPIO/Read", readGPIO, anyState);
+    new ReportCommand("GR", "GPIO/Read", readGPIO, anyState);
 
-    new UserCommand("CI", "Channel/Info", showChannelInfo, anyState);
-    new UserCommand("CD", "Config/Dump", dump_config, anyState);
-    new UserCommand("", "Help", show_help, anyState);
-    new UserCommand("T", "State", showState, anyState);
+    new ReportCommand("CI", "Channel/Info", showChannelInfo, anyState);
+    new ReportCommand("CD", "Config/Dump", dump_config, anyState);
+    new ReportCommand("", "Help", show_help, anyState);
+    new ReportCommand("T", "State", showState, anyState);
 
-    new UserCommand("$", "GrblSettings/List", report_normal_settings, cycleOrHold);
-    new UserCommand("L", "GrblNames/List", list_grbl_names, cycleOrHold);
-    new UserCommand("Limits", "Limits/Show", show_limits, cycleOrHold);
-    new UserCommand("S", "Settings/List", list_settings, cycleOrHold);
-    new UserCommand("SC", "Settings/ListChanged", list_changed_settings, cycleOrHold);
-    new UserCommand("CMD", "Commands/List", list_commands, cycleOrHold);
-    new UserCommand("A", "Alarms/List", listAlarms, anyState);
-    new UserCommand("E", "Errors/List", listErrors, anyState);
+    new ReportCommand("$", "GrblSettings/List", report_normal_settings, cycleOrHold);
+    new ReportCommand("L", "GrblNames/List", list_grbl_names, cycleOrHold);
+    new ReportCommand("Limits", "Limits/Show", show_limits, cycleOrHold);
+    new ReportCommand("S", "Settings/List", list_settings, cycleOrHold);
+    new ReportCommand("SC", "Settings/ListChanged", list_changed_settings, cycleOrHold);
+    new ReportCommand("CMD", "Commands/List", list_commands, cycleOrHold);
+    new ReportCommand("A", "Alarms/List", listAlarms, anyState);
+    new ReportCommand("E", "Errors/List", listErrors, anyState);
     new UserCommand("C", "GCode/Check", toggle_check_mode, anyState);
     new UserCommand("X", "Alarm/Disable", disable_alarm_lock, anyState);
     new UserCommand("NVX", "Settings/Erase", Setting::eraseNVS, notIdleOrAlarm, WA);
-    new UserCommand("V", "Settings/Stats", Setting::report_nvs_stats, notIdleOrAlarm);
-    new UserCommand("#", "GCode/Offsets", report_ngc, notIdleOrAlarm);
+    new ReportCommand("V", "Settings/Stats", Setting::report_nvs_stats, notIdleOrAlarm);
+    new ReportCommand("#", "GCode/Offsets", report_ngc, notIdleOrAlarm);
     new UserCommand("MD", "Motor/Disable", motor_disable, notIdleOrAlarm);
     new UserCommand("ME", "Motor/Enable", motor_enable, notIdleOrAlarm);
     new UserCommand("MI", "Motors/Init", motors_init, notIdleOrAlarm);
 
     new UserCommand("RM", "Macros/Run", macros_run, nullptr);
-    new UserCommand("PL", "Parameters/List", list_parameters, nullptr);
+    new ReportCommand("PL", "Parameters/List", list_parameters, nullptr);
 
     new UserCommand("H", "Home", home_all, allowConfigStates);
     new UserCommand("HX", "Home/X", home_x, allowConfigStates);
@@ -1079,31 +1079,31 @@ void make_user_commands() {
     new UserCommand("LV", "Log/Verbose", cmd_log_verbose, anyState);
 
     new UserCommand("SLP", "System/Sleep", go_to_sleep, notIdleOrAlarm);
-    new UserCommand("I", "Build/Info", get_report_build_info, allowConfigStates);
+    new ReportCommand("I", "Build/Info", get_report_build_info, allowConfigStates);
     new UserCommand("RST", "Settings/Restore", restore_settings, notIdleOrAlarm, WA);
 
     new UserCommand("SA", "Alarm/Send", sendAlarm, anyState);
-    new UserCommand("Heap", "Heap/Show", showHeap, anyState);
+    new ReportCommand("Heap", "Heap/Show", showHeap, anyState);
 #ifdef HEAPDIFF
-    new UserCommand("HS", "Heap/Snapshot", heap_snapshot, anyState);
-    new UserCommand("HD", "Heap/Diff", heap_diff, anyState);
-    new UserCommand("HRef", "Heap/Refs", heap_refs, anyState);
+    new ReportCommand("HS", "Heap/Snapshot", heap_snapshot, anyState);
+    new ReportCommand("HD", "Heap/Diff", heap_diff, anyState);
+    new ReportCommand("HRef", "Heap/Refs", heap_refs, anyState);
 #endif
-    new UserCommand("SS", "Startup/Show", showStartupLog, anyState);
-    new UserCommand("BS", "Backtrace/Show", showBacktrace, anyState);
+    new ReportCommand("SS", "Startup/Show", showStartupLog, anyState);
+    new ReportCommand("BS", "Backtrace/Show", showBacktrace, anyState);
 #ifdef CRASH_TEST
     new UserCommand("CRASH", "Crash/Test", forceCrash, anyState);
 #endif
     new UserCommand("UP", "Uart/Passthrough", uartPassthrough, notIdleOrAlarm);
 
-    new UserCommand("RI", "Report/Interval", setReportInterval, anyState);
+    new ReportCommand("RI", "Report/Interval", setReportInterval, anyState);
 
-    new UserCommand("13", "Report/Inches", switchInchMM, notIdleOrAlarm);
+    new ReportCommand("13", "Report/Inches", switchInchMM, notIdleOrAlarm);
 
-    new UserCommand("GS", "GRBL/Show", report_init_message_cmd, notIdleOrAlarm);
+    new ReportCommand("GS", "GRBL/Show", report_init_message_cmd, notIdleOrAlarm);
 
     new AsyncUserCommand("J", "Jog", doJog, notIdleOrJog);
-    new AsyncUserCommand("G", "GCode/Modes", report_gcode, anyState);
+    new ReportCommand("G", "GCode/Modes", report_gcode, anyState);
 };
 
 // This is the handler for all forms of settings commands,
@@ -1123,7 +1123,11 @@ Error do_command_or_setting(std::string_view key, std::string_view value, Authen
             if (auth_failed(cp, value, auth_level)) {
                 return Error::AuthenticationFailed;
             }
-            if (cp->synchronous()) {
+            // Run the state guard before draining the planner, so a command
+            // that is going to be rejected does not needlessly wait for
+            // motion to finish.  cp->action() re-checks the guard and returns
+            // the rejection code.
+            if (!cp->disallowed() && cp->drains_buffer()) {
                 protocol_buffer_synchronize();
             }
             if (value.empty()) {

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -1314,8 +1314,10 @@ Error execute_line(const char* line, Channel& channel, AuthenticationLevel auth_
     bool needs_context = line_needs_protocol_context(line);
 
     if (!on_protocol_task) {
-        // Called from the polling task.
-        if (Job::active() && &channel != Job::channel()) {
+        // Called from the polling task.  One locked read: jc is nullptr when
+        // no job is running, so this classification cannot race a nest/unnest.
+        Channel* jc = Job::channel();
+        if (jc && &channel != jc) {
             // Interloper while a job runs: reject anything that needs the
             // protocol task; run the side-effect-free rest here so it is not
             // stuck behind a consumer that is blocked in the planner.

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -1250,31 +1250,43 @@ Error settings_execute_line(const char* line, Channel& out, AuthenticationLevel 
     return do_command_or_setting(key, value, auth_level, out);
 }
 
-// Does this line have to run on the protocol task?  gcode always does; a '['
-// WebUI command does until WebCommand is classified (see the worry-later
-// list); a '$' command is looked up and answers with needs_protocol_context();
-// an unregistered "$name" is a yaml/NVS setting - a write must be ordered, a
-// read may run anywhere.  Called with leading whitespace already skipped and
-// line[0] != 0.
+// Does this line have to run on the protocol task?  gcode always does; a '$'
+// or '[' command is looked up in Command::List and answers with
+// needs_protocol_context() (WebCommand defaults true, WebReportCommand
+// false); an unregistered "$name" is a yaml/NVS setting - a write must be
+// ordered, a read may run anywhere; an unknown "[name]" is treated
+// conservatively.  Called with leading whitespace already skipped, line[0] != 0.
 static bool line_needs_protocol_context(const char* line) {
+    std::string_view name;
+    bool             has_value;
     if (line[0] == '[') {
-        return true;
-    }
-    if (line[0] != '$') {
+        // [ESPxxx] or [Full/Name] - the name runs to the ']'.
+        const char* rb = strchr(line, ']');
+        if (!rb) {
+            return true;  // malformed
+        }
+        name      = std::string_view(line + 1, rb - (line + 1));
+        has_value = rb[1] != '\0';
+    } else if (line[0] == '$') {
+        size_t end = 1;
+        while (line[end] && line[end] != '=' && line[end] != ' ' && line[end] != '\t') {
+            ++end;
+        }
+        name      = std::string_view(line + 1, end - 1);
+        has_value = line[end] == '=';
+    } else {
         return true;  // gcode
     }
-    size_t end = 1;
-    while (line[end] && line[end] != '=' && line[end] != ' ' && line[end] != '\t') {
-        ++end;
-    }
-    std::string_view name(line + 1, end - 1);
+
     for (Command* cp : Command::List) {
         if ((cp->getGrblName() && string_util::equal_ignore_case(cp->getGrblName(), name)) ||
             string_util::equal_ignore_case(cp->getName(), name)) {
             return cp->needs_protocol_context();
         }
     }
-    return line[end] == '=';  // unregistered: yaml/NVS write must be ordered
+    // Unregistered: a '$' name is a yaml/NVS setting - a write must be
+    // ordered; an unknown [ESPxxx] is treated conservatively.
+    return line[0] == '[' ? true : has_value;
 }
 
 // Run a '$' / '[' command right here (the polling task or the protocol task).

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -279,17 +279,21 @@ static Error disable_alarm_lock(const char* value, AuthenticationLevel auth_leve
     if (state_is(State::ConfigAlarm)) {
         return Error::ConfigurationInvalid;
     }
-    if (state_is(State::Alarm)) {
-        if (config->_control->safety_door_ajar()) {
-            send_alarm(ExecAlarm::StartupPin);
-            return Error::CheckDoor;
-        }
-        Homing::set_all_axes_homed();
-        config->_kinematics->releaseMotors(Axes::motorMask, Axes::hardLimitMask());
-        report_feedback_message(Message::AlarmUnlock);
-        set_state(State::Idle);
+    if (!state_is(State::Alarm)) {
+        // Nothing is locked, so $X is a no-op.  In particular it must not run
+        // the after_unlock macro while a job is running - that would nest a
+        // macro job into the middle of the program.
+        return Error::Ok;
     }
-    // Run the after_unlock macro even if no unlock was necessary
+    if (config->_control->safety_door_ajar()) {
+        send_alarm(ExecAlarm::StartupPin);
+        return Error::CheckDoor;
+    }
+    Homing::set_all_axes_homed();
+    config->_kinematics->releaseMotors(Axes::motorMask, Axes::hardLimitMask());
+    report_feedback_message(Message::AlarmUnlock);
+    set_state(State::Idle);
+
     config->_macros->_after_unlock.run(&out);
     return Error::Ok;
 }

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -1041,19 +1041,19 @@ void make_user_commands() {
     new ReportCommand("", "Help", show_help, anyState);
     new ReportCommand("T", "State", showState, anyState);
 
-    new ReportCommand("$", "GrblSettings/List", report_normal_settings, cycleOrHold);
-    new ReportCommand("L", "GrblNames/List", list_grbl_names, cycleOrHold);
+    new ReportCommand("$", "GrblSettings/List", report_normal_settings, anyState);
+    new ReportCommand("L", "GrblNames/List", list_grbl_names, anyState);
     new ReportCommand("Limits", "Limits/Show", show_limits, cycleOrHold);
-    new ReportCommand("S", "Settings/List", list_settings, cycleOrHold);
-    new ReportCommand("SC", "Settings/ListChanged", list_changed_settings, cycleOrHold);
-    new ReportCommand("CMD", "Commands/List", list_commands, cycleOrHold);
+    new ReportCommand("S", "Settings/List", list_settings, anyState);
+    new ReportCommand("SC", "Settings/ListChanged", list_changed_settings, anyState);
+    new ReportCommand("CMD", "Commands/List", list_commands, anyState);
     new ReportCommand("A", "Alarms/List", listAlarms, anyState);
     new ReportCommand("E", "Errors/List", listErrors, anyState);
     new UserCommand("C", "GCode/Check", toggle_check_mode, anyState);
     new UserCommand("X", "Alarm/Disable", disable_alarm_lock, anyState);
     new UserCommand("NVX", "Settings/Erase", Setting::eraseNVS, notIdleOrAlarm, WA);
     new ReportCommand("V", "Settings/Stats", Setting::report_nvs_stats, notIdleOrAlarm);
-    new ReportCommand("#", "GCode/Offsets", report_ngc, notIdleOrAlarm);
+    new ReportCommand("#", "GCode/Offsets", report_ngc, anyState);
     new UserCommand("MD", "Motor/Disable", motor_disable, notIdleOrAlarm);
     new UserCommand("ME", "Motor/Enable", motor_enable, notIdleOrAlarm);
     new UserCommand("MI", "Motors/Init", motors_init, notIdleOrAlarm);
@@ -1072,21 +1072,21 @@ void make_user_commands() {
     new UserCommand("HV", "Home/V", home_v, allowConfigStates);
     new UserCommand("HW", "Home/W", home_w, allowConfigStates);
 
-    new UserCommand("MU0", "Msg/Uart0", msg_to_uart0, anyState);
-    new UserCommand("MU1", "Msg/Uart1", msg_to_uart1, anyState);
-    new UserCommand("MC", "Msg/Channel", msg_to_channel, anyState);
-    new UserCommand("LM", "Log/Msg", cmd_log_msg, anyState);
-    new UserCommand("LE", "Log/Error", cmd_log_error, anyState);
-    new UserCommand("LW", "Log/Warn", cmd_log_warn, anyState);
-    new UserCommand("LI", "Log/Info", cmd_log_info, anyState);
-    new UserCommand("LD", "Log/Debug", cmd_log_debug, anyState);
-    new UserCommand("LV", "Log/Verbose", cmd_log_verbose, anyState);
+    new ReportCommand("MU0", "Msg/Uart0", msg_to_uart0, anyState);
+    new ReportCommand("MU1", "Msg/Uart1", msg_to_uart1, anyState);
+    new ReportCommand("MC", "Msg/Channel", msg_to_channel, anyState);
+    new ReportCommand("LM", "Log/Msg", cmd_log_msg, anyState);
+    new ReportCommand("LE", "Log/Error", cmd_log_error, anyState);
+    new ReportCommand("LW", "Log/Warn", cmd_log_warn, anyState);
+    new ReportCommand("LI", "Log/Info", cmd_log_info, anyState);
+    new ReportCommand("LD", "Log/Debug", cmd_log_debug, anyState);
+    new ReportCommand("LV", "Log/Verbose", cmd_log_verbose, anyState);
 
     new UserCommand("SLP", "System/Sleep", go_to_sleep, notIdleOrAlarm);
-    new ReportCommand("I", "Build/Info", get_report_build_info, allowConfigStates);
+    new ReportCommand("I", "Build/Info", get_report_build_info, anyState);
     new UserCommand("RST", "Settings/Restore", restore_settings, notIdleOrAlarm, WA);
 
-    new UserCommand("SA", "Alarm/Send", sendAlarm, anyState);
+    new ReportCommand("SA", "Alarm/Send", sendAlarm, anyState);
     new ReportCommand("Heap", "Heap/Show", showHeap, anyState);
 #ifdef HEAPDIFF
     new ReportCommand("HS", "Heap/Snapshot", heap_snapshot, anyState);
@@ -1104,7 +1104,7 @@ void make_user_commands() {
 
     new ReportCommand("13", "Report/Inches", switchInchMM, notIdleOrAlarm);
 
-    new ReportCommand("GS", "GRBL/Show", report_init_message_cmd, notIdleOrAlarm);
+    new ReportCommand("GS", "GRBL/Show", report_init_message_cmd, anyState);
 
     new AsyncUserCommand("J", "Jog", doJog, notIdleOrJog);
     new ReportCommand("G", "GCode/Modes", report_gcode, anyState);

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -1250,7 +1250,43 @@ Error settings_execute_line(const char* line, Channel& out, AuthenticationLevel 
     return do_command_or_setting(key, value, auth_level, out);
 }
 
-Error execute_line(const char* line, Channel& channel, AuthenticationLevel auth_level) {
+// Does this line have to run on the protocol task?  gcode always does; a '['
+// WebUI command does until WebCommand is classified (see the worry-later
+// list); a '$' command is looked up and answers with needs_protocol_context();
+// an unregistered "$name" is a yaml/NVS setting - a write must be ordered, a
+// read may run anywhere.  Called with leading whitespace already skipped and
+// line[0] != 0.
+static bool line_needs_protocol_context(const char* line) {
+    if (line[0] == '[') {
+        return true;
+    }
+    if (line[0] != '$') {
+        return true;  // gcode
+    }
+    size_t end = 1;
+    while (line[end] && line[end] != '=' && line[end] != ' ' && line[end] != '\t') {
+        ++end;
+    }
+    std::string_view name(line + 1, end - 1);
+    for (Command* cp : Command::List) {
+        if ((cp->getGrblName() && string_util::equal_ignore_case(cp->getGrblName(), name)) ||
+            string_util::equal_ignore_case(cp->getName(), name)) {
+            return cp->needs_protocol_context();
+        }
+    }
+    return line[end] == '=';  // unregistered: yaml/NVS write must be ordered
+}
+
+// Run a '$' / '[' command right here (the polling task or the protocol task).
+// Never reaches gcode or the planner.
+static Error run_command_inline(const char* line, Channel& channel, AuthenticationLevel auth_level) {
+    if (gc_state.skip_blocks) {
+        return Error::Ok;
+    }
+    return settings_execute_line(line, channel, auth_level);
+}
+
+Error execute_line(const char* line, Channel& channel, AuthenticationLevel auth_level, bool on_protocol_task) {
     // Empty or comment line. For syncing purposes.
     if (line[0] == 0) {
         return Error::Ok;
@@ -1259,13 +1295,31 @@ Error execute_line(const char* line, Channel& channel, AuthenticationLevel auth_
     while (isspace(*line)) {
         ++line;
     }
-    // User '$' or WebUI '[ESPxxx]' command
-    if (line[0] == '$' || line[0] == '[') {
-        if (gc_state.skip_blocks) {
-            return Error::Ok;
-        }
+    if (line[0] == 0) {
+        return Error::Ok;
+    }
 
-        return settings_execute_line(line, channel, auth_level);
+    bool needs_context = line_needs_protocol_context(line);
+
+    if (!on_protocol_task) {
+        // Called from the polling task.
+        if (Job::active() && &channel != Job::channel()) {
+            // Interloper while a job runs: reject anything that needs the
+            // protocol task; run the side-effect-free rest here so it is not
+            // stuck behind a consumer that is blocked in the planner.
+            if (needs_context) {
+                return Error::AnotherInterfaceBusy;
+            }
+            return run_command_inline(line, channel, auth_level);
+        }
+        // The job's own line, or any line when no job is running: hand it to
+        // protocol_main_loop so ordering and reply routing are unchanged.
+        return cmd_queue_defer(line, channel) ? Error::Deferred : Error::AnotherInterfaceBusy;
+    }
+
+    // on_protocol_task: run it for real.
+    if (line[0] == '$' || line[0] == '[') {
+        return run_command_inline(line, channel, auth_level);
     }
     // Everything else is gcode. Block if in alarm or jog mode.
     if (state_is(State::Alarm) || state_is(State::ConfigAlarm) || state_is(State::Jog)) {

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -24,6 +24,8 @@
 #include "Driver/watchdog.h"
 #include "Driver/heap.h"  // platform_max_free_block()
 
+#include <atomic>
+
 volatile ExecAlarm lastAlarm;  // The most recent alarm code
 
 volatile const char* unwind_cause = nullptr;
@@ -126,7 +128,15 @@ void output_loop(void* unused) {
     }
 }
 
-Channel* activeChannel = nullptr;  // Channel associated with the input line
+// activeChannel is a single-slot handoff of one input line from the polling
+// task (core 0, producer) to protocol_main_loop (core 1, consumer):
+//   producer: fills activeLine, then publishes with a release store
+//   consumer: acquire-loads the pointer, reads activeLine, then clears with a
+//             release store so the producer only overwrites activeLine after
+//             the consumer is done with it.
+// The paired release/acquire is what makes activeLine safe to share unlocked
+// across the two cores; a plain pointer here is a data race.
+std::atomic<Channel*> activeChannel { nullptr };  // Channel associated with the input line
 
 TaskHandle_t pollingTask = nullptr;
 
@@ -163,13 +173,15 @@ void polling_loop(void* unused) {
         // activeChannel is thus a form of flow control between the protocol
         // task that processes GCode lines and other events and this task that
         // handles IO from channels.
-        if (!activeChannel) {
+        if (!activeChannel.load(std::memory_order_acquire)) {
             // Job channels have priority
             if (!Job::active()) {
                 unwind_cause = nullptr;
                 // No job channel is active, so poll all of the serial-style
-                // channels to see if one has a line ready.
-                activeChannel = pollChannels(activeLine);
+                // channels to see if one has a line ready.  pollChannels()
+                // fills activeLine before returning, so the release store
+                // publishes the buffer contents together with the pointer.
+                activeChannel.store(pollChannels(activeLine), std::memory_order_release);
             } else {
                 if (state_is(State::Alarm) || state_is(State::ConfigAlarm) || state_is(State::Critical)) {
                     log_debug("Unwinding from Alarm");
@@ -188,7 +200,7 @@ void polling_loop(void* unused) {
                 auto status  = channel->pollLine(activeLine);
                 switch (status) {
                     case Error::Ok:
-                        activeChannel = channel;
+                        activeChannel.store(channel, std::memory_order_release);
                         break;
                     case Error::NoData:
                         break;
@@ -271,10 +283,14 @@ void protocol_main_loop() {
         if (should_exit()) {
             break;
         }
-        if (activeChannel) {
-            if (activeChannel->is_closing()) {
-                activeChannel->release_processing_ref();
-                activeChannel = nullptr;
+        // Acquire-load pairs with the polling task's release store, so
+        // activeLine is fully visible here before we read it.
+        if (Channel* channel = activeChannel.load(std::memory_order_acquire)) {
+            if (channel->is_closing()) {
+                channel->release_processing_ref();
+                // Release store: the polling task must not overwrite activeLine
+                // until we are done with it (here, nothing more to do).
+                activeChannel.store(nullptr, std::memory_order_release);
                 continue;
             }
 
@@ -283,20 +299,22 @@ void protocol_main_loop() {
                 report_echo_line_received(activeLine, allChannels);
             }
 
-            Channel* out_channel = Job::leader ? Job::leader : activeChannel;
+            Channel* out_channel = Job::leader ? Job::leader : channel;
 
             Error status_code = execute_line(activeLine, *out_channel, AuthenticationLevel::LEVEL_GUEST);
 
             // Tell the channel that the line has been processed.
             // If the line was aborted, the channel could be invalid
             if (!sys.abort()) {
-                activeChannel->ack(status_code);
+                channel->ack(status_code);
             }
 
             // Tell the input polling task that the line has been processed,
-            // so it can give us another one when available
-            activeChannel->release_processing_ref();
-            activeChannel = nullptr;
+            // so it can give us another one when available.  The release store
+            // ensures our reads of activeLine / ack() / release_processing_ref()
+            // complete before the polling task sees the slot free.
+            channel->release_processing_ref();
+            activeChannel.store(nullptr, std::memory_order_release);
         }
 
         // Auto-cycle start any queued moves.

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -24,7 +24,7 @@
 #include "Driver/watchdog.h"
 #include "Driver/heap.h"  // platform_max_free_block()
 
-#include <atomic>
+#include <cstring>  // strncpy
 
 volatile ExecAlarm lastAlarm;  // The most recent alarm code
 
@@ -128,19 +128,44 @@ void output_loop(void* unused) {
     }
 }
 
-// activeChannel is a single-slot handoff of one input line from the polling
-// task (core 0, producer) to protocol_main_loop (core 1, consumer):
-//   producer: fills activeLine, then publishes with a release store
-//   consumer: acquire-loads the pointer, reads activeLine, then clears with a
-//             release store so the producer only overwrites activeLine after
-//             the consumer is done with it.
-// The paired release/acquire is what makes activeLine safe to share unlocked
-// across the two cores; a plain pointer here is a data race.
-std::atomic<Channel*> activeChannel { nullptr };  // Channel associated with the input line
+// One line of input handed from the polling task (core 0, producer) to
+// protocol_main_loop (core 1, consumer).  The line is copied into the queue
+// item; xQueueSend/xQueueReceive supply the memory barrier that makes it safe
+// to read on the other core.  Depth 1 keeps the strict one-line-in-flight flow
+// control of the previous single-slot handoff.
+struct LineItem {
+    Channel* channel;  // source; holds a processing_ref until the line is acked
+    char     line[Channel::maxLine];
+};
+static constexpr UBaseType_t CMD_QUEUE_DEPTH = 1;
+QueueHandle_t                cmd_queue        = nullptr;
+
+bool cmd_queue_defer(const char* line, Channel& channel) {
+    LineItem item;
+    item.channel = &channel;
+    strncpy(item.line, line, Channel::maxLine - 1);
+    item.line[Channel::maxLine - 1] = '\0';
+    return xQueueSend(cmd_queue, &item, 0) == pdTRUE;
+}
 
 TaskHandle_t pollingTask = nullptr;
 
-char activeLine[Channel::maxLine];
+// Poll the registered serial-style channels for one line and route it through
+// execute_line() on the polling task.  When no job runs this feeds cmd_queue;
+// during a job it services interloper commands (run inline or rejected in
+// execute_line, never queued), so they are not stuck behind a consumer that is
+// blocked in the planner.
+static void poll_input_channel() {
+    char buf[Channel::maxLine];
+    if (Channel* ch = pollChannels(buf)) {
+        Error rc = execute_line(buf, *ch, AuthenticationLevel::LEVEL_GUEST, false);
+        if (rc != Error::Deferred) {
+            // Ran inline or was rejected - the polling task still holds the ref.
+            ch->ack(rc);
+            ch->release_processing_ref();
+        }
+    }
+}
 
 bool pollingPaused = false;
 void polling_loop(void* unused) {
@@ -168,57 +193,67 @@ void polling_loop(void* unused) {
             feed_watchdog();
         }
 
-        // If activeChannel is non-null, it means that we have received a line
-        // but the task running protocol_main_loop() has not yet picked it up.
-        // activeChannel is thus a form of flow control between the protocol
-        // task that processes GCode lines and other events and this task that
-        // handles IO from channels.
-        if (!activeChannel.load(std::memory_order_acquire)) {
-            // Job channels have priority
-            if (!Job::active()) {
+        if (!Job::active()) {
+            unwind_cause = nullptr;
+            // No job: every line goes to cmd_queue.  Gate on queue room so a
+            // slow consumer bounds read-ahead - the flow control the old
+            // single slot gave.
+            if (uxQueueSpacesAvailable(cmd_queue)) {
+                poll_input_channel();
+            }
+        } else {
+            if (state_is(State::Alarm) || state_is(State::ConfigAlarm) || state_is(State::Critical)) {
+                log_debug("Unwinding from Alarm");
+                Job::abort();
                 unwind_cause = nullptr;
-                // No job channel is active, so poll all of the serial-style
-                // channels to see if one has a line ready.  pollChannels()
-                // fills activeLine before returning, so the release store
-                // publishes the buffer contents together with the pointer.
-                activeChannel.store(pollChannels(activeLine), std::memory_order_release);
-            } else {
-                if (state_is(State::Alarm) || state_is(State::ConfigAlarm) || state_is(State::Critical)) {
-                    log_debug("Unwinding from Alarm");
-                    Job::abort();
-                    unwind_cause = nullptr;
-                    continue;
-                }
-                if (unwind_cause) {
-                    Job::abort();
-                    unwind_cause = nullptr;
-                    continue;
-                }
-                // A job channel is active, so accept line-oriented input only
-                // from the job channel on top of the job stack.
-                auto channel = Job::channel();
-                auto status  = channel->pollLine(activeLine);
-                switch (status) {
-                    case Error::Ok:
-                        activeChannel.store(channel, std::memory_order_release);
-                        break;
-                    case Error::NoData:
-                        break;
-                    case Error::Eof:
-                        notifyf("Job done", "%s job sent", channel->name());
-                        log_debug(channel->name() << " job sent");
-                        Job::unnest();
-                        break;
-                    default:
-                        if (Job::leader) {
-                            log_error_to(*Job::leader,
-                                         static_cast<int>(status) << " (" << errorString(status) << ") in " << channel->name()
-                                                                  << " at line " << channel->lineNumber());
+                continue;
+            }
+            if (unwind_cause) {
+                Job::abort();
+                unwind_cause = nullptr;
+                continue;
+            }
+
+            // Job channel has priority: feed it while cmd_queue has room.
+            char buf[Channel::maxLine];
+            if (uxQueueSpacesAvailable(cmd_queue)) {
+                if (Channel* channel = Job::channel()) {
+                    auto status = channel->pollLine(buf);
+                    switch (status) {
+                        case Error::Ok:
+                            // From the job channel, so execute_line() defers it.
+                            // Hold a processing_ref from here to the consumer's ack.
+                            if (channel->try_acquire_processing_ref()) {
+                                if (execute_line(buf, *channel, AuthenticationLevel::LEVEL_GUEST, false) != Error::Deferred) {
+                                    channel->release_processing_ref();  // not queued after all
+                                }
+                            }
+                            break;
+                        case Error::NoData:
+                            break;
+                        case Error::Eof:
+                            notifyf("Job done", "%s job sent", channel->name());
+                            log_debug(channel->name() << " job sent");
+                            Job::unnest();
+                            break;
+                        default: {
+                            Channel* ldr = Job::leader_channel();
+                            if (ldr) {
+                                log_error_to(*ldr,
+                                             static_cast<int>(status) << " (" << errorString(status) << ") in "
+                                                                      << channel->name() << " at line " << channel->lineNumber());
+                            }
+                            Job::abort();
+                            break;
                         }
-                        Job::abort();
-                        break;
+                    }
                 }
             }
+
+            // Also service the other channels every pass, so interloper reads
+            // and rejections happen promptly.  execute_line() runs or rejects
+            // them on this task; they never enter cmd_queue, so no queue gate.
+            poll_input_channel();
         }
     }
 }
@@ -283,38 +318,29 @@ void protocol_main_loop() {
         if (should_exit()) {
             break;
         }
-        // Acquire-load pairs with the polling task's release store, so
-        // activeLine is fully visible here before we read it.
-        if (Channel* channel = activeChannel.load(std::memory_order_acquire)) {
+        // A line collected by the polling task.  xQueueReceive supplies the
+        // barrier that makes item.line fully visible here.
+        LineItem item;
+        if (xQueueReceive(cmd_queue, &item, 0)) {
+            Channel* channel = item.channel;
             if (channel->is_closing()) {
                 channel->release_processing_ref();
-                // Release store: the polling task must not overwrite activeLine
-                // until we are done with it (here, nothing more to do).
-                activeChannel.store(nullptr, std::memory_order_release);
-                continue;
+            } else {
+                if (gcode_echo->get()) {
+                    report_echo_line_received(item.line, allChannels);
+                }
+
+                Channel* ldr         = Job::leader_channel();
+                Channel* out_channel = ldr ? ldr : channel;
+
+                Error status_code = execute_line(item.line, *out_channel, AuthenticationLevel::LEVEL_GUEST, true);
+
+                // If the line was aborted, the channel could be invalid.
+                if (!sys.abort()) {
+                    channel->ack(status_code);
+                }
+                channel->release_processing_ref();
             }
-
-            // The input polling task has collected a line of input
-            if (gcode_echo->get()) {
-                report_echo_line_received(activeLine, allChannels);
-            }
-
-            Channel* out_channel = Job::leader ? Job::leader : channel;
-
-            Error status_code = execute_line(activeLine, *out_channel, AuthenticationLevel::LEVEL_GUEST);
-
-            // Tell the channel that the line has been processed.
-            // If the line was aborted, the channel could be invalid
-            if (!sys.abort()) {
-                channel->ack(status_code);
-            }
-
-            // Tell the input polling task that the line has been processed,
-            // so it can give us another one when available.  The release store
-            // ensures our reads of activeLine / ack() / release_processing_ref()
-            // complete before the polling task sees the slot free.
-            channel->release_processing_ref();
-            activeChannel.store(nullptr, std::memory_order_release);
         }
 
         // Auto-cycle start any queued moves.
@@ -1274,6 +1300,7 @@ QueueHandle_t event_queue;
 void protocol_init() {
     event_queue   = xQueueCreate(50, sizeof(EventItem));
     message_queue = xQueueCreate(15, sizeof(LogMessage));
+    cmd_queue     = xQueueCreate(CMD_QUEUE_DEPTH, sizeof(LineItem));
 }
 
 void IRAM_ATTR protocol_send_event_from_ISR(const Event* evt, void* arg) {

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -115,5 +115,10 @@ void protocol_send_event_from_ISR(const Event* evt, void* arg = 0);
 
 void drain_messages();
 
+// Copy a line onto cmd_queue for protocol_main_loop to execute.  Returns false
+// if the queue is full.  Called by execute_line() on the polling task.
+class Channel;
+bool cmd_queue_defer(const char* line, Channel& channel);
+
 extern uint32_t heapLowWater;
 extern uint32_t maxBlockLowWater;  // largest-free-block low-water; UINT_MAX where unavailable

--- a/FluidNC/src/Report.cpp
+++ b/FluidNC/src/Report.cpp
@@ -600,8 +600,8 @@ void report_realtime_status(Channel& channel) {
             }
         }
     }
-    if (Job::active()) {
-        msg << "|" << Job::channel()->_progress;
+    if (Channel* jc = Job::channel()) {
+        msg << "|" << jc->_progress;
     }
 #ifdef DEBUG_STEPPER_ISR
     msg << "|ISRs:" << Stepper::isr_count;

--- a/FluidNC/src/Settings.cpp
+++ b/FluidNC/src/Settings.cpp
@@ -66,9 +66,10 @@ Command::Command(const char*   description,
                  const char*   grblName,
                  const char*   fullName,
                  bool (*cmdChecker)(),
-                 bool synchronous) :
+                 bool needs_protocol_context,
+                 bool drains_buffer) :
     Word(type, permissions, description, grblName, fullName),
-    _cmdChecker(cmdChecker), _synchronous(synchronous) {
+    _cmdChecker(cmdChecker), _needs_protocol_context(needs_protocol_context), _drains_buffer(drains_buffer) {
     List.insert(List.begin(), this);
 }
 

--- a/FluidNC/src/Settings.h
+++ b/FluidNC/src/Settings.h
@@ -81,7 +81,15 @@ protected:
     bool (*_cmdChecker)();
 
 private:
-    bool _synchronous = true;
+    // _needs_protocol_context: the command must execute on the protocol task
+    //   because it touches the planner, the state machine, the event queue, or
+    //   nests a job.  Commands without it are pure observers that can run off
+    //   the protocol task.
+    // _drains_buffer: call protocol_buffer_synchronize() before the command
+    //   runs.  Only meaningful in the protocol context, so drains_buffer()
+    //   ANDs the two ($J needs the context but must not block on the buffer).
+    bool _needs_protocol_context = false;
+    bool _drains_buffer          = false;
 
 public:
     // Command::List is a vector of all commands,
@@ -95,14 +103,19 @@ public:
             const char*   grblName,
             const char*   fullName,
             bool (*cmdChecker)(),
-            bool synchronous = false);
+            bool needs_protocol_context = false,
+            bool drains_buffer          = false);
 
     // The default implementation of addWebui() does nothing.
     // Derived classes may override it to do something.
     virtual void addWebui(JSONencoder*) {};
 
     virtual Error action(const char* value, AuthenticationLevel auth_level, Channel& out) = 0;
-    bool          synchronous() { return _synchronous; }
+
+    bool needs_protocol_context() { return _needs_protocol_context; }
+    bool drains_buffer() { return _needs_protocol_context && _drains_buffer; }
+    // True if this command's state guard currently disallows it.
+    bool disallowed() { return _cmdChecker && _cmdChecker(); }
 };
 
 class Setting : public Word {
@@ -384,13 +397,16 @@ public:
                 const char* name,
                 Error (*action)(const char*, AuthenticationLevel, Channel&),
                 bool (*cmdChecker)(),
-                permissions_t auth        = WG,
-                bool          synchronous = true) :
-        Command(NULL, GRBLCMD, auth, grblName, name, cmdChecker, synchronous),
+                permissions_t auth                   = WG,
+                bool          needs_protocol_context = true,
+                bool          drains_buffer          = true) :
+        Command(NULL, GRBLCMD, auth, grblName, name, cmdChecker, needs_protocol_context, drains_buffer),
         _action(action) {}
 
     Error action(const char* value, AuthenticationLevel auth_level, Channel& response);
 };
+// Feeds the planner but must stay responsive: runs in the protocol context
+// without a preceding buffer sync.  (Currently just $J.)
 class AsyncUserCommand : public UserCommand {
 public:
     AsyncUserCommand(const char* grblName,
@@ -398,7 +414,17 @@ public:
                      Error (*action)(const char*, AuthenticationLevel, Channel&),
                      bool (*cmdChecker)(),
                      permissions_t auth = WG) :
-        UserCommand(grblName, name, action, cmdChecker, auth, false) {}
+        UserCommand(grblName, name, action, cmdChecker, auth, /*needs_protocol_context=*/true, /*drains_buffer=*/false) {}
+};
+// A pure observer: reads state and prints.  No protocol context, no buffer sync.
+class ReportCommand : public UserCommand {
+public:
+    ReportCommand(const char* grblName,
+                  const char* name,
+                  Error (*action)(const char*, AuthenticationLevel, Channel&),
+                  bool (*cmdChecker)()  = anyState,
+                  permissions_t auth    = WG) :
+        UserCommand(grblName, name, action, cmdChecker, auth, /*needs_protocol_context=*/false, /*drains_buffer=*/false) {}
 };
 
 // Execute the startup script lines stored in non-volatile storage upon initialization

--- a/FluidNC/src/Settings.h
+++ b/FluidNC/src/Settings.h
@@ -443,7 +443,11 @@ public:
                      permissions_t auth = WG) :
         UserCommand(grblName, name, action, cmdChecker, auth, /*needs_protocol_context=*/true, /*drains_buffer=*/false) {}
 };
-// A pure observer: reads state and prints.  No protocol context, no buffer sync.
+// A command with no protocol-task dependency: it touches no planner, no state
+// machine, no event-queue consumer, and nests no job, so it runs on the
+// polling task and never drains the motion buffer.  Most are pure reports; a
+// few have a small non-motion side effect ($RI sets a channel's report
+// interval, $SA posts an alarm event).
 class ReportCommand : public UserCommand {
 public:
     ReportCommand(const char* grblName,

--- a/FluidNC/src/Settings.h
+++ b/FluidNC/src/Settings.h
@@ -430,6 +430,10 @@ public:
 // Execute the startup script lines stored in non-volatile storage upon initialization
 Error settings_execute_line(const char* line, Channel& out, AuthenticationLevel);
 Error do_command_or_setting(std::string_view key, std::string_view value, AuthenticationLevel auth_level, Channel&);
-Error execute_line(const char* line, Channel& channel, AuthenticationLevel auth_level);
+// on_protocol_task: true when called from protocol_main_loop (run it now);
+// false when called from the polling task (run side-effect-free commands
+// inline, hand anything needing the protocol context to cmd_queue, reject
+// interloper gcode/commands during a job).
+Error execute_line(const char* line, Channel& channel, AuthenticationLevel auth_level, bool on_protocol_task);
 
 extern const enum_opt_t onoffOptions;

--- a/FluidNC/src/Settings.h
+++ b/FluidNC/src/Settings.h
@@ -374,7 +374,22 @@ private:
     Error (*_action)(const char*, AuthenticationLevel, Channel& out);
     const char* password;
 
+protected:
+    WebCommand(const char*   description,
+               type_t        type,
+               permissions_t permissions,
+               const char*   grblName,
+               const char*   name,
+               Error (*action)(const char*, AuthenticationLevel, Channel& out),
+               bool (*cmdChecker)(),
+               bool          needs_protocol_context) :
+        Command(description, type, permissions, grblName, name, cmdChecker, needs_protocol_context, /*drains_buffer=*/false),
+        _action(action) {}
+
 public:
+    // [ESPxxx] commands touch the filesystem, NVS, the network, or restart the
+    // box, so by default they must run on the protocol task; the read-only
+    // status ones use WebReportCommand.
     WebCommand(const char*   description,
                type_t        type,
                permissions_t permissions,
@@ -382,10 +397,22 @@ public:
                const char*   name,
                Error (*action)(const char*, AuthenticationLevel, Channel& out),
                bool (*cmdChecker)() = notIdleOrAlarm) :
-        Command(description, type, permissions, grblName, name, cmdChecker),
-        _action(action) {}
+        WebCommand(description, type, permissions, grblName, name, action, cmdChecker, /*needs_protocol_context=*/true) {}
 
     Error action(const char* value, AuthenticationLevel auth_level, Channel& out);
+};
+
+// A read-only [ESPxxx] status/info command with no protocol-task dependency.
+class WebReportCommand : public WebCommand {
+public:
+    WebReportCommand(const char*   description,
+                     type_t        type,
+                     permissions_t permissions,
+                     const char*   grblName,
+                     const char*   name,
+                     Error (*action)(const char*, AuthenticationLevel, Channel& out),
+                     bool (*cmdChecker)() = anyState) :
+        WebCommand(description, type, permissions, grblName, name, action, cmdChecker, /*needs_protocol_context=*/false) {}
 };
 
 class UserCommand : public Command {

--- a/FluidNC/src/WebUI/EthConfig.cpp
+++ b/FluidNC/src/WebUI/EthConfig.cpp
@@ -213,7 +213,7 @@ namespace WebUI {
             _eth_gateway = new IPaddrSetting("Ethernet Static Gateway", WEBSET, WA, NULL, "Ethernet/Gateway", NULL_IP);
             _eth_netmask = new IPaddrSetting("Ethernet Static Mask", WEBSET, WA, NULL, "Ethernet/Netmask", NULL_IP);
 
-            new WebCommand(NULL, WEBCMD, WG, NULL, "Ethernet/Status", showEthStatus, anyState);
+            new WebReportCommand(NULL, WEBCMD, WG, NULL, "Ethernet/Status", showEthStatus, anyState);
             new WebCommand("IP=ipaddress MSK=netmask GW=gateway", WEBCMD, WA, NULL, "Ethernet/Setup", showSetEthParams);
             new WebCommand(NULL, WEBCMD, WA, "EI", "Ethernet/Init", initEth, anyState);
 

--- a/FluidNC/src/WebUI/NetConfig.cpp
+++ b/FluidNC/src/WebUI/NetConfig.cpp
@@ -156,7 +156,7 @@ namespace WebUI {
 
     public:
         NetConfig(const char* name) : Module(name) {}
-        void init() { new WebCommand(NULL, WEBCMD, WG, "ESP800", "Firmware/Info", showFwInfo, anyState); }
+        void init() { new WebReportCommand(NULL, WEBCMD, WG, "ESP800", "Firmware/Info", showFwInfo, anyState); }
         ~NetConfig() {}
     };
 

--- a/FluidNC/src/WebUI/WebCommands.cpp
+++ b/FluidNC/src/WebUI/WebCommands.cpp
@@ -221,15 +221,15 @@ namespace WebUI {
             // RU - need user or admin password to read
             // WU - need user or admin password to set
             // WA - need admin password to set
-            new WebCommand(NULL, WEBCMD, WU, "ESP420", "System/Stats", showSysStats, anyState);
+            new WebReportCommand(NULL, WEBCMD, WU, "ESP420", "System/Stats", showSysStats, anyState);
             new WebCommand("RESTART", WEBCMD, WA, "ESP444", "System/Control", setSystemMode);
 
             //      new WebCommand("ON|OFF", WEBCMD, WA, "ESP115", "Radio/State", setRadioState);
 
             new WebCommand("P=position T=type V=value", WEBCMD, WA, "ESP401", "WebUI/Set", setWebSetting);
-            new WebCommand(NULL, WEBCMD, WU, "ESP400", "WebUI/List", listSettings, anyState);
-            new WebCommand(NULL, WEBCMD, WG, "ESP0", "WebUI/Help", showWebHelp, anyState);
-            new WebCommand(NULL, WEBCMD, WG, "ESP", "WebUI/Help", showWebHelp, anyState);
+            new WebReportCommand(NULL, WEBCMD, WU, "ESP400", "WebUI/List", listSettings, anyState);
+            new WebReportCommand(NULL, WEBCMD, WG, "ESP0", "WebUI/Help", showWebHelp, anyState);
+            new WebReportCommand(NULL, WEBCMD, WG, "ESP", "WebUI/Help", showWebHelp, anyState);
         }
     };
     ModuleFactory::InstanceBuilder<WebCommands> web_commands_module __attribute__((init_priority(103))) ("web_commands", true);

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -697,10 +697,10 @@ namespace WebUI {
             _ntp_enable = new EnumSetting("NTP Enable", WEBSET, WA, NULL, "NTP/Enable", false, &onoffOptions);
 
             new WebCommand(NULL, WEBCMD, WU, "ESP410", "WiFi/ListAPs", listAPs);
-            new WebCommand(NULL, WEBCMD, WG, NULL, "wifi/status", showWiFiStatus, anyState);
-            new WebCommand(NULL, WEBCMD, WG, "ESP800", "Firmware/Info", showFwInfo, anyState);
+            new WebReportCommand(NULL, WEBCMD, WG, NULL, "wifi/status", showWiFiStatus, anyState);
+            new WebReportCommand(NULL, WEBCMD, WG, "ESP800", "Firmware/Info", showFwInfo, anyState);
 
-            new WebCommand(NULL, WEBCMD, WG, "ESP111", "System/IP", showIP);
+            new WebReportCommand(NULL, WEBCMD, WG, "ESP111", "System/IP", showIP);
             new WebCommand("IP=ipaddress MSK=netmask GW=gateway", WEBCMD, WA, "ESP103", "Sta/Setup", showSetStaParams);
 
             //stop active services


### PR DESCRIPTION
## What this does

Lets a second channel (a pendant, a WebUI/telnet console) run **informational commands while a job is streaming**, without stalling the job and without the OOM that motivated the work. The core change is a two‑task split of command dispatch: the decision of *what a line is and where it runs* now happens on the polling task, and only lines that genuinely need the protocol/planner context cross to `protocol_main_loop`.

## Background

An M5Dial / FluidDial pendant on a UART channel drove FluidNC to an out‑of‑memory abort during SD jobs:

* FluidDial's `service_config_requests()` retries an unanswered `$/...` config query every 500 ms, indefinitely.
* During a job, `polling_loop` only line‑polls `Job::channel()`. Every non‑job channel's `Channel::_queue` (a `std::deque<uint8_t>`) accumulates the retry traffic and is never drained → ~2 KB/min of heap loss → `std::bad_alloc` → terminate.

Bounding `_queue` stops the crash, but the deeper issue is that `protocol_main_loop` is the **single consumer** of the input‑line handoff and it blocks inside `mc_line`'s `plan_check_full_buffer()` spin while the planner is full. Anything behind it in the handoff — a status query, a config probe — waited *seconds* during a job (`$G` from the console took 12 s in testing). No polling‑schedule tweak fixes that; the consumer itself is the bottleneck.

## The change, in pieces

| commit | what |
|---|---|
| **Use atomic operations to make the GCode line handoff safe** | `activeChannel`/`activeLine` were shared unsynchronized between the polling task (core 0) and `protocol_main_loop` (core 1). Make the handoff `std::atomic` with release/acquire. |
| **Bound `Channel::_queue`** | Cap at `4*maxLine`. When full at a line boundary, discard the whole incoming line through its newline (a line already in progress finishes) — the queue never holds a partial line. One `log_debug` per overflow episode. **This is the actual OOM fix.** |
| **Lock the Job stack against cross‑core mutation** | `job` is pushed by `nest()` on the protocol task and popped by `unnest()`/`abort()` on the polling task with no synchronization. Add an internal mutex; `channel()`/`source()` return `nullptr` when idle instead of dereferencing `back()` on an empty vector; `leader_channel()` for a locked read. |
| **Split the command "synchronous" flag into context + buffer‑drain** | `Command::synchronous()` conflated "must run on the protocol task" with "drain the planner first" — they differ for `$J`. Replace with `needs_protocol_context()` and `drains_buffer()`. New `ReportCommand` for pure observers (`$G $$ $S $T $CD $#` …), so they no longer needlessly wait for buffered motion. Also: run the per‑command state guard **before** the buffer sync (`Command::disallowed()`), so a command that's going to be rejected doesn't drain the planner first. |
| **Make `$X` a no‑op outside Alarm state** | `disable_alarm_lock()` ran the `_after_unlock` macro unconditionally; issued during a job that nested a macro job into the middle of the program. |
| **Two‑task command dispatch** | The single‑slot handoff becomes a `cmd_queue` (`LineItem{channel,line}`, depth 1, same flow control). `execute_line()` gains `on_protocol_task`; `line_needs_protocol_context()` classifies a line once against `Command::List`. On the polling task: an interloper's line that needs context is rejected (`Error::AnotherInterfaceBusy`), one that doesn't runs inline via `run_command_inline()`, everything else defers to `cmd_queue` (`Error::Deferred`, new). `polling_loop` now also services non‑job channels every pass during a job, so their reads execute in ~1 ms regardless of planner depth. Also fixes a job‑channel `processing_ref` underflow. |
| **Allow more informational commands from run state** | Loosen `$$ $L $S $SC $CMD $# $I $GS` to `anyState` and move `$MU0/$MU1/$MC`, `$LM..$LV`, `$SA` to `ReportCommand` — all deliberately fine from an interloper. `$V` (NVS/FLASH contention) and `$Limits` (spins until feedhold) stay restricted. |
| **Classify WebCommands** | `WebCommand` now defaults `needs_protocol_context() == true` (filesystem, NVS, network, restart). New `WebReportCommand` for the read‑only status set: `ESP420`, `ESP400`, `ESP0`/`ESP`, `ESP800`, `ESP111`, `wifi/status`, `Ethernet/Status`. `line_needs_protocol_context()` looks `[ESPxxx]` up by name. |

## Runtime behavior

| line source | needs protocol context (gcode, `$H`, `$J`, writes, FS/NVS…) | no context (`$G`, `$$`, `$/axes/...`, `ESP420`, …) |
|---|---|---|
| the job's own channel | protocol task, ordered | protocol task, ordered |
| a different channel while a job runs | `error:120` | runs inline on the polling task, ~1 ms |
| no job running | protocol task (unchanged) | protocol task (unchanged) |

The per‑command state guard (`_cmdChecker`) still applies as a second layer everywhere.

## Testing

Bench + hardware (ESP32‑S3, WiFi, SD job, FluidDial pendant on UART):

* No `Channel::_queue` drops during a job — the pendant's `$/...` probes are answered on the next `polling_loop` pass instead of after the move buffer drains.
* Console informational commands, including a full `$CD` dump, stay responsive mid‑job.
* Builds clean for `wifi_s3` and `wifi`.

## Known limitations / follow‑ups

* `run_command_inline()` runs on the polling task and must not block — a `ReportCommand` streaming to a back‑pressured `WSChannel` could stall realtime‑char handling. Not observed in practice; a dedicated command task or an interloper reject for large dumps would close it.
* `polling_loop` now calls `pollChannels(buf)` every pass during a job (~1 ms) — cheap, but a throttle counter is a candidate if overhead shows.
* Config‑tree reads on the polling task still race a job‑file `$/x=NNN` write on the protocol task — accepted for numeric scalars (torn read = old‑or‑new), a `config_mutex` on just the command paths would remove it.
* `[ESP…]` from the WebUI console still runs synchronously on the webclient task (unchanged); only `[ESP…]` over serial/telnet/pendant goes through the new path.

## Behavior changes reviewers should note

* `$$ $L $S $SC $CMD $# $I $GS` now work from any channel in `Cycle`/`Hold` (were `IdleError`).
* `$X` from `Idle` no longer runs the `_after_unlock` macro.
* `ReportCommand`s no longer call `protocol_buffer_synchronize()` before running (they never needed to).
* Pasting g‑code into a non‑job channel during a job now returns `error:120` per line instead of silently buffering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
