### PR TITLE
esp32: keep state_is() and the spindle ISR dispatch out of flash

### DIFF
--- a/FluidNC/src/Spindles/10vSpindle.cpp
+++ b/FluidNC/src/Spindles/10vSpindle.cpp
@@ -98,4 +98,14 @@ namespace Spindles {
     namespace {
         SpindleFactory::InstanceBuilder<_10v> registration("10V");
     }
+
+    // Called from the step ISR in place of a virtual dispatch, which would have
+    // to read this class's vtable out of flash.  IRAM_ATTR, and the qualified
+    // call keeps it non-virtual.
+    static void IRAM_ATTR _10v_speed_thunk(Spindle* s, uint32_t dev_speed) {
+        static_cast<_10v*>(s)->_10v::setSpeedfromISR(dev_speed);
+    }
+    Spindle::IsrSpeedFn _10v::isr_speed_fn() {
+        return _10v_speed_thunk;
+    }
 }

--- a/FluidNC/src/Spindles/10vSpindle.h
+++ b/FluidNC/src/Spindles/10vSpindle.h
@@ -29,6 +29,7 @@ namespace Spindles {
         void init() override;
         void config_message() override;
         void setSpeedfromISR(uint32_t dev_speed) override;
+        IsrSpeedFn isr_speed_fn() override;
 
         void deinit() override;
 

--- a/FluidNC/src/Spindles/DacSpindle.cpp
+++ b/FluidNC/src/Spindles/DacSpindle.cpp
@@ -65,5 +65,15 @@ namespace Spindles {
     namespace {
         SpindleFactory::InstanceBuilder<Dac> registration("DAC");
     }
+
+    // Called from the step ISR in place of a virtual dispatch, which would have
+    // to read this class's vtable out of flash.  IRAM_ATTR, and the qualified
+    // call keeps it non-virtual.
+    static void IRAM_ATTR dac_speed_thunk(Spindle* s, uint32_t dev_speed) {
+        static_cast<Dac*>(s)->Dac::setSpeedfromISR(dev_speed);
+    }
+    Spindle::IsrSpeedFn Dac::isr_speed_fn() {
+        return dac_speed_thunk;
+    }
 }
 #endif

--- a/FluidNC/src/Spindles/DacSpindle.h
+++ b/FluidNC/src/Spindles/DacSpindle.h
@@ -32,6 +32,7 @@ namespace Spindles {
         void init() override;
         void config_message() override;
         void setSpeedfromISR(uint32_t dev_speed) override;
+        IsrSpeedFn isr_speed_fn() override;
 
         // Configuration handlers: no fields of its own -- exists so this class
         // has its own real group() for the doc generator to find (see

--- a/FluidNC/src/Spindles/HBridgeSpindle.cpp
+++ b/FluidNC/src/Spindles/HBridgeSpindle.cpp
@@ -130,4 +130,14 @@ namespace Spindles {
     namespace {
         SpindleFactory::InstanceBuilder<HBridge> registration("HBridge");
     }
+
+    // Called from the step ISR in place of a virtual dispatch, which would have
+    // to read this class's vtable out of flash.  IRAM_ATTR, and the qualified
+    // call keeps it non-virtual.
+    static void IRAM_ATTR hbridge_speed_thunk(Spindle* s, uint32_t dev_speed) {
+        static_cast<HBridge*>(s)->HBridge::setSpeedfromISR(dev_speed);
+    }
+    Spindle::IsrSpeedFn HBridge::isr_speed_fn() {
+        return hbridge_speed_thunk;
+    }
 }

--- a/FluidNC/src/Spindles/HBridgeSpindle.h
+++ b/FluidNC/src/Spindles/HBridgeSpindle.h
@@ -43,6 +43,7 @@ namespace Spindles {
 
         void init() override;
         void setSpeedfromISR(uint32_t dev_speed) override;
+        IsrSpeedFn isr_speed_fn() override;
         void setState(SpindleState state, SpindleSpeed speed) override;
         void config_message() override;
         // Configuration handlers:

--- a/FluidNC/src/Spindles/NullSpindle.cpp
+++ b/FluidNC/src/Spindles/NullSpindle.cpp
@@ -31,4 +31,14 @@ namespace Spindles {
     namespace {
         SpindleFactory::InstanceBuilder<Null> registration("NoSpindle");
     }
+
+    // Called from the step ISR in place of a virtual dispatch, which would have
+    // to read this class's vtable out of flash.  IRAM_ATTR, and the qualified
+    // call keeps it non-virtual.
+    static void IRAM_ATTR null_speed_thunk(Spindle* s, uint32_t dev_speed) {
+        static_cast<Null*>(s)->Null::setSpeedfromISR(dev_speed);
+    }
+    Spindle::IsrSpeedFn Null::isr_speed_fn() {
+        return null_speed_thunk;
+    }
 }

--- a/FluidNC/src/Spindles/NullSpindle.h
+++ b/FluidNC/src/Spindles/NullSpindle.h
@@ -24,6 +24,7 @@ namespace Spindles {
 
         void init() override;
         void setSpeedfromISR(uint32_t dev_speed) override;
+        IsrSpeedFn isr_speed_fn() override;
         void setState(SpindleState state, SpindleSpeed speed) override;
         void config_message() override;
 

--- a/FluidNC/src/Spindles/OnOffSpindle.cpp
+++ b/FluidNC/src/Spindles/OnOffSpindle.cpp
@@ -79,4 +79,14 @@ namespace Spindles {
     namespace {
         SpindleFactory::InstanceBuilder<OnOff> registration("OnOff");
     }
+
+    // Called from the step ISR in place of a virtual dispatch, which would have
+    // to read this class's vtable out of flash.  IRAM_ATTR, and the qualified
+    // call keeps it non-virtual.
+    static void IRAM_ATTR onoff_speed_thunk(Spindle* s, uint32_t dev_speed) {
+        static_cast<OnOff*>(s)->OnOff::setSpeedfromISR(dev_speed);
+    }
+    Spindle::IsrSpeedFn OnOff::isr_speed_fn() {
+        return onoff_speed_thunk;
+    }
 }

--- a/FluidNC/src/Spindles/OnOffSpindle.h
+++ b/FluidNC/src/Spindles/OnOffSpindle.h
@@ -47,6 +47,7 @@ namespace Spindles {
         void init() override;
 
         void setSpeedfromISR(uint32_t dev_speed) override;
+        IsrSpeedFn isr_speed_fn() override;
         void setState(SpindleState state, SpindleSpeed speed) override;
         void config_message() override;
 

--- a/FluidNC/src/Spindles/PWMSpindle.cpp
+++ b/FluidNC/src/Spindles/PWMSpindle.cpp
@@ -111,4 +111,14 @@ namespace Spindles {
     namespace {
         SpindleFactory::InstanceBuilder<PWM> registration("PWM");
     }
+
+    // Called from the step ISR in place of a virtual dispatch, which would have
+    // to read this class's vtable out of flash.  IRAM_ATTR, and the qualified
+    // call keeps it non-virtual.
+    static void IRAM_ATTR pwm_speed_thunk(Spindle* s, uint32_t dev_speed) {
+        static_cast<PWM*>(s)->PWM::setSpeedfromISR(dev_speed);
+    }
+    Spindle::IsrSpeedFn PWM::isr_speed_fn() {
+        return pwm_speed_thunk;
+    }
 }

--- a/FluidNC/src/Spindles/PWMSpindle.h
+++ b/FluidNC/src/Spindles/PWMSpindle.h
@@ -28,6 +28,7 @@ namespace Spindles {
 
         void init() override;
         void setSpeedfromISR(uint32_t dev_speed) override;
+        IsrSpeedFn isr_speed_fn() override;
         void setState(SpindleState state, SpindleSpeed speed) override;
         void config_message() override;
         // Configuration handlers:

--- a/FluidNC/src/Spindles/PlasmaSpindle.cpp
+++ b/FluidNC/src/Spindles/PlasmaSpindle.cpp
@@ -122,4 +122,14 @@ namespace Spindles {
     namespace {
         SpindleFactory::InstanceBuilder<PlasmaSpindle> registration("PlasmaSpindle");
     }
+
+    // Called from the step ISR in place of a virtual dispatch, which would have
+    // to read this class's vtable out of flash.  IRAM_ATTR, and the qualified
+    // call keeps it non-virtual.
+    static void IRAM_ATTR plasmaspindle_speed_thunk(Spindle* s, uint32_t dev_speed) {
+        static_cast<PlasmaSpindle*>(s)->PlasmaSpindle::setSpeedfromISR(dev_speed);
+    }
+    Spindle::IsrSpeedFn PlasmaSpindle::isr_speed_fn() {
+        return plasmaspindle_speed_thunk;
+    }
 }

--- a/FluidNC/src/Spindles/PlasmaSpindle.h
+++ b/FluidNC/src/Spindles/PlasmaSpindle.h
@@ -76,6 +76,7 @@ namespace Spindles {
         void init() override;
 
         void setSpeedfromISR(uint32_t dev_speed) override;
+        IsrSpeedFn isr_speed_fn() override;
         void setState(SpindleState state, SpindleSpeed speed) override;
         void config_message() override;
 

--- a/FluidNC/src/Spindles/Spindle.cpp
+++ b/FluidNC/src/Spindles/Spindle.cpp
@@ -10,6 +10,8 @@
 
 Spindles::Spindle* spindle = nullptr;
 
+Spindles::Spindle::IsrSpeedFn spindle_isr_speed_fn = nullptr;
+
 namespace Spindles {
     // ========================= Spindle ==================================
 
@@ -46,6 +48,7 @@ namespace Spindles {
             if (candidate != spindle) {  // we are changing spindles
                 gc_state.selected_tool = new_tool;
                 spindle                = candidate;
+                spindle_isr_speed_fn   = candidate->isr_speed_fn();
                 new_spindle            = true;
                 log_info("Changed to spindle:" << spindle->name());
             }
@@ -55,7 +58,8 @@ namespace Spindles {
                     log_error("No spindles are defined");
                     return;
                 }
-                spindle = spindles[0];
+                spindle              = spindles[0];
+                spindle_isr_speed_fn = spindle->isr_speed_fn();
             }
         }
     }

--- a/FluidNC/src/Spindles/Spindle.h
+++ b/FluidNC/src/Spindles/Spindle.h
@@ -70,6 +70,15 @@ namespace Spindles {
 
         virtual void setSpeedfromISR(uint32_t dev_speed) = 0;
 
+        // Reaching setSpeedfromISR() through the vtable is not safe from the
+        // step ISR: vtables are linked into flash, and the ISR can run while
+        // the flash cache is disabled.  Any class that overrides
+        // setSpeedfromISR() must also override this, returning an IRAM_ATTR
+        // thunk that calls its own version non-virtually.  Stepper uses the
+        // cached pointer, refreshed whenever the active spindle changes.
+        using IsrSpeedFn = void (*)(Spindle*, uint32_t);
+        virtual IsrSpeedFn isr_speed_fn() = 0;
+
         void spinDown() { setState(SpindleState::Disable, 0); }
 
         bool                  is_reversable;
@@ -189,3 +198,7 @@ namespace Spindles {
     using SpindleFactory = Configuration::GenericFactory<Spindle>;
 }
 extern Spindles::Spindle* spindle;
+
+// Resolved from the active spindle whenever it changes, so that the step ISR
+// never has to read a vtable out of flash.  May be null before setup finishes.
+extern Spindles::Spindle::IsrSpeedFn spindle_isr_speed_fn;

--- a/FluidNC/src/Spindles/VFDSpindle.cpp
+++ b/FluidNC/src/Spindles/VFDSpindle.cpp
@@ -273,4 +273,14 @@ namespace Spindles {
         Spindle::groupDelaySettings(handler);
         detail_->group(handler);
     }
+
+    // Called from the step ISR in place of a virtual dispatch, which would have
+    // to read this class's vtable out of flash.  IRAM_ATTR, and the qualified
+    // call keeps it non-virtual.
+    static void IRAM_ATTR vfdspindle_speed_thunk(Spindle* s, uint32_t dev_speed) {
+        static_cast<VFDSpindle*>(s)->VFDSpindle::setSpeedfromISR(dev_speed);
+    }
+    Spindle::IsrSpeedFn VFDSpindle::isr_speed_fn() {
+        return vfdspindle_speed_thunk;
+    }
 }

--- a/FluidNC/src/Spindles/VFDSpindle.h
+++ b/FluidNC/src/Spindles/VFDSpindle.h
@@ -55,6 +55,7 @@ namespace Spindles {
         void config_message() override;
         void setState(SpindleState state, SpindleSpeed speed) override;
         void setSpeedfromISR(uint32_t dev_speed) override;
+        IsrSpeedFn isr_speed_fn() override;
 
         uint32_t     _sync_dev_speed;
         SpindleSpeed _slop;

--- a/FluidNC/src/State.h
+++ b/FluidNC/src/State.h
@@ -22,4 +22,8 @@ enum class State : uint8_t {
 };
 
 void set_state(State s);
+
+// Defined IRAM_ATTR in System.cpp, because the step ISR calls this and the ISR
+// can run while the flash cache is disabled, when a call into flash panics the
+// board.  The attribute is on the definition; this header cannot see IRAM_ATTR.
 bool state_is(State s);

--- a/FluidNC/src/Stepper.cpp
+++ b/FluidNC/src/Stepper.cpp
@@ -229,14 +229,18 @@ bool IRAM_ATTR Stepper::pulse_func() {
                 st.steps[axis] = st.exec_block->steps[axis] >> st.exec_segment->amass_level;
             }
             // Set real-time spindle output as segment is loaded, just prior to the first step.
-            spindle->setSpeedfromISR(st.exec_segment->spindle_dev_speed);
+            if (spindle_isr_speed_fn) {
+                spindle_isr_speed_fn(spindle, st.exec_segment->spindle_dev_speed);
+            }
         } else {
             // Segment buffer empty. Shutdown.
             stop_stepping();
             if (!state_is(State::Jog)) {  // added to prevent ... jog after probing crash
                 // Ensure pwm is set properly upon completion of rate-controlled motion.
                 if (st.exec_block != NULL && st.exec_block->is_pwm_rate_adjusted) {
-                    spindle->setSpeedfromISR(0);
+                    if (spindle_isr_speed_fn) {
+                        spindle_isr_speed_fn(spindle, 0);
+                    }
                 }
             }
 

--- a/FluidNC/src/System.cpp
+++ b/FluidNC/src/System.cpp
@@ -155,7 +155,7 @@ void set_state(State s) {
         allChannels.notifyState();
     }
 }
-bool state_is(State s) {
+bool IRAM_ATTR state_is(State s) {
     return sys.state() == s;
 }
 


### PR DESCRIPTION
> _Found and written by **Claude** (Anthropic's AI assistant), working on a fork at the owner's direction. Flagging that up front so this gets human scrutiny rather than being taken on trust — I have said explicitly below what was observed on hardware and what is reasoning from the code._

### The step ISR reads vtables out of flash

Running a job produced:

```
Guru Meditation Error: Core 1 panic'ed (Cache disabled but cached memory region accessed)
PC : 0x40082565  ->  Machine::Stepping::step()   Stepping.cpp
A0 : 0x400822dc  ->  Stepper::pulse_func()       Stepper.cpp
```

Any SPI flash access disables the cache on both cores. An ISR that touches flash in that window panics — which is why `$HTTP/BlockDuringMotion` exists.

**Two independent causes, both fixed here.**

**1. `platformio_override.ini` was disabling the vtable-in-DRAM mechanism.** `extra_scripts` *replaces* the value inherited through `extends` rather than adding to it, so setting it for the wifi/noradio/bt environments silently discarded `FluidNC/ld/esp32/vtable_in_dram.py` from `[common_esp32]`. Without it the project's own `sections.ld` is never on the linker's search path, `vtable_in_dram.ld` never applies, and every vtable stays in flash:

```
before:  vtables in DRAM   0,  in flash 240
after:   vtables in DRAM  30,  in flash 210
Pins::GPIOPinDetail   3f40eca8 (flash)  ->  3ffc4f50 (DRAM)
Spindles::Null        3f4.....  (flash)  ->  3ffc5618 (DRAM)
```

Those are exactly the two sets `vtable_in_dram.ld` names — and both are read by the step ISR: `Pin::write()` dispatches through `PinDetail`, and `Stepper::pulse_func()` calls `spindle->setSpeedfromISR()`. The protection was already designed; it had simply been switched off by accident.

**2. Two remaining flash accesses the linker script does not cover.** `state_is()` was a plain call into flash from the ISR — now `IRAM_ATTR`. `spindle->setSpeedfromISR()` read the Spindle vtable — the active spindle now supplies a plain function pointer, resolved once when the spindle changes and called directly. Every `setSpeedfromISR` implementation was already in IRAM; only the dispatch was not.

### Verification

Disassembled the linked image: `Stepper::pulse_func()`, `Machine::Stepping::step()` and `Stepping::unstep()` contain **no literal referencing flash and no calls into flash**. Builds on wifi, noradio, bt and rp2040_wifi; unit tests pass.

The panic above was observed on hardware and its PC decoded to the call site named. I have not reproduced the fixed build under the same conditions for long enough to call it proven in the field.
