### PR TITLE
Fix task-watchdog stall on soft reset in S3/RP2040 step engines (#1775)

### DIFF
--- a/FluidNC/esp32/esp32s3/i2s_engine_dedicated.cpp
+++ b/FluidNC/esp32/esp32s3/i2s_engine_dedicated.cpp
@@ -33,7 +33,12 @@ static bool i2s_out_initialized = 0;
 static uint32_t _pulse_delay_us;
 static uint32_t _dir_delay_us;
 
-static int32_t _stepPulseEndTime;
+// _stepPulseEndTime and _stepPulsePending are read/written from both the
+// stepper timer ISR (via Stepping::step()/finish_step()) and the foreground
+// reset path (Stepper::reset() -> stop_stepping() -> unstep()), so they're
+// volatile to keep the compiler from caching stale values across contexts.
+static volatile int32_t _stepPulseEndTime;
+static volatile bool    _stepPulsePending = false;
 
 static uint32_t i2s_output_ = 0;
 static uint32_t i2s_pulse_  = 0;
@@ -228,12 +233,20 @@ static void IRAM_ATTR start_step() {
 // will happen in start_unstep()
 static void IRAM_ATTR finish_step() {
     _stepPulseEndTime = usToEndTicks(_pulse_delay_us);
+    _stepPulsePending = true;
 
     i2s_out_gpio_shiftout(i2s_output_ ^ i2s_pulse_);
 }
 
 static bool IRAM_ATTR start_unstep() {
-    spinUntil(_stepPulseEndTime);
+    // Only spin out the pulse width if a step pulse is actually in flight.
+    // unstep() is also called from stop_stepping() on soft reset, where
+    // _stepPulseEndTime is stale; the CCOUNT-based spinUntil() can then
+    // spin for up to ~half the 32-bit wraparound and trip the task watchdog.
+    if (_stepPulsePending) {
+        _stepPulsePending = false;
+        spinUntil(_stepPulseEndTime);
+    }
     i2s_out_gpio_shiftout(i2s_output_);
     i2s_pulse_ = 0;
     return false;

--- a/FluidNC/rp2040/i2s_engine.cpp
+++ b/FluidNC/rp2040/i2s_engine.cpp
@@ -55,9 +55,9 @@ namespace {
     bool start_unstep() {
         // Only spin out the pulse width if a step pulse is actually in
         // flight.  unstep() is also called from stop_stepping() on soft
-        // reset, where step_pulse_end_time is stale; the CCOUNT-based
-        // spinUntil() can then spin for up to ~half the 32-bit wraparound
-        // and trip the task watchdog.
+        // reset, where step_pulse_end_time is stale; spinUntil() compares
+        // against the RP2040's free-running 1 MHz timer, so a stale deadline
+        // can spin for up to ~35 minutes and trip the watchdog.
         if (step_pulse_pending) {
             step_pulse_pending = false;
             spinUntil(step_pulse_end_time);

--- a/FluidNC/rp2040/i2s_engine.cpp
+++ b/FluidNC/rp2040/i2s_engine.cpp
@@ -9,7 +9,13 @@
 namespace {
     uint32_t pulse_delay_us = 2;
     uint32_t dir_delay_us   = 0;
-    int32_t  step_pulse_end_time;
+
+    // step_pulse_end_time and step_pulse_pending are read/written from both
+    // the stepper timer ISR (via Stepping::step()/finish_step()) and the
+    // foreground reset path (Stepper::reset() -> stop_stepping() -> unstep()),
+    // so they're volatile to keep the compiler from caching stale values.
+    volatile int32_t step_pulse_end_time;
+    volatile bool    step_pulse_pending = false;
 
     uint32_t init_engine(uint32_t dir_delay, uint32_t pulse_delay, uint32_t& frequency, bool (*callback)(void)) {
         (void)frequency;
@@ -43,10 +49,19 @@ namespace {
     void finish_step() {
         i2s_out_delay();
         step_pulse_end_time = usToEndTicks(pulse_delay_us);
+        step_pulse_pending  = true;
     }
 
     bool start_unstep() {
-        spinUntil(step_pulse_end_time);
+        // Only spin out the pulse width if a step pulse is actually in
+        // flight.  unstep() is also called from stop_stepping() on soft
+        // reset, where step_pulse_end_time is stale; the CCOUNT-based
+        // spinUntil() can then spin for up to ~half the 32-bit wraparound
+        // and trip the task watchdog.
+        if (step_pulse_pending) {
+            step_pulse_pending = false;
+            spinUntil(step_pulse_end_time);
+        }
         return false;
     }
 

--- a/FluidNC/rp2040/pio_engine.cpp
+++ b/FluidNC/rp2040/pio_engine.cpp
@@ -126,8 +126,8 @@ static void finish_step() {
 static bool start_unstep() {
     // Only spin out the pulse width if a step pulse is actually in flight.
     // unstep() is also called from stop_stepping() on soft reset, where
-    // _stepPulseEndTime is stale; the CCOUNT-based spinUntil() can then
-    // spin for up to ~half the 32-bit wraparound and trip the task watchdog.
+    // _stepPulseEndTime is stale; spinUntil() compares against the RP2040's
+    // free-running 1 MHz timer, so a stale deadline can spin for up to ~35 minutes and trip the watchdog.
     if (_stepPulsePending) {
         _stepPulsePending = false;
         spinUntil(_stepPulseEndTime);

--- a/FluidNC/rp2040/pio_engine.cpp
+++ b/FluidNC/rp2040/pio_engine.cpp
@@ -13,7 +13,13 @@
 
 static uint32_t _pulse_delay_us;
 static uint32_t _dir_delay_us;
-static int32_t  _stepPulseEndTime;
+
+// _stepPulseEndTime and _stepPulsePending are read/written from both the
+// stepper timer ISR (via Stepping::step()/finish_step()) and the foreground
+// reset path (Stepper::reset() -> stop_stepping() -> unstep()), so they're
+// volatile to keep the compiler from caching stale values across contexts.
+static volatile int32_t _stepPulseEndTime;
+static volatile bool    _stepPulsePending = false;
 
 static PIO      _pio         = pio0;
 static uint     _sm          = 0;
@@ -114,10 +120,18 @@ static void start_step() {}
 static void finish_step() {
     commit_step_shadow();
     _stepPulseEndTime = usToEndTicks(_pulse_delay_us);
+    _stepPulsePending = true;
 }
 
 static bool start_unstep() {
-    spinUntil(_stepPulseEndTime);
+    // Only spin out the pulse width if a step pulse is actually in flight.
+    // unstep() is also called from stop_stepping() on soft reset, where
+    // _stepPulseEndTime is stale; the CCOUNT-based spinUntil() can then
+    // spin for up to ~half the 32-bit wraparound and trip the task watchdog.
+    if (_stepPulsePending) {
+        _stepPulsePending = false;
+        spinUntil(_stepPulseEndTime);
+    }
     return false;
 }
 

--- a/FluidNC/src/WebUI/WifiImplCommon.cpp
+++ b/FluidNC/src/WebUI/WifiImplCommon.cpp
@@ -16,10 +16,19 @@ namespace WebUI {
         // seconds, so feed the watchdog on every pass or it trips before the
         // scan finishes. feed_watchdog() is a no-op when the current task
         // isn't subscribed, so it is safe on every platform/caller.
+        //
+        // Feeding the watchdog removes the reboot that would otherwise end a
+        // wedged scan, so bound the wait explicitly -- same 25 s safety net as
+        // the async HTTP path (WifiScanAsync.cpp). On expiry, return an empty
+        // list rather than hanging the caller forever.
+        const uint32_t deadline = millis() + 25000;
         for (;;) {
             startApListScan();
             if (apListScanState() == ApScanState::Done) {
                 return apListCount();
+            }
+            if ((int32_t)(millis() - deadline) >= 0) {
+                return 0;
             }
             feed_watchdog();
             delay(200);

--- a/FluidNC/src/WebUI/WifiImplCommon.cpp
+++ b/FluidNC/src/WebUI/WifiImplCommon.cpp
@@ -1,5 +1,7 @@
 #include "WifiImpl.h"
 
+#include "Driver/watchdog.h"  // feed_watchdog()
+
 #include <Arduino.h>  // delay()
 
 namespace WebUI {
@@ -7,12 +9,20 @@ namespace WebUI {
         // Block until a scan completes, driving the non-blocking primitives.
         // On platforms whose startApListScan() is itself synchronous this
         // returns after one pass.
+        //
+        // This runs synchronously on the caller's task -- for the $WiFi/ListAPs
+        // ($ command / ESP410) path that is loopTask, which protocol_main_loop()
+        // has subscribed to the task watchdog. A WiFi scan takes several
+        // seconds, so feed the watchdog on every pass or it trips before the
+        // scan finishes. feed_watchdog() is a no-op when the current task
+        // isn't subscribed, so it is safe on every platform/caller.
         for (;;) {
             startApListScan();
             if (apListScanState() == ApScanState::Done) {
                 return apListCount();
             }
-            delay(1000);
+            feed_watchdog();
+            delay(200);
         }
     }
 


### PR DESCRIPTION
## Problem

Intermittent `task_wdt` abort with `loopTask` (CPU 1) wedged in `spinUntil()`:

```
#0  spinUntil                       delay_usecs.cpp:45
#1  start_unstep()                  esp32s3/i2s_engine_dedicated.cpp:235
#2  Machine::Stepping::unstep()     Stepping.cpp:190
#3  Stepper::stop_stepping()        Stepper.cpp:176
#4  Stepper::reset()                Stepper.cpp:297
    ... execute_realtime_command -> protocol_exec_rt_system -> protocol_main_loop
```

This is #1775 again. #1778 fixed it, but only in `esp32/timed_engine.cpp` and `rp2040/timed_engine.cpp`.

## Cause

The "mark pulse-end time in `finish_step()`, spin it out later in `start_unstep()`" overlap trick relies on `_stepPulseEndTime` being a fresh deadline. But `Stepping::unstep()` is also called from `Stepper::reset() -> go_idle() -> stop_stepping()` on a soft reset / alarm, with **no preceding `finish_step()`** — so `start_unstep()` spins against a stale deadline.

On the S3, `spinUntil()`'s CCOUNT wraps every ~17.9 s at 240 MHz and the compare is signed, so a deadline 9–18 s in the past reads as far in the future → the loop busy-waits several seconds → task watchdog fires on `loopTask`. (RP2040's `spinUntil()` uses the free-running 1 MHz timer, ~35 min to wrap — same failure mode, longer stall.) Intermittent, depending on the phase between the last real step and the reset.

The same unguarded pattern (and a non-`volatile` deadline) is in three engines #1778 didn't touch:

- `FluidNC/esp32/esp32s3/i2s_engine_dedicated.cpp` — the S3 dedicated-GPIO I2S engine, the one hit in practice on esp32-s3
- `FluidNC/rp2040/pio_engine.cpp`
- `FluidNC/rp2040/i2s_engine.cpp`

## Fix

Port #1778's guard to all three: a `volatile bool` pending flag set in `finish_step()`, checked and cleared in `start_unstep()`, plus `volatile` on the deadline so the foreground reset path doesn't read a cached value.

The other engines (`esp32/i2s_engine.cpp`, both `rmt_engine*`, `rp2040/pio_engine_delayed.cpp`) return early from `start_unstep()` without spinning and need no change.

## Also in this PR: a second, related task-watchdog stall — `$WiFi/ListAPs`

A user hit a `task_wdt` abort running `$WiFi/ListAPs` (ESP410, the `$`-command / serial path) on this same build, and there are matching reports on builds without #1824. Different code, same class of bug, so it's folded in here.

`WifiConfig::listAPs()` → `WifiImpl::beginApListScan()` spins `startApListScan()` / `apListScanState()` with a `delay()` until the scan completes, synchronously on the caller's task — `loopTask` (via `protocol_main_loop()`) or the polling task, both TWDT-subscribed. The loop never fed the watchdog, so a multi-second scan trips it. #1824 moved the *HTTP* `[ESP410]` path off-task (`WifiScanAsync.cpp`) but did not touch `beginApListScan()`, so the `$` path fails with or without that commit.

Fix (`WifiImplCommon.cpp`): `feed_watchdog()` on every pass of the wait loop (a no-op when the caller isn't TWDT-subscribed), poll delay 1000 → 200 ms so the command also returns sooner, and — since feeding the watchdog removes the reboot that would otherwise end a wedged scan — a 25 s deadline that returns an empty AP list on expiry (same safety net `WifiScanAsync.cpp` uses).

On rp2040/rp2350 `startApListScan()` blocks the whole scan in one call, so there the feed only covers the gaps between passes; a fully watchdog-safe rp2040 scan would need the feed inside that port's `startApListScan()`. The reported crash is esp32-s3, whose scan is async and fully covered.

## Test

- esp32-s3: idle ~15 s, then several Ctrl-X soft resets — no more WDT abort. RP2040 engines are the same change by inspection.
- User retest confirmed `$WiFi/ListAPs` no longer trips the watchdog.
- `wifi_s3` and `rp2040_wifi` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)