### PR TITLE
Answer ESP410 WiFi AP scans asynchronously (portable)

### DIFF
--- a/FluidNC/esp32/WifiImpl.cpp
+++ b/FluidNC/esp32/WifiImpl.cpp
@@ -373,17 +373,27 @@ namespace WebUI {
             return result;
         }
 
-        int32_t beginApListScan() override {
-            while (true) {
-                int32_t n = WiFi.scanComplete();
-                if (n >= 0) {
-                    return n;
-                }
-                if (n == WIFI_SCAN_FAILED) {
-                    WiFi.scanNetworks(true, false, false, 1000);
-                }
-                delay(1000);
+        void startApListScan() override {
+            if (WiFi.scanComplete() == WIFI_SCAN_FAILED) {
+                // async, hidden=false, passive=false, max milliseconds per channel
+                WiFi.scanNetworks(true, false, false, 1000);
             }
+        }
+
+        ApScanState apListScanState() override {
+            switch (WiFi.scanComplete()) {
+                case WIFI_SCAN_RUNNING:
+                    return ApScanState::Running;
+                case WIFI_SCAN_FAILED:
+                    return ApScanState::Failed;
+                default:
+                    return ApScanState::Done;
+            }
+        }
+
+        int32_t apListCount() override {
+            int16_t n = WiFi.scanComplete();
+            return n > 0 ? n : 0;
         }
 
         bool isApProtected(int index) const override { return WiFi.encryptionType(index) != WIFI_AUTH_OPEN; }

--- a/FluidNC/esp32/WifiImpl.cpp
+++ b/FluidNC/esp32/WifiImpl.cpp
@@ -79,6 +79,9 @@ namespace WebUI {
                 disconnect_seen = false;
                 log_info_to(Console, "WiFi STA Connected");
                 break;
+            case ARDUINO_EVENT_WIFI_SCAN_DONE:
+                // Fired by every WiFi.scanNetworks() (e.g. ESP410 AP scan); nothing to do.
+                break;
             default:
                 log_debug_to(Console, "WiFi event: " << (int)event);
                 break;

--- a/FluidNC/rp2040/WifiImpl.cpp
+++ b/FluidNC/rp2040/WifiImpl.cpp
@@ -33,6 +33,8 @@ namespace WebUI {
 
     class Rp2xxxWifiImpl : public WifiImpl {
     private:
+        int32_t _apScanCount = -1;  // cached result for the non-blocking scan API
+
         static uint32_t cyw43CountryCode(const char* country) {
             if (country == nullptr || country[0] == '\0' || strcmp(country, "01") == 0) {
                 return CYW43_COUNTRY_WORLDWIDE;
@@ -165,14 +167,26 @@ namespace WebUI {
             return result;
         }
 
-        int32_t beginApListScan() override {
-            int32_t n = WiFi.scanNetworks(false);
-            return n < 0 ? 0 : n;
+        // arduino-pico's WiFi.scanNetworks() has no async mode like
+        // arduino-esp32's, so this runs one synchronous scan (a few seconds)
+        // and then reports Done.  A failed scan is reported as "0 APs", not
+        // retried, matching the previous behavior.
+        void startApListScan() override {
+            if (_apScanCount < 0) {
+                _apScanCount = std::max<int32_t>(0, WiFi.scanNetworks(false));
+            }
         }
+
+        ApScanState apListScanState() override { return _apScanCount < 0 ? ApScanState::Failed : ApScanState::Done; }
+
+        int32_t apListCount() override { return _apScanCount < 0 ? 0 : _apScanCount; }
 
         bool isApProtected(int index) const override { return WiFi.encryptionType(index) != ENC_TYPE_NONE; }
 
-        void finishApListScan() override { WiFi.scanDelete(); }
+        void finishApListScan() override {
+            WiFi.scanDelete();
+            _apScanCount = -1;
+        }
 
         void initNTP() override {
             NTP.begin("pool.ntp.org", "time.nist.gov");

--- a/FluidNC/src/WebUI/WebUIServer.cpp
+++ b/FluidNC/src/WebUI/WebUIServer.cpp
@@ -1,12 +1,17 @@
 // Copyright (c) 2014 Luc Lebosse. All rights reserved.
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
 
+#include "Platform.h"  // HOSTED
 #include "Machine/MachineConfig.h"
 #include "Serial.h"    // is_realtime_command()
 #include "Settings.h"  // settings_execute_line()
 #include "Error.h"     // ErrorException
 
 #include "WebUIServer.h"
+
+#if !HOSTED
+#    include "WifiScanAsync.h"  // beginAsyncWifiScan(), pollAsyncWifiScan()
+#endif
 
 #include "Driver/fluidnc_mdns.h"
 #include "NetSettings.h"
@@ -732,6 +737,14 @@ namespace WebUI {
             request->send(503, "text/plain", "Try again when not moving\n");
             return;
         }
+#if !HOSTED
+        // A WiFi AP scan is slow; run it asynchronously so it does not stall
+        // the command task or trip the connection watchdog.  The response is
+        // sent later from poll() -> pollAsyncWifiScan().
+        if (request->method() == HTTP_GET && beginAsyncWifiScan(request, cmd)) {
+            return;
+        }
+#endif
         char line[256];
         strncpy(line, cmd, 255);
         AsyncWebServerResponse* response;
@@ -1460,6 +1473,9 @@ namespace WebUI {
 
     void WebUI_Server::poll() {
         static uint32_t start_time = millis();
+#if !HOSTED
+        pollAsyncWifiScan();
+#endif
 #ifdef HAVE_DNS
         if (WiFi.getMode() == WIFI_AP) {
             dnsServer.processNextRequest();

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -96,6 +96,43 @@ namespace WebUI {
     static EnumSetting*     _wifi_ps_mode;
     static EnumSetting*     _ntp_enable;
 
+    // RSSI (dBm) -> 0..100 % bar, as WebUI expects.
+    static int32_t apSignalPercent(int32_t rssi) {
+        if (rssi <= -100) {
+            return 0;
+        }
+        if (rssi >= -50) {
+            return 100;
+        }
+        return 2 * (rssi + 100);
+    }
+
+    // Encodes the ESP410 AP list from a completed scan.  Declared in
+    // WifiImpl.h; shared with the async handler in WifiScanAsync.cpp.
+    void encodeApList(JSONencoder& j, int32_t apCount, bool jsonWrapper) {
+        j.begin();
+        if (jsonWrapper) {
+            j.member("cmd", "410");
+            j.member("status", "ok");
+            j.begin_array("data");
+        } else {
+            j.begin_array("AP_LIST");
+        }
+        for (int32_t i = 0; i < apCount; ++i) {
+            j.begin_object();
+#ifdef ARDUINO_ARCH_RP2040
+            j.member("SSID", WiFi.SSID(i));
+#else
+            j.member("SSID", WiFi.SSID(i).c_str());
+#endif
+            j.member("SIGNAL", apSignalPercent(WiFi.RSSI(i)));
+            j.member("IS_PROTECTED", wifiImpl().isApProtected(i));
+            j.end_object();
+        }
+        j.end_array();
+        j.end();
+    }
+
     class WiFiConfig : public Module {
     private:
         static void print_mac(Channel& out, const char* prefix, const char* mac) { log_stream(out, prefix << " (" << mac << ")"); }
@@ -145,7 +182,7 @@ namespace WebUI {
                     if (WiFi.isConnected()) {  //in theory no need but ...
                         j.id_value_object("Connected to", WiFi.SSID().c_str());
                         if (wifiImpl().allowRssiRead()) {
-                            j.id_value_object("Signal", std::string("") + std::to_string(getSignal(WiFi.RSSI())) + "%");
+                            j.id_value_object("Signal", std::string("") + std::to_string(apSignalPercent(WiFi.RSSI())) + "%");
                         }
                         wifiImpl().addStaPhyModeJson(j);
                         j.id_value_object("Channel", WiFi.channel());
@@ -199,7 +236,7 @@ namespace WebUI {
                     if (WiFi.isConnected()) {  //in theory no need but ...
                         log_stream(out, "Connected to: " << WiFi.SSID().c_str());
                         if (wifiImpl().allowRssiRead()) {
-                            log_stream(out, "Signal: " << getSignal(WiFi.RSSI()) << "%");
+                            log_stream(out, "Signal: " << apSignalPercent(WiFi.RSSI()) << "%");
                         }
                         wifiImpl().addStaPhyModeStatus(out);
                         log_stream(out, "Channel: " << WiFi.channel());
@@ -374,16 +411,6 @@ namespace WebUI {
             //to save time in decoding `?`
             s << " # axis:" << Axes::_numberAxis;
             return Error::Ok;
-        }
-
-        static int32_t getSignal(int32_t RSSI) {
-            if (RSSI <= -100) {
-                return 0;
-            }
-            if (RSSI >= -50) {
-                return 100;
-            }
-            return 2 * (RSSI + 100);
         }
 
         static bool ConnectSTA2AP() {
@@ -635,33 +662,12 @@ namespace WebUI {
 
         static Error listAPs(const char* parameter, AuthenticationLevel auth_level, Channel& out) {  // ESP410
             (void)auth_level;
+            bool jsonWrapper = parameter != NULL && strstr(parameter, "json=yes") != NULL;
+
+            int32_t   n = wifiImpl().beginApListScan();
             JSONencoder j(&out);
-            j.begin();
-
-            if (parameter != NULL && (strstr(parameter, "json=yes")) != NULL) {
-                j.member("cmd", "410");
-                j.member("status", "ok");
-                j.begin_array("data");
-            } else {
-                j.begin_array("AP_LIST");
-            }
-
-            int32_t n = wifiImpl().beginApListScan();
-
-            for (int i = 0; i < n; ++i) {
-                j.begin_object();
-#ifdef ARDUINO_ARCH_RP2040
-                j.member("SSID", WiFi.SSID(i));
-#else
-                j.member("SSID", WiFi.SSID(i).c_str());
-#endif
-                j.member("SIGNAL", getSignal(WiFi.RSSI(i)));
-                j.member("IS_PROTECTED", wifiImpl().isApProtected(i));
-                j.end_object();
-            }
+            encodeApList(j, n, jsonWrapper);
             wifiImpl().finishApListScan();
-            j.end_array();
-            j.end();
             return Error::Ok;
         }
 

--- a/FluidNC/src/WebUI/WifiImpl.h
+++ b/FluidNC/src/WebUI/WifiImpl.h
@@ -49,9 +49,25 @@ namespace WebUI {
         virtual std::string webAddressIp() const = 0;
         virtual std::string apInfoString() const = 0;
 
-        virtual int32_t beginApListScan()              = 0;
-        virtual bool    isApProtected(int index) const = 0;
-        virtual void    finishApListScan()             = 0;
+        // AP-list scan.  The primitives are non-blocking:
+        //   startApListScan()  - launch a scan unless one is already running
+        //                        or its results are still available
+        //   apListScanState()  - Running: in progress; Done: results ready
+        //                        (apListCount() valid, may be 0); Failed: no
+        //                        scan running or complete, (re)start one
+        //   apListCount() / isApProtected(i) - read completed results
+        //   finishApListScan() - release the results
+        // beginApListScan() is the blocking convenience used by the
+        // non-async ESP410 path; it is defined once in WifiImplCommon.cpp in
+        // terms of the primitives above.
+        enum class ApScanState { Running, Done, Failed };
+        virtual void        startApListScan()          = 0;
+        virtual ApScanState apListScanState()          = 0;
+        virtual int32_t     apListCount()              = 0;
+        virtual bool        isApProtected(int index) const = 0;
+        virtual void        finishApListScan()         = 0;
+
+        int32_t beginApListScan();
 
         virtual void initNTP() = 0;
 
@@ -59,4 +75,12 @@ namespace WebUI {
     };
 
     WifiImpl& wifiImpl();
+
+    // Encodes the ESP410 / [WiFi/ListAPs] response body (the AP list) from a
+    // completed scan into `j`.  Shared by the synchronous command handler
+    // (WifiConfig.cpp) and the async one (WifiScanAsync.cpp) so both return
+    // the same shape.  `apCount` comes from beginApListScan()/apListCount();
+    // `jsonWrapper` selects the {"cmd":"410",...,"data":[...]} envelope over
+    // the bare {"AP_LIST":[...]}.
+    void encodeApList(JSONencoder& j, int32_t apCount, bool jsonWrapper);
 }

--- a/FluidNC/src/WebUI/WifiImplCommon.cpp
+++ b/FluidNC/src/WebUI/WifiImplCommon.cpp
@@ -1,6 +1,21 @@
 #include "WifiImpl.h"
 
+#include <Arduino.h>  // delay()
+
 namespace WebUI {
+    int32_t WifiImpl::beginApListScan() {
+        // Block until a scan completes, driving the non-blocking primitives.
+        // On platforms whose startApListScan() is itself synchronous this
+        // returns after one pass.
+        for (;;) {
+            startApListScan();
+            if (apListScanState() == ApScanState::Done) {
+                return apListCount();
+            }
+            delay(1000);
+        }
+    }
+
     enum WiFiCountry {
         WiFiCountry01 = 0,
         WiFiCountryAT,

--- a/FluidNC/src/WebUI/WifiScanAsync.cpp
+++ b/FluidNC/src/WebUI/WifiScanAsync.cpp
@@ -75,7 +75,9 @@ namespace WebUI {
             return true;
         }
 
-        wifiImpl().startApListScan();
+        // Record the paused request; the scan is started (and, if it fails to
+        // start, retried) from pollAsyncWifiScan() so no WiFi work runs on the
+        // async webserver task here.
         s_pending.reset(new PendingScan { request->pause(), jsonWrapper, millis() });
         return true;
     }
@@ -97,7 +99,11 @@ namespace WebUI {
 
             WifiImpl::ApScanState state    = wifiImpl().apListScanState();
             bool                  timedOut = (millis() - s_pending->startMs) >= WIFI_SCAN_TIMEOUT_MS;
-            if (state == WifiImpl::ApScanState::Running && !timedOut) {
+            if (state != WifiImpl::ApScanState::Done && !timedOut) {
+                // Running: wait.  Failed (never started, or start failed):
+                // (re)kick it - startApListScan() is idempotent - and wait.
+                // Only the timeout below ends a scan that never completes.
+                wifiImpl().startApListScan();
                 return;
             }
 

--- a/FluidNC/src/WebUI/WifiScanAsync.cpp
+++ b/FluidNC/src/WebUI/WifiScanAsync.cpp
@@ -33,9 +33,12 @@ namespace WebUI {
 
         // beginAsyncWifiScan() runs on the async webserver task;
         // pollAsyncWifiScan() runs on the polling task.  The mutex guards the
-        // handoff of this pointer between them.  A FreeRTOS semaphore is used
-        // rather than std::mutex to match the rest of FluidNC and stay
-        // portable across the toolchains that build the WebUI.
+        // handoff of s_pending between them and nothing else - in particular
+        // the scan itself is driven only from the polling task, so the
+        // (possibly blocking) startApListScan() call is made with the lock
+        // released.  A FreeRTOS semaphore is used rather than std::mutex to
+        // match the rest of FluidNC and stay portable across the toolchains
+        // that build the WebUI.
         SemaphoreHandle_t            s_mutex = xSemaphoreCreateMutex();
         std::unique_ptr<PendingScan> s_pending;
 
@@ -85,6 +88,7 @@ namespace WebUI {
     void pollAsyncWifiScan() {
         AsyncWebServerRequestPtr requestPtr;
         std::string              body;
+        bool                     kickScan = false;
 
         {
             Lock lock;
@@ -103,15 +107,21 @@ namespace WebUI {
                 // Running: wait.  Failed (never started, or start failed):
                 // (re)kick it - startApListScan() is idempotent - and wait.
                 // Only the timeout below ends a scan that never completes.
-                wifiImpl().startApListScan();
-                return;
+                // Deferred until the lock is released: on rp2040/rp2350
+                // startApListScan() blocks for the whole scan.
+                kickScan = true;
+            } else {
+                int32_t count = (state == WifiImpl::ApScanState::Done) ? wifiImpl().apListCount() : 0;
+                body          = buildBody(count, s_pending->jsonWrapper);
+                wifiImpl().finishApListScan();
+                requestPtr = std::move(s_pending->request);
+                s_pending.reset();
             }
+        }
 
-            int32_t count = (state == WifiImpl::ApScanState::Done) ? wifiImpl().apListCount() : 0;
-            body          = buildBody(count, s_pending->jsonWrapper);
-            wifiImpl().finishApListScan();
-            requestPtr = std::move(s_pending->request);
-            s_pending.reset();
+        if (kickScan) {
+            wifiImpl().startApListScan();
+            return;
         }
 
         if (auto request = requestPtr.lock()) {

--- a/FluidNC/src/WebUI/WifiScanAsync.cpp
+++ b/FluidNC/src/WebUI/WifiScanAsync.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 - FluidNC contributors
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#include "WifiScanAsync.h"
+
+#include "WifiImpl.h"  // wifiImpl(), encodeApList()
+#include "../JSONEncoder.h"
+
+#include <Arduino.h>  // millis()
+#include <ESPAsyncWebServer.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+#include <cctype>
+#include <memory>
+#include <string>
+
+using namespace asyncsrv;  // T_Cache_Control, T_no_cache
+
+namespace WebUI {
+    namespace {
+        // Safety net so a pending request is never leaked if the scan never
+        // finishes (e.g. the radio wedges).  The scan itself is watchdog-safe
+        // because the request is paused while it runs.
+        constexpr uint32_t WIFI_SCAN_TIMEOUT_MS = 25000;
+
+        struct PendingScan {
+            AsyncWebServerRequestPtr request;
+            bool                     jsonWrapper;
+            uint32_t                 startMs;
+        };
+
+        // beginAsyncWifiScan() runs on the async webserver task;
+        // pollAsyncWifiScan() runs on the polling task.  The mutex guards the
+        // handoff of this pointer between them.  A FreeRTOS semaphore is used
+        // rather than std::mutex to match the rest of FluidNC and stay
+        // portable across the toolchains that build the WebUI.
+        SemaphoreHandle_t            s_mutex = xSemaphoreCreateMutex();
+        std::unique_ptr<PendingScan> s_pending;
+
+        struct Lock {
+            Lock() { xSemaphoreTake(s_mutex, portMAX_DELAY); }
+            ~Lock() { xSemaphoreGive(s_mutex); }
+        };
+
+        bool isListApsCommand(const char* cmd, bool& jsonWrapper) {
+            std::string s(cmd ? cmd : "");
+            for (auto& c : s) {
+                c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+            }
+            jsonWrapper = s.find("JSON=YES") != std::string::npos;
+            return s.rfind("[ESP410]", 0) == 0 || s.find("WIFI/LISTAPS") != std::string::npos;
+        }
+
+        // Builds the ESP410 response body from the completed scan results,
+        // using the same encoder as the synchronous WiFiConfig::listAPs().
+        std::string buildBody(int32_t count, bool jsonWrapper) {
+            std::string body;
+            JSONencoder j([&body](const char* text) { body += text; });
+            encodeApList(j, count, jsonWrapper);
+            return body;
+        }
+    }
+
+    bool beginAsyncWifiScan(AsyncWebServerRequest* request, const char* cmd) {
+        bool jsonWrapper;
+        if (!isListApsCommand(cmd, jsonWrapper)) {
+            return false;
+        }
+
+        Lock lock;
+        if (s_pending) {
+            request->send(503, "text/plain", "Wi-Fi scan already in progress\n");
+            return true;
+        }
+
+        wifiImpl().startApListScan();
+        s_pending.reset(new PendingScan { request->pause(), jsonWrapper, millis() });
+        return true;
+    }
+
+    void pollAsyncWifiScan() {
+        AsyncWebServerRequestPtr requestPtr;
+        std::string              body;
+
+        {
+            Lock lock;
+            if (!s_pending) {
+                return;
+            }
+            if (s_pending->request.expired()) {  // client disconnected while paused
+                wifiImpl().finishApListScan();
+                s_pending.reset();
+                return;
+            }
+
+            WifiImpl::ApScanState state    = wifiImpl().apListScanState();
+            bool                  timedOut = (millis() - s_pending->startMs) >= WIFI_SCAN_TIMEOUT_MS;
+            if (state == WifiImpl::ApScanState::Running && !timedOut) {
+                return;
+            }
+
+            int32_t count = (state == WifiImpl::ApScanState::Done) ? wifiImpl().apListCount() : 0;
+            body          = buildBody(count, s_pending->jsonWrapper);
+            wifiImpl().finishApListScan();
+            requestPtr = std::move(s_pending->request);
+            s_pending.reset();
+        }
+
+        if (auto request = requestPtr.lock()) {
+            AsyncWebServerResponse* response = request->beginResponse(200, "application/json", body.c_str());
+            response->addHeader(T_Cache_Control, T_no_cache);
+            request->send(response);
+        }
+    }
+}

--- a/FluidNC/src/WebUI/WifiScanAsync.h
+++ b/FluidNC/src/WebUI/WifiScanAsync.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 - FluidNC contributors
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#pragma once
+
+class AsyncWebServerRequest;
+
+namespace WebUI {
+    // A WiFi AP scan (ESP410 / [WiFi/ListAPs]) can take several seconds.
+    // Running it inline stalls the web command task and can trip the HTTP
+    // connection watchdog.  These helpers move it off the request path:
+    // beginAsyncWifiScan() pauses the request and kicks off an asynchronous
+    // scan through wifiImpl(); pollAsyncWifiScan() (called from
+    // WebUI_Server::poll()) sends the response once results are ready.
+    //
+    // All WiFi specifics live behind wifiImpl(), so this module is portable
+    // across the MCU builds that compile the WebUI (esp32, esp32s3, rp2040,
+    // rp2350).  It is excluded from the host/simulator build, which has no
+    // wifiImpl().
+
+    // Returns true if `cmd` is an AP-scan web command: the request has been
+    // paused (or answered with an error) and the caller must not touch it.
+    // Returns false for any other command.
+    bool beginAsyncWifiScan(AsyncWebServerRequest* request, const char* cmd);
+
+    // Completes a pending paused scan request.  Call once per poll cycle.
+    void pollAsyncWifiScan();
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -513,6 +513,7 @@ build_src_filter =
     -<WebUI/Mdns.cpp>
     ; -<WebUI/NotificationsService.cpp>
     -<WebUI/WifiConfig.cpp>
+    -<WebUI/WifiScanAsync.cpp>
     -<../esp32/OLED.cpp>
     -<SSD1306_I2C.cpp>
     -<Spindles/VFD/*>


### PR DESCRIPTION
Reworks #1748 to keep all WiFi-specific detail behind the `wifiImpl()` portability seam instead of in `WebUIServer.cpp`, so it builds across every MCU target that compiles the WebUI (esp32, esp32s3, rp2040, rp2350).

## Problem

Requesting a WiFi AP scan from the WebUI (the magnifying glass next to `Sta/SSID`) or sending `[ESP410]` runs the multi-second scan inline on the web command task. It produces no response bytes for several seconds and trips the connection watchdog, restarting the controller.

## Approach

Pause the HTTP GET request for the duration of the scan and send the AP list once results are ready, driven from `WebUI_Server::poll()`.

- **`WifiImpl`** gains non-blocking scan primitives: `startApListScan()` / `apListScanState()` (`Running`/`Done`/`Failed`) / `apListCount()`. The blocking `beginApListScan()` (still used by the serial/telnet/websocket `[ESP410]` path) becomes a single definition in `WifiImplCommon.cpp` built on those primitives, replacing the per-platform copies.
  - esp32: real async scan (`WiFi.scanNetworks(true, …)` + `scanComplete()`).
  - rp2040/rp2350: one synchronous `scanNetworks(false)` (arduino-pico has no async mode), failed scan reported as 0 APs — same behavior as before.
- **New `WebUI/WifiScanAsync.{h,cpp}`** (no `#ifdef`s): `beginAsyncWifiScan()` pauses the request and starts the scan; `pollAsyncWifiScan()` completes it. Cross-task handoff uses a FreeRTOS semaphore (not `std::mutex`, which does not compile on arduino-pico).
- **`WebUI::encodeApList()`** in `WifiConfig.cpp` is now the single ESP410-body encoder, shared by the synchronous `listAPs` and the async path, so both return the same shape. `getSignal` folded into `apSignalPercent`.
- `WebUIServer.cpp` footprint is two `#if !HOSTED` call sites. The new module is excluded from the host/simulator build (no `wifiImpl()` there).
- Also adds an explicit empty `ARDUINO_EVENT_WIFI_SCAN_DONE` case to `wifiEventHandler()` so the scan no longer logs `WiFi event: 102`.

## Testing

Builds clean: `wifi`, `wifi_s3`, `rp2040_wifi`, `rp2350_wifi`. Verified on hardware that both the async (WebUI/HTTP GET) and synchronous (serial) `[ESP410]` paths return the AP list; the watchdog no longer fires.

Closes #1748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)