### PR TITLE
Fix nested $sd/run losing the parent file

### DIFF
--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -218,10 +218,19 @@ static void poll_once() {
                 return;
             }
 
-            // Job channel has priority: feed it while cmd_queue has room.
+            // Job channel has priority: feed it while cmd_queue has room, but
+            // not while a line we already handed off is still in flight.
+            // protocol_main_loop frees the cmd_queue slot on xQueueReceive,
+            // before execute_line() runs, so a $sd/run that is about to nest a
+            // child file has not nested it yet; reading the next line here - or
+            // hitting EOF and unnesting - would pull the parent out from under
+            // that pending nest.  The processing ref, held from just before the
+            // handoff below until the consumer's ack, is the "line in flight"
+            // signal; gating on it restores the barrier that the old
+            // single-slot activeChannel handoff provided for free.
             char buf[Channel::maxLine];
             if (uxQueueSpacesAvailable(cmd_queue)) {
-                if (Channel* channel = Job::channel()) {
+                if (Channel* channel = Job::channel(); channel && channel->pending_processing_refs() == 0) {
                     auto status = channel->pollLine(buf);
                     switch (status) {
                         case Error::Ok:


### PR DESCRIPTION
A $sd/run issued from within a running file could return control to nowhere: the child ran, then the whole job ended, and every line after the $sd/run in the parent was silently dropped.

Regression from #1811 (two-task command dispatch).  The old single-slot activeChannel handoff cleared only after execute_line() + ack, so the polling task could not touch the job channel while a $sd/run line was still being processed.  The cmd_queue that replaced it frees its slot on xQueueReceive, before execute_line() -> runFile() -> Job::nest() runs. In that window the polling task sees a free slot, reads the next line from the parent (nest hasn't happened yet), fails try_acquire_processing_ ref() because the $sd/run line's ref is still held, and drops the line - which also leaves the slot free, so it spins through the rest of the parent dropping lines until pollLine() hits EOF and Job::unnest()s the parent.  runFile() then nests the child onto an empty stack.

Gate the poll loop's job branch on channel->pending_processing_refs() == 0.  That ref is held from just before the handoff until the consumer's ack (after Job::nest() has run), so the polling task no longer advances or EOFs the job channel while a handed-off line is in flight - the barrier the single-slot handoff gave for free.

Confirmed on hardware (wifi_s3): $sd/run=/Loop/PutterGrid.nc from BottomLoop.nc now returns to BottomLoop.nc and execution continues.