### PR TITLE
Stop an exception in a support task from killing the controller

### DIFF
--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -285,8 +285,12 @@ void polling_loop(void* unused) {
             poll_once();
         } catch (const std::exception& ex) {
             report_poll_exception(ex.what());
+            feed_watchdog();
+            vTaskDelay(1);
         } catch (...) {
             report_poll_exception("unknown exception");
+            feed_watchdog();
+            vTaskDelay(1);
         }
     }
 }

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -111,18 +111,25 @@ void output_loop(void* unused) {
         // Block until a message is received
         LogMessage message;
         if (xQueueReceive(message_queue, &message, 100)) {  // Use timeout to check exit flag
-            if (!message.channel->is_closing()) {
-                if (message.isString) {
-                    std::string* s = static_cast<std::string*>(message.line);
-                    message.channel->print_msg(message.level, s->c_str());
-                    delete s;
-                } else {
-                    const char* cp = static_cast<const char*>(message.line);
-                    message.channel->print_msg(message.level, cp);
+            // Sending can throw - std::bad_alloc when the heap is exhausted,
+            // for instance.  An exception escaping a raw FreeRTOS task reaches
+            // std::terminate() and panics the controller, so drop the message
+            // instead, but always release the reference so the channel can
+            // still be reaped.
+            try {
+                if (!message.channel->is_closing()) {
+                    if (message.isString) {
+                        std::string* s = static_cast<std::string*>(message.line);
+                        message.channel->print_msg(message.level, s->c_str());
+                        delete s;
+                    } else {
+                        const char* cp = static_cast<const char*>(message.line);
+                        message.channel->print_msg(message.level, cp);
+                    }
+                } else if (message.isString) {
+                    delete static_cast<std::string*>(message.line);
                 }
-            } else if (message.isString) {
-                delete static_cast<std::string*>(message.line);
-            }
+            } catch (...) {}
             message.channel->release_log_ref();
         }
     }
@@ -168,12 +175,9 @@ static void poll_input_channel() {
 }
 
 bool pollingPaused = false;
-void polling_loop(void* unused) {
-    add_watchdog_to_task();
-    for (;;) {
-        if (should_exit()) {
-            break;
-        }
+// One pass of the polling loop.  Factored out of polling_loop() so that the
+// whole pass can be wrapped in a try block; "continue" becomes "return".
+static void poll_once() {
 
         // Poll the input sources waiting for a complete line to arrive
         /*feedLoopWDT(), */ vTaskDelay(1);
@@ -181,7 +185,7 @@ void polling_loop(void* unused) {
         if (pollingPaused) {
             feed_watchdog();
             vTaskDelay(100);
-            continue;
+            return;
         }
 
         // Polling without an argument checks for realtime characters
@@ -206,12 +210,12 @@ void polling_loop(void* unused) {
                 log_debug("Unwinding from Alarm");
                 Job::abort();
                 unwind_cause = nullptr;
-                continue;
+                return;
             }
             if (unwind_cause) {
                 Job::abort();
                 unwind_cause = nullptr;
-                continue;
+                return;
             }
 
             // Job channel has priority: feed it while cmd_queue has room.
@@ -254,6 +258,35 @@ void polling_loop(void* unused) {
             // and rejections happen promptly.  execute_line() runs or rejects
             // them on this task; they never enter cmd_queue, so no queue gate.
             poll_input_channel();
+        }
+    }
+
+// Reporting allocates, so if the heap is what failed this can throw again.
+// Swallow that too - an exception escaping the polling task is fatal.
+static void report_poll_exception(const char* what) {
+    try {
+        log_error("Polling error: " << what << ", free heap " << xPortGetFreeHeapSize());
+    } catch (...) {}
+}
+
+// A job must survive a transient failure in the IO machinery.  Losing WiFi can
+// squeeze the heap hard enough that an ordinary std::string allocation throws
+// std::bad_alloc, and an exception escaping a raw FreeRTOS task calls
+// std::terminate(), which panics the controller and kills the job with it.
+// Catch here instead and take another pass; motion planning and stepping do
+// not allocate, so the job keeps running.
+void polling_loop(void* unused) {
+    add_watchdog_to_task();
+    for (;;) {
+        if (should_exit()) {
+            break;
+        }
+        try {
+            poll_once();
+        } catch (const std::exception& ex) {
+            report_poll_exception(ex.what());
+        } catch (...) {
+            report_poll_exception("unknown exception");
         }
     }
 }

--- a/FluidNC/src/WebUI/WebClient.cpp
+++ b/FluidNC/src/WebUI/WebClient.cpp
@@ -34,7 +34,15 @@ namespace WebUI {
                     webClient->cmds.pop_front();
                     xSemaphoreGive(webClient->xBufferLock);
                     // TODO: check error result and see if we can do anything...
-                    settings_execute_line(cmd.c_str(), *webClient, AuthenticationLevel::LEVEL_ADMIN);
+                    // An exception escaping this raw task would terminate the
+                    // controller, taking any running job with it.
+                    try {
+                        settings_execute_line(cmd.c_str(), *webClient, AuthenticationLevel::LEVEL_ADMIN);
+                    } catch (...) {
+                        try {
+                            log_error_to(Console, "Web command failed: " << cmd);
+                        } catch (...) {}
+                    }
                     // Should not call detach, since we still need to send the remaining buffer, so we should not free and clear yet.
                     xSemaphoreTake(webClient->xBufferLock, portMAX_DELAY);
                     webClient->done = true;

--- a/FluidNC/src/WebUI/WebClient.cpp
+++ b/FluidNC/src/WebUI/WebClient.cpp
@@ -40,7 +40,7 @@ namespace WebUI {
                         settings_execute_line(cmd.c_str(), *webClient, AuthenticationLevel::LEVEL_ADMIN);
                     } catch (...) {
                         try {
-                            log_error_to(Console, "Web command failed: " << cmd);
+                            log_error_to(Console, "Web command failed");
                         } catch (...) {}
                     }
                     // Should not call detach, since we still need to send the remaining buffer, so we should not free and clear yet.


### PR DESCRIPTION
> _Found and written by **Claude** (Anthropic's AI assistant), working on a fork at the owner's direction. Flagging that up front so this gets human scrutiny rather than being taken on trust — I have said explicitly below what was observed on hardware and what is reasoning from the code._

### An exception in a support task takes the controller down

`polling_loop()` and `output_loop()` are raw FreeRTOS tasks with no exception handling. Anything that escapes either reaches `std::terminate()`, which panics the board and takes a running job with it.

Observed on hardware, backtrace decoded against the image:

```
polling_loop -> pollChannels -> AllChannels::poll -> Channel::pollLine
  -> Channel::autoReport -> report_realtime_status
    -> LogStream::write -> std::string::push_back
      -> operator new -> __cxa_allocate_exception -> std::terminate -> abort
```

A status report could not be formatted, and a three-hour cut ended. Motion planning and stepping do not allocate, so catching this and taking another pass leaves the job running.

### The change

The body of `polling_loop()` moves into `poll_once()` so a whole pass can sit in a `try` block; its `continue` statements become `return`, which is equivalent. `output_loop()` drops the offending message but always releases the log reference, so the channel can still be reaped. `WebClients::background_task()` gets the same treatment.

Reporting the failure can itself throw when the heap is what failed, so that logging is wrapped too.

### What this does not do

**This is containment, not a cure.** In the trace above the runtime could not allocate the `std::bad_alloc` object either — that is what `__cxa_allocate_exception` calling `std::terminate` means — so no handler can intervene at that point. This helps where an allocation fails while a little headroom remains, and it removes a whole class of "any throw anywhere reboots the machine". It does not make the board resilient to genuine heap exhaustion; that needs the leak fixed, which is separate work.

Builds on wifi, noradio, bt and rp2040_wifi; unit tests pass.
