### PR TITLE
WebUI: reap orphaned WebSocket channels

### DIFF
--- a/FluidNC/src/WebUI/WSChannel.cpp
+++ b/FluidNC/src/WebUI/WSChannel.cpp
@@ -360,7 +360,7 @@ namespace WebUI {
     // (often an RST with no FIN) but the WS_EVT_DISCONNECT event that would have
     // called removeChannel() never arrived, orphaning the channel and its heap.
     // The connection check means a live-but-idle client is never touched.
-    void WSChannels::reapStaleChannels(uint32_t stale_ms) {
+    void WSChannels::reapStaleChannels(AsyncWebSocket* server, uint32_t stale_ms) {
         const uint32_t now = millis();
 
         // Collect candidates into a fixed stack buffer so nothing is allocated
@@ -384,7 +384,7 @@ namespace WebUI {
         }
 
         for (size_t i = 0; i < candidateCount; ++i) {
-            if (get_client(_server, candidateIds[i])) {
+            if (get_client(server, candidateIds[i])) {
                 continue;  // still connected at the WS layer - leave it alone
             }
             log_debug_to(Console, "Reaping orphaned WebSocket cid#" << candidateIds[i]);

--- a/FluidNC/src/WebUI/WSChannel.cpp
+++ b/FluidNC/src/WebUI/WSChannel.cpp
@@ -363,29 +363,32 @@ namespace WebUI {
     void WSChannels::reapStaleChannels(uint32_t stale_ms) {
         const uint32_t now = millis();
 
-        // Reserve before taking the lock so the push_back loop below cannot
-        // allocate (and therefore cannot throw) while ws_channels_mutex is held.
-        // Candidates are always a subset of _wsChannels, and a channel added
-        // after this snapshot is by definition not yet stale, so this capacity
-        // is sufficient.
-        std::vector<objnum_t> candidateIds;
-        candidateIds.reserve(_wsChannels.size() + 2);
+        // Collect candidates into a fixed stack buffer so nothing is allocated
+        // (and nothing can throw) while ws_channels_mutex is held, and reap only
+        // a few per call: an orphan is rare, so clearing a handful per poll
+        // keeps us well under the AllChannels kill-queue depth.
+        static constexpr size_t maxPerCycle = 4;
+        objnum_t                candidateIds[maxPerCycle];
+        size_t                  candidateCount = 0;
         {
             xSemaphoreTake(ws_channels_mutex, portMAX_DELAY);
             for (auto const wsChannel : _wsChannels) {
-                if ((now - wsChannel->lastActivityMs()) >= stale_ms && candidateIds.size() < candidateIds.capacity()) {
-                    candidateIds.push_back(wsChannel->id());
+                if (candidateCount >= maxPerCycle) {
+                    break;
+                }
+                if ((now - wsChannel->lastActivityMs()) >= stale_ms) {
+                    candidateIds[candidateCount++] = wsChannel->id();
                 }
             }
             xSemaphoreGive(ws_channels_mutex);
         }
 
-        for (auto const channelId : candidateIds) {
-            if (get_client(_server, channelId)) {
+        for (size_t i = 0; i < candidateCount; ++i) {
+            if (get_client(_server, candidateIds[i])) {
                 continue;  // still connected at the WS layer - leave it alone
             }
-            log_debug_to(Console, "Reaping orphaned WebSocket cid#" << channelId);
-            removeChannel(channelId);
+            log_debug_to(Console, "Reaping orphaned WebSocket cid#" << candidateIds[i]);
+            removeChannel(candidateIds[i]);
         }
     }
 

--- a/FluidNC/src/WebUI/WSChannel.cpp
+++ b/FluidNC/src/WebUI/WSChannel.cpp
@@ -363,11 +363,17 @@ namespace WebUI {
     void WSChannels::reapStaleChannels(uint32_t stale_ms) {
         const uint32_t now = millis();
 
+        // Reserve before taking the lock so the push_back loop below cannot
+        // allocate (and therefore cannot throw) while ws_channels_mutex is held.
+        // Candidates are always a subset of _wsChannels, and a channel added
+        // after this snapshot is by definition not yet stale, so this capacity
+        // is sufficient.
         std::vector<objnum_t> candidateIds;
+        candidateIds.reserve(_wsChannels.size() + 2);
         {
             xSemaphoreTake(ws_channels_mutex, portMAX_DELAY);
             for (auto const wsChannel : _wsChannels) {
-                if ((now - wsChannel->lastActivityMs()) >= stale_ms) {
+                if ((now - wsChannel->lastActivityMs()) >= stale_ms && candidateIds.size() < candidateIds.capacity()) {
                     candidateIds.push_back(wsChannel->id());
                 }
             }

--- a/FluidNC/src/WebUI/WSChannel.cpp
+++ b/FluidNC/src/WebUI/WSChannel.cpp
@@ -35,7 +35,7 @@ namespace WebUI {
     }
 
     WSChannel::WSChannel(AsyncWebSocket* server, objnum_t clientNum, std::string session) :
-        Channel("websocket"), _server(server), _clientNum(clientNum), _session(session) {
+        Channel("websocket"), _server(server), _clientNum(clientNum), _session(session), _lastActivityMs(millis()) {
         setReportInterval(200);  // we will set automatic reporting on by default for now
         if (auto client = get_client(_server, _clientNum)) {
             client->setCloseClientOnQueueFull(false);
@@ -355,6 +355,34 @@ namespace WebUI {
         }
     }
 
+    // Reap WSChannels that have been silent for stale_ms AND whose underlying
+    // AsyncWebSocketClient is no longer connected - i.e. the socket went away
+    // (often an RST with no FIN) but the WS_EVT_DISCONNECT event that would have
+    // called removeChannel() never arrived, orphaning the channel and its heap.
+    // The connection check means a live-but-idle client is never touched.
+    void WSChannels::reapStaleChannels(uint32_t stale_ms) {
+        const uint32_t now = millis();
+
+        std::vector<objnum_t> candidateIds;
+        {
+            xSemaphoreTake(ws_channels_mutex, portMAX_DELAY);
+            for (auto const wsChannel : _wsChannels) {
+                if ((now - wsChannel->lastActivityMs()) >= stale_ms) {
+                    candidateIds.push_back(wsChannel->id());
+                }
+            }
+            xSemaphoreGive(ws_channels_mutex);
+        }
+
+        for (auto const channelId : candidateIds) {
+            if (get_client(_server, channelId)) {
+                continue;  // still connected at the WS layer - leave it alone
+            }
+            log_debug_to(Console, "Reaping orphaned WebSocket cid#" << channelId);
+            removeChannel(channelId);
+        }
+    }
+
     void WSChannels::handleEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len) {
         uint32_t num = client->id();
         _server      = server;
@@ -409,10 +437,17 @@ namespace WebUI {
                     }
                 }
             } break;
+            case WS_EVT_PING:
+            case WS_EVT_PONG: {
+                if (auto wsChannel = getWSChannel(num, {})) {
+                    wsChannel->noteActivity(millis());
+                }
+            } break;
             case WS_EVT_DATA: {
                 AwsFrameInfo* info      = (AwsFrameInfo*)arg;
                 auto          wsChannel = getWSChannel(num, {});
                 if (wsChannel) {
+                    wsChannel->noteActivity(millis());
                     if (info->opcode == WS_TEXT) {
                         //data[len]=0; // !!! this should not be safe? but was there before,
                         // will copy to a std::string of specified length to be on the safe side

--- a/FluidNC/src/WebUI/WSChannel.h
+++ b/FluidNC/src/WebUI/WSChannel.h
@@ -42,6 +42,12 @@ namespace WebUI {
         void        active(bool is_active);
         std::string session() { return _session; };
 
+        // Liveness: bumped on every inbound frame (data, ping, pong).  A socket
+        // that is RST without a FIN, or a sleeping browser tab, stops producing
+        // these; reapStaleChannels() closes it once it has been silent too long.
+        void     noteActivity(uint32_t now) { _lastActivityMs = now; }
+        uint32_t lastActivityMs() const { return _lastActivityMs; }
+
     private:
         AsyncWebSocket* _server;
         objnum_t        _clientNum;
@@ -57,6 +63,7 @@ namespace WebUI {
         std::string               _output_line;
         uint32_t                  _output_pending_since = 0;
         unsigned long             _last_queue_full      = 0;
+        uint32_t                  _lastActivityMs       = 0;
 
         // may_block=false: if the client send queue is full, give up rather than
         // spin (used from pollLine(), which runs under AllChannels' poll mutex).
@@ -87,6 +94,10 @@ namespace WebUI {
         static bool sendError(uint32_t pageid, std::string error, std::string session);
         static void closeSessionChannels(const std::string& session, objnum_t exceptId = 0);
         static void sendPing();
+
+        // Close and remove any channel with no inbound traffic for stale_ms.
+        // Safe to call from the WebUI poll task alongside sendPing().
+        static void reapStaleChannels(uint32_t stale_ms);
         static void handleEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len);
 
         static void showChannels();

--- a/FluidNC/src/WebUI/WSChannel.h
+++ b/FluidNC/src/WebUI/WSChannel.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <atomic>
 #include <list>
 #include <map>
 #include <ESPAsyncWebServer.h>
@@ -42,11 +43,13 @@ namespace WebUI {
         void        active(bool is_active);
         std::string session() { return _session; };
 
-        // Liveness: bumped on every inbound frame (data, ping, pong).  A socket
-        // that is RST without a FIN, or a sleeping browser tab, stops producing
-        // these; reapStaleChannels() closes it once it has been silent too long.
-        void     noteActivity(uint32_t now) { _lastActivityMs = now; }
-        uint32_t lastActivityMs() const { return _lastActivityMs; }
+        // Time (millis()) of the last inbound frame - data, ping or pong.  Set
+        // from the AsyncWebSocket event task and read from the WebUI poll task,
+        // hence atomic.  reapStaleChannels() uses it only as a debounce: a
+        // channel is removed when it is BOTH silent this long AND already
+        // disconnected, so this is not an idle timeout on live connections.
+        void     noteActivity(uint32_t now) { _lastActivityMs.store(now, std::memory_order_relaxed); }
+        uint32_t lastActivityMs() const { return _lastActivityMs.load(std::memory_order_relaxed); }
 
     private:
         AsyncWebSocket* _server;
@@ -63,7 +66,7 @@ namespace WebUI {
         std::string               _output_line;
         uint32_t                  _output_pending_since = 0;
         unsigned long             _last_queue_full      = 0;
-        uint32_t                  _lastActivityMs       = 0;
+        std::atomic<uint32_t>     _lastActivityMs { 0 };
 
         // may_block=false: if the client send queue is full, give up rather than
         // spin (used from pollLine(), which runs under AllChannels' poll mutex).

--- a/FluidNC/src/WebUI/WSChannel.h
+++ b/FluidNC/src/WebUI/WSChannel.h
@@ -100,7 +100,7 @@ namespace WebUI {
 
         // Close and remove any channel with no inbound traffic for stale_ms.
         // Safe to call from the WebUI poll task alongside sendPing().
-        static void reapStaleChannels(uint32_t stale_ms);
+        static void reapStaleChannels(AsyncWebSocket* server, uint32_t stale_ms);
         static void handleEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len);
 
         static void showChannels();

--- a/FluidNC/src/WebUI/WebUIServer.cpp
+++ b/FluidNC/src/WebUI/WebUIServer.cpp
@@ -1474,6 +1474,10 @@ namespace WebUI {
             if (_socket_server) {
                 _socket_server->cleanupClients(WEBUI_MAX_WS_CLIENTS);
                 WSChannels::sendPing();
+                // Clean up channels whose socket died without a DISCONNECT event.
+                // Only silent-AND-disconnected channels are reaped, so the 60 s
+                // window is just debounce against a slow initial handshake.
+                WSChannels::reapStaleChannels(60 * 1000);
             }
             start_time = millis();
         }

--- a/FluidNC/src/WebUI/WebUIServer.cpp
+++ b/FluidNC/src/WebUI/WebUIServer.cpp
@@ -1477,7 +1477,7 @@ namespace WebUI {
                 // Clean up channels whose socket died without a DISCONNECT event.
                 // Only silent-AND-disconnected channels are reaped, so the 60 s
                 // window is just debounce against a slow initial handshake.
-                WSChannels::reapStaleChannels(60 * 1000);
+                WSChannels::reapStaleChannels(_socket_server, 60 * 1000);
             }
             start_time = millis();
         }


### PR DESCRIPTION
If a WebSocket socket dies without delivering `WS_EVT_DISCONNECT` (e.g. an
RST with no FIN), its `WSChannel` is never removed: it stays registered,
keeps its line-assembly buffer, and holds a client slot indefinitely.

This timestamps each `WSChannel` on every inbound frame (`WS_EVT_DATA`,
`WS_EVT_PING`, `WS_EVT_PONG`). From the existing 10 s WebUI poll,
`reapStaleChannels()` removes a channel only when it has been silent past a
60 s debounce window **and** its `AsyncWebSocketClient` is no longer
connected -- i.e. the socket is confirmed gone but the disconnect event
never arrived.

The "already disconnected" check is deliberate: a live-but-idle client is
never touched, so there is no idle-timeout behaviour change. This is
narrower than the corresponding change in #1796, which used a plain idle
timeout.

Built for `wifi`.

---

Part of a set of small, independently reviewable PRs carved out of the
ownership / exception-safety work in #1796 by @WaldemarFech, rebased onto
current `main`:

- #1812 &mdash; WebUI: make WS_EVT_CONNECT exception-safe
- #1813 &mdash; channels: AllChannels::kill() reports queue-full failure
- #1814 &mdash; WebUI: reap orphaned WebSocket channels (this PR)

They are mutually independent and can be merged in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
