### PR TITLE
Do not report a file read error as the end of a job

### DIFF
--- a/FluidNC/src/FileStream.cpp
+++ b/FluidNC/src/FileStream.cpp
@@ -17,9 +17,16 @@ int FileStream::available() {
 }
 
 int FileStream::read() {
+    if (!_fd) {
+        return -1;
+    }
     char   data;
     size_t res = fread(&data, 1, 1, _fd);
     return res == 1 ? data : -1;
+}
+
+bool FileStream::read_failed() {
+    return _io_error || (_fd && ferror(_fd) != 0);
 }
 
 int FileStream::peek() {
@@ -29,7 +36,17 @@ int FileStream::peek() {
 void FileStream::flush() {}
 
 int FileStream::read(char* buffer, size_t length) {
-    return fread(buffer, 1, length, _fd);
+    if (!_fd) {
+        return -1;
+    }
+    size_t got = fread(buffer, 1, length, _fd);
+    // Report the failure once the buffered data has been handed back, so
+    // callers that check for a negative return actually see one.  Previously
+    // this could only ever return >= 0, which made those checks dead code.
+    if (got == 0 && read_failed()) {
+        return -1;
+    }
+    return static_cast<int>(got);
 }
 
 size_t FileStream::write(uint8_t c) {
@@ -45,7 +62,8 @@ size_t FileStream::size() {
 }
 
 size_t FileStream::position() {
-    return ftell(_fd);
+    // While saved, the file is closed and _saved_position is where we left off.
+    return _fd ? ftell(_fd) : _saved_position;
 }
 
 void FileStream::setup(const char* mode) {
@@ -82,7 +100,13 @@ void FileStream::restore() {
     if (_fd) {
         fseek(_fd, _saved_position, SEEK_SET);
     } else {
-        // XXX need to unwind the job stack somehow
+        // The file could not be reopened - the SD card was pulled, or the
+        // mount dropped.  Record it so the next read reports an error.  It
+        // used to just leave _fd null, and a read from a null FILE* reports
+        // end of file, which the job machinery reads as "program complete":
+        // the job would stop partway through and claim it had finished.
+        _io_error = true;
+        log_error("Cannot reopen " << _fpath.string() << "; the job will be stopped");
     }
 }
 

--- a/FluidNC/src/FileStream.h
+++ b/FluidNC/src/FileStream.h
@@ -29,6 +29,10 @@ class FileStream : public Channel {
     long        _saved_position;  // Used when the
     const char* _mode;
 
+    // Set when the file could not be reopened after a save().  Sticky, because
+    // the resulting read failures must not be mistaken for end-of-file.
+    bool _io_error = false;
+
     void setup(const char* mode);
 
 public:
@@ -47,6 +51,11 @@ public:
     void        flush() override;
 
     //    size_t readBytes(char* buffer, size_t length) override { return read((uint8_t*)buffer, length); }
+
+    // fread() returning short does not distinguish end-of-file from an I/O
+    // error, and for a GCode file those mean opposite things: one is a job
+    // that finished, the other is a job that must not be reported as done.
+    bool read_failed();
 
     int read(char* buffer, size_t length);  // read chars from stream into buffer
     int read(uint8_t* buffer, size_t length) { return read((char*)buffer, length); }

--- a/FluidNC/src/InputFile.cpp
+++ b/FluidNC/src/InputFile.cpp
@@ -32,6 +32,11 @@ Error InputFile::readLine(char* line, size_t maxlen) {
         line[len++] = c;
     }
     line[len] = '\0';
+    if (read_failed()) {
+        // An I/O error is not end of file.  Do not hand back the partial line
+        // either: a truncated GCode line is a wrong move, not a short one.
+        return Error::FsFailedRead;
+    }
     return len || c >= 0 ? Error::Ok : Error::Eof;
 }
 
@@ -46,7 +51,6 @@ void InputFile::ack(Error status) {
         }
     }
 }
-
 
 void InputFile::end_message() {
     _progress = "SD: ";


### PR DESCRIPTION
> _Found and written by **Claude** (Anthropic's AI assistant), working on a fork at the owner's direction. Flagging that up front so this gets human scrutiny rather than being taken on trust — I have said explicitly below what was observed on hardware and what is reasoning from the code._

### An SD read error is reported as a completed job

```cpp
int FileStream::read() {
    size_t res = fread(&data, 1, 1, _fd);
    return res == 1 ? data : -1;      // error and end-of-file are the same value
}
```

`InputFile::readLine()` turns that `-1` into `Error::Eof`, the polling loop treats `Eof` as "job sent", calls `Job::unnest()`, and the machine returns to idle. So a transient read failure is **indistinguishable from a program that ran to completion**: the job stops partway through and is reported as finished. The only trace is at debug level.

`FileStream::restore()` is the same class of problem. It reopens the GCode file after a nested file or macro has borrowed the descriptor, and on failure leaves `_fd` null under an existing `// XXX need to unwind the job stack somehow` comment. Reading from a null `FILE*` reports end-of-file, so a card that cannot be reopened also ends the job and calls it success.

### The change

- `FileStream::read_failed()`, backed by `ferror()` plus a sticky flag set when `restore()` cannot reopen the file.
- `InputFile::readLine()` returns `Error::FsFailedRead` instead of `Error::Eof` on an I/O error, and **discards the partial line** rather than executing it — a truncated GCode line is a wrong move, not a short one.
- `read()`, `read(char*, size_t)` and `position()` guarded against a null descriptor.
- `read(char*, size_t)` now returns `-1` on error. It previously could only return `>= 0`, which made the existing `if (len < 0)` check in `FileCommands.cpp` dead code.

### Honesty about evidence

Found by **reading the code** while investigating a job that stopped and left the machine idle with no message. The symptom is consistent with this, but I never captured a case proving that specific run took this path — the silent failure is precisely what makes it hard to confirm. The defect in the code is plain regardless: `fread` short-read is treated as EOF with no `ferror()` check.

Builds on wifi, noradio, bt and rp2040_wifi; unit tests pass.
