### PR TITLE
ESP32: Fix guard disabling the task-watchdog layer

### DIFF
--- a/FluidNC/esp32/wdt.cpp
+++ b/FluidNC/esp32/wdt.cpp
@@ -7,6 +7,15 @@
 #include "Config.h"
 #include <esp_idf_version.h>
 
+// ESP-IDF v5 names this CONFIG_ESP_TASK_WDT_EN; v4.x names it
+// CONFIG_ESP_TASK_WDT.  Testing only the v5 name leaves every function in this
+// file compiled to an empty body on v4.x, so feed_watchdog() feeds nothing and
+// add_watchdog_to_task() subscribes nothing, while the task watchdog itself is
+// enabled and will panic on expiry.  Accept either name.
+#if defined(CONFIG_ESP_TASK_WDT_EN) || defined(CONFIG_ESP_TASK_WDT)
+#    define FLUIDNC_TASK_WDT_ENABLED 1
+#endif
+
 static TaskHandle_t wdt_task_handle = nullptr;
 
 static void get_wdt_task_handle() {
@@ -32,7 +41,7 @@ static void get_wdt_task_handle() {
 
 // cppcheck-suppress unusedFunction
 void enable_core0_WDT() {
-#ifdef CONFIG_ESP_TASK_WDT_EN
+#ifdef FLUIDNC_TASK_WDT_ENABLED
     if (!wdt_task_handle) {
         return;
     }
@@ -45,7 +54,7 @@ void enable_core0_WDT() {
 
 // cppcheck-suppress unusedFunction
 void disable_core0_WDT() {
-#ifdef CONFIG_ESP_TASK_WDT_EN
+#ifdef FLUIDNC_TASK_WDT_ENABLED
     get_wdt_task_handle();
     if (!wdt_task_handle) {
         return;
@@ -58,7 +67,7 @@ void disable_core0_WDT() {
 }
 
 void feed_watchdog() {
-#ifdef CONFIG_ESP_TASK_WDT_EN
+#ifdef FLUIDNC_TASK_WDT_ENABLED
     // esp_task_wdt_reset() logs an error ("task not found") if the current
     // task isn't subscribed to the TWDT, instead of silently no-opping.
     // FluidNC's watchdog is opt-in (see add_watchdog_to_task()), and several
@@ -74,7 +83,7 @@ void feed_watchdog() {
 }
 
 void add_watchdog_to_task() {
-#ifdef CONFIG_ESP_TASK_WDT_EN
+#ifdef FLUIDNC_TASK_WDT_ENABLED
     esp_task_wdt_add(NULL);  // NULL means current task
 #endif
 }


### PR DESCRIPTION
### The problem

Every function in `FluidNC/esp32/wdt.cpp` is guarded by `CONFIG_ESP_TASK_WDT_EN`.
That is the ESP-IDF **v5** name for the setting. On IDF 4.x, which the current
`framework-arduinoespressif32` package uses, the symbol is `CONFIG_ESP_TASK_WDT`,
so none of the guards are satisfied and every function compiles to an empty body.

From the linked image, before this change:

```
feed_watchdog:         entry / retw     ← feeds nothing
add_watchdog_to_task:  entry / retw     ← subscribes nothing
enable_core0_WDT:      entry / retw
disable_core0_WDT:     entry / retw
```

The watchdog itself is very much enabled — the same sdkconfig has
`CONFIG_ESP_TASK_WDT_TIMEOUT_S 5` and `CONFIG_ESP_TASK_WDT_PANIC` — so the timer
runs while FluidNC's only means of answering it does nothing. A task that
subscribes itself, such as `async_tcp`, still trips it and panics the board, and
the `feed_watchdog()` calls placed around the code to prevent exactly that have no
effect.

I ran into this chasing repeated `Task watchdog got triggered … async_tcp`
reboots during SD card access. Several rounds of adding `feed_watchdog()` calls
changed nothing, because none of them were compiled in.

### The change

Accept either spelling. One `#if defined(A) || defined(B)` and the four guards
renamed to the internal macro.

After, from the same image:

```
feed_watchdog:
    entry
    call8  esp_task_wdt_status
    call8  esp_task_wdt_reset
    retw
```

### Worth reviewing carefully

This turns supervision back on rather than adding anything new.
`add_watchdog_to_task()` is called by the polling and protocol tasks, which have
therefore not actually been supervised on IDF 4.x. They will be after this.

Both feed regularly — `polling_loop()` in its main loop, `protocol_main_loop()`
via `protocol_handle_events()` — so this should be correct. But any path in those
tasks that blocks longer than the five second timeout will now be caught where it
previously passed unnoticed, and that is a behaviour change on hardware I cannot
survey. I would rather flag it than have it surface as a surprise.

Builds on `wifi`, `noradio` and `bt`; unit tests pass.
