### PR TITLE
Fix swapped miso/mosi arguments in ETH.begin() for SPI Ethernet PHYs

### DIFF
--- a/FluidNC/src/Machine/EthPhy.cpp
+++ b/FluidNC/src/Machine/EthPhy.cpp
@@ -86,8 +86,8 @@ namespace Machine {
                             rstPin,
                             SPI2_HOST,
                             int(sckPin),
-                            int(mosiPin),
                             int(misoPin),
+                            int(mosiPin),
                             uint8_t(_frequency_hz / 1000000));
         if (!ok) {
             log_error("Ethernet PHY init failed");


### PR DESCRIPTION
## Problem

`EthPhy::init()` passes the SPI data pins to `ETH.begin()` in the wrong order.

The SPI overload is declared in `libraries/Ethernet/src/ETH.h` (arduino-esp32 3.x) as:

```cpp
bool begin(
  eth_phy_type_t type, int32_t phy_addr, int cs, int irq, int rst, spi_host_device_t spi_host,
  int sck = -1, int miso = -1, int mosi = -1,
  uint8_t spi_freq_mhz = ETH_PHY_SPI_FREQ_MHZ
);
```

`FluidNC/src/Machine/EthPhy.cpp` calls it with `sck, mosi, miso`, so the two data pins
are handed to the driver the wrong way round.

## Effect

A correctly wired module never initialises. The driver's chip-ID read comes back from
whatever the floating MISO input settles on, so `esp_eth_driver_install()` fails before
the link is ever brought up:

```
E (279) w5500.mac: W5500 version mismatched, expected 0x04, got 0xff
E (279) w5500.mac: emac_w5500_init(883): verify chip ID failed
E (280) esp_eth: esp_eth_driver_install(250): init mac failed
[MSG:ERR: Ethernet PHY init failed]
[MSG:INFO: Ethernet off]
```

This is easy to misread as a wiring fault: the value read back changes from boot to
boot with whatever the floating pin picks up, and the module's link LED still lights,
because link negotiation does not go through SPI.

It affects every SPI PHY handled here (`w5500`, `dm9051`, `ksz8851`), on any target
where `MAX_N_ETH` is defined.

## Fix

Swap the two arguments so each lands in the parameter it is named for. One line.

## Testing

A W5500 Lite on a plain ESP32 has been running with this change for two days: `$EI`
succeeds repeatedly, the static-IP path brings the interface up, and both the WebUI
and Telnet are reachable over Ethernet. Before the change the same board with the
same wiring failed every time.

---

🤖 Prepared with [Claude Code](https://claude.com/claude-code)
