### PR TITLE
platformio_override.ini silently disables the vtable-in-DRAM script

### DIFF
--- a/platformio_override.ini
+++ b/platformio_override.ini
@@ -2,11 +2,24 @@
 extends = env:wifi
 build_src_filter = ${env:wifi.build_src_filter} +<src/OLED.cpp>
 
+; extra_scripts REPLACES the value inherited via "extends" rather than adding to
+; it, so these must repeat ${common_esp32.extra_scripts} explicitly.  Leaving it
+; out silently drops FluidNC/ld/esp32/vtable_in_dram.py, which is what puts the
+; PinDetail and Spindle vtables in DRAM.  Without it they land in flash, and the
+; step ISR reads them - which panics the board whenever the flash cache happens
+; to be disabled.
+
 [env:wifi]
-extra_scripts = pre:FluidNC/ld/esp32/i2s_engine_fpermissive.py
+extra_scripts =
+    ${common_esp32.extra_scripts}
+    pre:FluidNC/ld/esp32/i2s_engine_fpermissive.py
 
 [env:noradio]
-extra_scripts = pre:FluidNC/ld/esp32/i2s_engine_fpermissive.py
+extra_scripts =
+    ${common_esp32.extra_scripts}
+    pre:FluidNC/ld/esp32/i2s_engine_fpermissive.py
 
 [env:bt]
-extra_scripts = pre:FluidNC/ld/esp32/i2s_engine_fpermissive.py
+extra_scripts =
+    ${common_esp32.extra_scripts}
+    pre:FluidNC/ld/esp32/i2s_engine_fpermissive.py


### PR DESCRIPTION
Written by Claude, at the direction of Claudia.

`extra_scripts` **replaces** the value inherited through `extends` rather than appending to it. The overrides in `platformio_override.ini` set their own `extra_scripts` without repeating the inherited one, so `FluidNC/ld/esp32/vtable_in_dram.py` never runs for those environments.

That script is what applies `vtable_in_dram.ld`, which places the `PinDetail` and `Spindle` vtables in DRAM:

```
    **Detail.cpp.o(.rodata .rodata.*)
    **Spindle.cpp.o(.rodata .rodata.*)
```

Without it they link into flash at `0x3f4.....`, and the step ISR reads them — `Stepper::pulse_func()` calls `spindle->setSpeedfromISR()`. The step timer is registered with `ESP_INTR_FLAG_IRAM` (`FluidNC/esp32/StepTimer.cpp`), so that ISR keeps running while the flash cache is disabled during any SPI flash access. Reading a vtable there panics:

```
Cache disabled but cached memory region accessed
PC : 0x400823ce -> Stepper::pulse_func()  Stepper.cpp:232
A0 : 0x400816dc -> timer_isr()            StepTimer.cpp:22
```

which is precisely the failure the build configuration exists to prevent. The mechanism was simply switched off by accident for anyone building through the override file.

The fix repeats `${common_esp32.extra_scripts}` in each override so both scripts run. Measured on the resulting image:

|  | before | after |
|---|---|---|
| vtables in DRAM | 0 | 30 |
| `Pins::GPIOPinDetail` | `3f40eca8` (flash) | `3ffc4f50` (DRAM) |

Builds using `[env:wifi]` from `platformio.ini` directly were never affected — they inherit `extra_scripts` normally.
