### PR TITLE
Fixed atc_manual return to location

### DIFF
--- a/FluidNC/src/ToolChangers/atc_manual.cpp
+++ b/FluidNC/src/ToolChangers/atc_manual.cpp
@@ -49,8 +49,9 @@ namespace ATCs {
     void Manual_ATC::probe_notification() {}
 
     bool Manual_ATC::tool_change(tool_t new_tool, bool pre_select, bool set_tool) {
-        bool spindle_was_on = false;  // used to restore the spindle state
-        bool was_inch_mode  = false;  // allows use to restore inch mode if req'd
+        bool spindle_was_on       = (gc_state.modal.spindle != SpindleState::Disable);   // used to restore the spindle state
+        bool was_inch_mode        = (gc_state.modal.units == Units::Inches);             // allows use to restore inch mode if req'd
+        bool was_incremental_mode = (gc_state.modal.distance == Distance::Incremental);  // was G91 active
 
         protocol_buffer_synchronize();  // wait for all motion to complete
         _macro.erase();                 // clear previous gcode
@@ -75,8 +76,6 @@ namespace ATCs {
             return true;
         }
 
-        was_inch_mode = (gc_state.modal.units == Units::Inches);
-
         if (gc_state.modal.plane_select != Plane::XY) {
             log_error("This ATC only works in G17 (XY) mode");
             send_alarm(ExecAlarm::SpindleControl);
@@ -85,6 +84,10 @@ namespace ATCs {
 
         if (was_inch_mode) {
             _macro.addf("G21");
+        }
+
+        if (was_incremental_mode) {
+            _macro.addf("G90");
         }
 
         try {
@@ -104,15 +107,14 @@ namespace ATCs {
             _prev_tool = new_tool;
 
             // save current location, so we can return after the tool change.
-            _macro.addf("#<start_x >= #<_abs_x>");
-            _macro.addf("#<start_y >= #<_abs_y>");
-            _macro.addf("#<start_z >= #<_abs_z>");
+            _macro.addf("#<start_x >= #<_x>");
+            _macro.addf("#<start_y >= #<_y>");
+            _macro.addf("#<start_z >= #<_z>");
 
             move_to_safe_z();
 
             // turn off the spindle
-            if (gc_state.modal.spindle != SpindleState::Disable) {
-                spindle_was_on = true;
+            if (spindle_was_on) {
                 _macro.addf("M5");
             }
 
@@ -142,8 +144,8 @@ namespace ATCs {
             move_to_safe_z();
 
             // return to location before the tool change
-            _macro.addf("G53G0X#<start_x>Y#<start_y>");
-            _macro.addf("G53G0Z#<start_z>");
+            _macro.addf("G0X#<start_x>Y#<start_y>");
+            _macro.addf("G0Z#<start_z>");
 
             if (spindle_was_on) {
                 _macro.addf("M3");  // spindle should handle spinup delay
@@ -151,6 +153,10 @@ namespace ATCs {
 
             if (was_inch_mode) {
                 _macro.addf("G20");
+            }
+
+            if (was_incremental_mode) {
+                _macro.addf("G91");
             }
 
             _macro.run(nullptr);

--- a/FluidNC/src/ToolChangers/atc_manual.cpp
+++ b/FluidNC/src/ToolChangers/atc_manual.cpp
@@ -86,10 +86,6 @@ namespace ATCs {
             _macro.addf("G21");
         }
 
-        if (was_incremental_mode) {
-            _macro.addf("G90");
-        }
-
         try {
             if (_prev_tool == 0) {  // M6T<anything> from T0 is used for a manual change before zero'ing
                 move_to_change_location();
@@ -144,6 +140,7 @@ namespace ATCs {
             move_to_safe_z();
 
             // return to location before the tool change
+            _macro.addf("G90");
             _macro.addf("G0X#<start_x>Y#<start_y>");
             _macro.addf("G0Z#<start_z>");
 


### PR DESCRIPTION
- The spindle was returning in G53 which does not account for new tool length. It now uses the current work (G54, etc) location.
- This requires G90 mode, so a G91 check and restore was added.