### PR TITLE
A WebClient can be freed while its command is still queued

### DIFF
--- a/FluidNC/src/WebUI/WebClient.cpp
+++ b/FluidNC/src/WebUI/WebClient.cpp
@@ -50,6 +50,10 @@ namespace WebUI {
                 } else {
                     xSemaphoreGive(webClient->xBufferLock);
                 }
+                // Balances the reference taken in executeCommandBackground().
+                // After this the channel may be reaped at any time, so nothing
+                // below may touch webClient.
+                webClient->release_processing_ref();
             } else
                 delay(1);  // This should never happen if portMAX_DELAY is trully infinite
         }
@@ -192,10 +196,25 @@ namespace WebUI {
             done = true;
             return;
         }
+        // The queue carries a bare pointer, and the request's onDisconnect
+        // handler can kill() this channel at any moment.  Without a reference
+        // the reaper sees both counts at zero and frees it while the entry is
+        // still queued, leaving background_task() to run a command against a
+        // deleted Channel.  Hold a processing reference until the background
+        // task is finished with it.
+        if (!try_acquire_processing_ref()) {
+            return;  // already closing; nothing would read the result
+        }
         xSemaphoreTake(xBufferLock, portMAX_DELAY);
         cmds.push_back(std::string(cmd));
         WebClient* _this = this;
-        xQueueSend(WebClients::_background_task_queue, &_this, portTICK_PERIOD_MS * 100);
+        if (xQueueSend(WebClients::_background_task_queue, &_this, portTICK_PERIOD_MS * 100) != pdTRUE) {
+            cmds.pop_back();
+            xSemaphoreGive(xBufferLock);
+            release_processing_ref();
+            log_error("WebClient: could not queue command for background execution");
+            return;
+        }
         xSemaphoreGive(xBufferLock);
     }
 

--- a/FluidNC/src/WebUI/WebClient.cpp
+++ b/FluidNC/src/WebUI/WebClient.cpp
@@ -203,6 +203,9 @@ namespace WebUI {
         // deleted Channel.  Hold a processing reference until the background
         // task is finished with it.
         if (!try_acquire_processing_ref()) {
+            xSemaphoreTake(xBufferLock, portMAX_DELAY);
+            done = true;
+            xSemaphoreGive(xBufferLock);
             return;  // already closing; nothing would read the result
         }
         xSemaphoreTake(xBufferLock, portMAX_DELAY);

--- a/FluidNC/src/WebUI/WebClient.cpp
+++ b/FluidNC/src/WebUI/WebClient.cpp
@@ -213,6 +213,7 @@ namespace WebUI {
         WebClient* _this = this;
         if (xQueueSend(WebClients::_background_task_queue, &_this, portTICK_PERIOD_MS * 100) != pdTRUE) {
             cmds.pop_back();
+            done = true;
             xSemaphoreGive(xBufferLock);
             release_processing_ref();
             log_error("WebClient: could not queue command for background execution");


### PR DESCRIPTION
Written by Claude, at the direction of Claudia.

Same class of bug as #1818, on a different path: a `Channel` reachable through a bare pointer that `AllChannels`' reaper cannot see.

## The race

`WebClient::executeCommandBackground()` pushes a bare `WebClient*` onto the shared background queue and takes no reference on the channel:

```cpp
xSemaphoreTake(xBufferLock, portMAX_DELAY);
cmds.push_back(std::string(cmd));
WebClient* _this = this;
xQueueSend(WebClients::_background_task_queue, &_this, portTICK_PERIOD_MS * 100);
xSemaphoreGive(xBufferLock);
```

Meanwhile the request's `onDisconnect` handler kills the channel as soon as the client goes away, which is correct in itself:

```cpp
request->onDisconnect([webClient]() {
    webClient->detachWS();
    if (!allChannels.kill(webClient)) { ... }
});
```

`reap_channels()` frees a zombie once both reference counts are zero — and they are, because nothing on this path ever took one:

1. `GET` → `new WebClient` → queue push, no reference held
2. client disconnects → `onDisconnect` → `allChannels.kill()`
3. `poll()` → `begin_closing()`, `deregistration()`, `_zombies.push_back()`
4. `reap_channels()` sees `0` and `0` → `delete`
5. `background_task()` dequeues the stale pointer, takes `webClient->xBufferLock` and runs `settings_execute_line(cmd, *webClient, ...)` against the deleted `Channel`

Any log call inside the command then dispatches a virtual through a freed object. Observed on an ESP32 with no job running at all, shortly after two WebUI requests:

```
abort() was called at PC 0x401dda63 on core 0
  __cxa_pure_virtual
  Print::write(unsigned char const*, unsigned int)
  Channel::print_msg(MsgLevel, char const*)   Channel.cpp:429
  output_loop(void*)                          Protocol.cpp:121
```

Decoded against the matching ELF, `ELF file SHA256` verified.

## The fix

Take a processing reference before queueing and release it once the background task is finished with the channel. `try_acquire_processing_ref()` already refuses after `begin_closing()`, so a command arriving for a channel on its way out is dropped rather than queued against a doomed object. If the queue send fails the command is unqueued and the reference released, so a full queue cannot pin the channel forever.

The window is small but entirely reachable: a browser that closes the connection while a command is still executing is ordinary behaviour, and the command runs on a separate task for exactly as long as it takes.

## Testing

The reasoning is from code and from the decoded backtrace above. I have not constructed a deterministic reproduction of the race — the crash was intermittent — so the direct evidence is the trace plus the missing reference, not a before/after test. The board it was found on has run without recurrence since, which is consistent but not conclusive on its own.
