### PR TITLE
channels: AllChannels::kill() reports queue-full failure

### DIFF
--- a/FluidNC/src/Serial.cpp
+++ b/FluidNC/src/Serial.cpp
@@ -225,7 +225,7 @@ Channel* AllChannels::poll(char* line) {
     reap_channels();
 
     Channel* deadChannel;
-    while (xQueueReceive(_killQueue, &deadChannel, 0)) {
+    while (_killQueue && xQueueReceive(_killQueue, &deadChannel, 0)) {
         deadChannel->begin_closing();
         deregistration(deadChannel);
         _zombies.push_back(deadChannel);

--- a/FluidNC/src/Serial.cpp
+++ b/FluidNC/src/Serial.cpp
@@ -117,10 +117,8 @@ void AllChannels::ready() {
     }
 }
 
-void AllChannels::kill(Channel* channel) {
-    if (_killQueue) {
-        xQueueSend(_killQueue, &channel, pdMS_TO_TICKS(10));
-    }
+bool AllChannels::kill(Channel* channel) {
+    return _killQueue && xQueueSend(_killQueue, &channel, pdMS_TO_TICKS(10)) == pdTRUE;
 }
 
 void AllChannels::registration(Channel* channel) {

--- a/FluidNC/src/Serial.h
+++ b/FluidNC/src/Serial.h
@@ -38,8 +38,8 @@ public:
     // telnet and HTTP-command channels being torn down between two poll cycles.
     AllChannels() : Channel("all") { _killQueue = xQueueCreate(32, sizeof(Channel*)); }
 
-    // Queues a channel for deletion by the polling task.  Returns false if the
-    // kill queue was full and the channel could NOT be queued; the caller still
+    // Queues a channel for deletion by the polling task.  Returns false if it
+    // could not be queued (kill queue full, or never created); the caller still
     // owns the channel in that case and must retry.
     bool kill(Channel* channel);
 

--- a/FluidNC/src/Serial.h
+++ b/FluidNC/src/Serial.h
@@ -34,9 +34,14 @@ class AllChannels : public Channel {
     std::vector<Channel*> snapshot_channels();
 
 public:
-    AllChannels() : Channel("all") { _killQueue = xQueueCreate(16, sizeof(Channel*)); }
+    // Depth covers the worst realistic burst: every WebSocket client plus the
+    // telnet and HTTP-command channels being torn down between two poll cycles.
+    AllChannels() : Channel("all") { _killQueue = xQueueCreate(32, sizeof(Channel*)); }
 
-    void kill(Channel* channel);
+    // Queues a channel for deletion by the polling task.  Returns false if the
+    // kill queue was full and the channel could NOT be queued; the caller still
+    // owns the channel in that case and must retry.
+    bool kill(Channel* channel);
 
     void registration(Channel* channel);
     void deregistration(Channel* channel);

--- a/FluidNC/src/WebUI/TelnetClient.cpp
+++ b/FluidNC/src/WebUI/TelnetClient.cpp
@@ -45,10 +45,12 @@ namespace WebUI {
     }
 
     void TelnetClient::closeOnDisconnectLocked() {
-        if (!_wifiClient->connected()) {
-            bool expected = false;
-            if (_disconnected.compare_exchange_strong(expected, true)) {
-                allChannels.kill(this);
+        if (!_wifiClient->connected() && !_disconnected.load()) {
+            // Latch _disconnected only once the channel is actually queued for
+            // deletion.  If the kill queue is momentarily full, a later call
+            // (this runs from every read/peek/poll path) will retry.
+            if (allChannels.kill(this)) {
+                _disconnected.store(true);
             }
         }
     }

--- a/FluidNC/src/WebUI/WSChannel.cpp
+++ b/FluidNC/src/WebUI/WSChannel.cpp
@@ -263,7 +263,12 @@ namespace WebUI {
                 wsChannel->flushRx();
 
                 _wsChannels.erase(it);
-                allChannels.kill(wsChannel);
+                if (!allChannels.kill(wsChannel)) {
+                    // Queue full and the poll task did not drain it in time.  The
+                    // channel is already deactivated and off the list; it will not
+                    // be polled again, but its memory is not reclaimed here.
+                    log_error_to(Console, "WebSocket kill queue full, leaking cid#" << num);
+                }
                 break;
             }
         }

--- a/FluidNC/src/WebUI/WSChannel.cpp
+++ b/FluidNC/src/WebUI/WSChannel.cpp
@@ -264,10 +264,11 @@ namespace WebUI {
 
                 _wsChannels.erase(it);
                 if (!allChannels.kill(wsChannel)) {
-                    // Queue full and the poll task did not drain it in time.  The
-                    // channel is already deactivated and off the list; it will not
-                    // be polled again, but its memory is not reclaimed here.
-                    log_error_to(Console, "WebSocket kill queue full, leaking cid#" << num);
+                    // Could not queue the channel for deletion (kill queue full,
+                    // or never created).  It is deactivated and off _wsChannels,
+                    // but still registered with AllChannels - it will keep being
+                    // polled (returning nothing) and its memory is not reclaimed.
+                    log_error_to(Console, "Could not queue WebSocket cid#" << num << " for deletion, leaking it");
                 }
                 break;
             }

--- a/FluidNC/src/WebUI/WebUIServer.cpp
+++ b/FluidNC/src/WebUI/WebUIServer.cpp
@@ -751,9 +751,10 @@ namespace WebUI {
             // We rely on AsyncWebServer to take care of that
             request->onDisconnect([webClient]() {
                 webClient->detachWS();
-                allChannels.kill(webClient);
-                // Should not delete, kill() takes care of that
-                //delete webClient;
+                // Should not delete here, kill() takes care of that once no refs remain
+                if (!allChannels.kill(webClient)) {
+                    log_error("WebClient kill queue full, leaking HTTP command channel");
+                }
             });
         } else
             response = request->beginResponse(200, "", "");

--- a/FluidNC/src/WebUI/WebUIServer.cpp
+++ b/FluidNC/src/WebUI/WebUIServer.cpp
@@ -753,7 +753,7 @@ namespace WebUI {
                 webClient->detachWS();
                 // Should not delete here, kill() takes care of that once no refs remain
                 if (!allChannels.kill(webClient)) {
-                    log_error("WebClient kill queue full, leaking HTTP command channel");
+                    log_error("Could not queue HTTP command channel for deletion, leaking it");
                 }
             });
         } else


### PR DESCRIPTION
`AllChannels::kill()` queues a channel for the poll task to reap. It
returned `void` and silently discarded the channel if the 16-entry
`_killQueue` was full, leaking the channel and leaving a stale pointer in
the registry.

- `kill()` now returns whether the channel was actually queued.
- Kill queue depth raised 16 -> 32 to cover a worst-case teardown burst
  (every WebSocket client plus the telnet and HTTP-command channels)
  between two poll cycles. Cost: 64 bytes.
- `TelnetClient` latches `_disconnected` only on a successful `kill()`, so
  a transient queue-full is retried from the next read/peek/poll call.
- The two genuinely one-shot disconnect paths (`WSChannels::removeChannel`
  and the `WebClient` `onDisconnect` lambda) now log loudly instead of
  failing silently.

This does not add a deferred-retry mechanism for those one-shot paths -- a
full 32-deep queue plus a poll task starved for >10 ms would still leak,
but visibly now. A proper deferred-kill list is follow-up work.

Built for `wifi`.

---

Part of a set of small, independently reviewable PRs carved out of the
ownership / exception-safety work in #1796 by @WaldemarFech, rebased onto
current `main`:

- #1812 &mdash; WebUI: make WS_EVT_CONNECT exception-safe
- #1813 &mdash; channels: AllChannels::kill() reports queue-full failure (this PR)
- #1814 &mdash; WebUI: reap orphaned WebSocket channels

They are mutually independent and can be merged in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
