### PR TITLE
Merge the output task into the polling task

### DIFF
--- a/FluidNC/src/Channel.cpp
+++ b/FluidNC/src/Channel.cpp
@@ -9,6 +9,7 @@
 #include "Limit.h"
 #include "Logging.h"
 #include "Job.h"
+#include "Protocol.h"  // poll_task_drain_one_message()
 #include <string_view>
 #include <algorithm>
 
@@ -24,6 +25,14 @@ namespace {
         for (uint32_t attempt = 0; attempt < message_queue_max_retries; ++attempt) {
             if (xQueueSend(message_queue, &msg, message_queue_retry_ticks)) {
                 return true;
+            }
+            // If this is the polling task, it is also the drainer: blocking on
+            // the queue it is supposed to empty would deadlock.  Ship one
+            // queued message ourselves to make room, then retry immediately.
+            if (poll_task_drain_one_message()) {
+                if (xQueueSend(message_queue, &msg, 0)) {
+                    return true;
+                }
             }
         }
 

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -25,6 +25,7 @@
 #include "Driver/heap.h"  // platform_max_free_block()
 
 #include <cstring>  // strncpy
+#include <memory>   // std::unique_ptr
 
 volatile ExecAlarm lastAlarm;  // The most recent alarm code
 
@@ -109,19 +110,14 @@ static constexpr UBaseType_t MESSAGE_QUEUE_DEPTH = 128;
 static void process_one_message(LogMessage& message) {
     // print_msg() can throw - std::bad_alloc under heap exhaustion.  An
     // exception escaping the polling task's try block still unwinds the whole
-    // pass; drop the message instead, but always release the ref so the
-    // channel can be reaped.
+    // pass; drop the message instead.  Own the queued string in a unique_ptr
+    // so it is freed on every path (throw included), and always release the
+    // ref so a closing channel can be reaped.
+    std::unique_ptr<std::string> owned(message.isString ? static_cast<std::string*>(message.line) : nullptr);
     try {
         if (!message.channel->is_closing()) {
-            if (message.isString) {
-                std::string* s = static_cast<std::string*>(message.line);
-                message.channel->print_msg(message.level, s->c_str());
-                delete s;
-            } else {
-                message.channel->print_msg(message.level, static_cast<const char*>(message.line));
-            }
-        } else if (message.isString) {
-            delete static_cast<std::string*>(message.line);
+            const char* text = message.isString ? owned->c_str() : static_cast<const char*>(message.line);
+            message.channel->print_msg(message.level, text);
         }
     } catch (...) {}
     message.channel->release_log_ref();
@@ -154,6 +150,23 @@ void drain_messages() {
             vTaskDelay(1);
         }
     }
+}
+
+// Make room in message_queue from the one task that would otherwise deadlock
+// waiting for it to drain: the polling task is the drainer, so if it fills the
+// queue itself (a burst of log_* before it reaches drain_output()), a blocking
+// xQueueSend would wait forever.  Ship one message inline and report success so
+// the caller can retry.  A no-op (returns false) on every other task.
+bool poll_task_drain_one_message() {
+    if (xTaskGetCurrentTaskHandle() != pollingTask) {
+        return false;
+    }
+    LogMessage message;
+    if (xQueueReceive(message_queue, &message, 0) != pdTRUE) {
+        return false;
+    }
+    process_one_message(message);
+    return true;
 }
 
 // One line of input handed from the polling task (core 0, producer) to
@@ -259,6 +272,10 @@ static void poll_once() {
         /*feedLoopWDT(), */ vTaskDelay(1);
         // Polling is paused when xmodem is using a channel for binary upload
         if (pollingPaused) {
+            // xmodem only pauses channel *input*; log output must keep moving
+            // or every logging task backs up on a full message_queue for the
+            // duration of the binary transfer.
+            drain_output(MESSAGE_QUEUE_DEPTH);
             feed_watchdog();
             vTaskDelay(100);
             return;

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -93,44 +93,65 @@ static void request_safety_door() {
     rtSafetyDoor = true;
 }
 
-TaskHandle_t outputTask = nullptr;
+TaskHandle_t outputTask  = nullptr;
+TaskHandle_t pollingTask = nullptr;
 
 QueueHandle_t message_queue;
 
-void drain_messages() {
-    while (uxQueueMessagesWaiting(message_queue)) {
-        vTaskDelay(1);  // Let the output task finish sending data
+// Was 15 when a dedicated priority-2 task drained the queue preemptively.
+// Now the polling task drains it once per pass, so a command that logs a
+// burst before yielding needs room here or it self-throttles on
+// enqueue_log_message()'s retry (up to ~250 ms).  128 * 16 B = 2 KB.
+static constexpr UBaseType_t MESSAGE_QUEUE_DEPTH = 128;
+
+// Ship one queued log message to its channel.  Runs on the polling task
+// (drain_output() below) and, synchronously, from drain_messages().
+static void process_one_message(LogMessage& message) {
+    // print_msg() can throw - std::bad_alloc under heap exhaustion.  An
+    // exception escaping the polling task's try block still unwinds the whole
+    // pass; drop the message instead, but always release the ref so the
+    // channel can be reaped.
+    try {
+        if (!message.channel->is_closing()) {
+            if (message.isString) {
+                std::string* s = static_cast<std::string*>(message.line);
+                message.channel->print_msg(message.level, s->c_str());
+                delete s;
+            } else {
+                message.channel->print_msg(message.level, static_cast<const char*>(message.line));
+            }
+        } else if (message.isString) {
+            delete static_cast<std::string*>(message.line);
+        }
+    } catch (...) {}
+    message.channel->release_log_ref();
+}
+
+// Drain up to `max` queued log messages.  Non-blocking: the polling task
+// calls this once per pass instead of a dedicated output task blocking on
+// the queue.  Channel writes here are non-blocking too (WSChannel defers a
+// full send queue to its pollLine()), so a wedged client cannot stall the
+// polling loop.
+static void drain_output(int max) {
+    LogMessage message;
+    for (int i = 0; i < max && xQueueReceive(message_queue, &message, 0) == pdTRUE; ++i) {
+        process_one_message(message);
+        feed_watchdog();
     }
 }
 
-void output_loop(void* unused) {
-    while (true) {
-        if (should_exit()) {
-            break;
-        }
-        // Block until a message is received
+// Flush all currently-queued messages.  From the polling task (the drainer)
+// this runs inline; from any other task it waits for the polling task to
+// drain, so channel writes stay on SUPPORT_TASK_CORE as before.
+void drain_messages() {
+    if (xTaskGetCurrentTaskHandle() == pollingTask) {
         LogMessage message;
-        if (xQueueReceive(message_queue, &message, 100)) {  // Use timeout to check exit flag
-            // Sending can throw - std::bad_alloc when the heap is exhausted,
-            // for instance.  An exception escaping a raw FreeRTOS task reaches
-            // std::terminate() and panics the controller, so drop the message
-            // instead, but always release the reference so the channel can
-            // still be reaped.
-            try {
-                if (!message.channel->is_closing()) {
-                    if (message.isString) {
-                        std::string* s = static_cast<std::string*>(message.line);
-                        message.channel->print_msg(message.level, s->c_str());
-                        delete s;
-                    } else {
-                        const char* cp = static_cast<const char*>(message.line);
-                        message.channel->print_msg(message.level, cp);
-                    }
-                } else if (message.isString) {
-                    delete static_cast<std::string*>(message.line);
-                }
-            } catch (...) {}
-            message.channel->release_log_ref();
+        while (xQueueReceive(message_queue, &message, 0) == pdTRUE) {
+            process_one_message(message);
+        }
+    } else {
+        while (uxQueueMessagesWaiting(message_queue)) {
+            vTaskDelay(1);
         }
     }
 }
@@ -154,8 +175,6 @@ bool cmd_queue_defer(const char* line, Channel& channel) {
     item.line[Channel::maxLine - 1] = '\0';
     return xQueueSend(cmd_queue, &item, 0) == pdTRUE;
 }
-
-TaskHandle_t pollingTask = nullptr;
 
 // Poll the registered serial-style channels for one line and route it through
 // execute_line() on the polling task.  When no job runs this feeds cmd_queue;
@@ -249,6 +268,10 @@ static void poll_once() {
         // Polling with an argument both checks for realtime characters and
         // returns a line-oriented command if one is ready.
         pollChannels();
+
+        // Ship queued log output (formerly the dedicated "output" task).
+        drain_output(MESSAGE_QUEUE_DEPTH);
+
         for (auto const& module : Modules()) {
             module->poll();
             feed_watchdog();
@@ -327,6 +350,10 @@ static void poll_once() {
             // them on this task; they never enter cmd_queue, so no queue gate.
             poll_input_channel();
         }
+
+        // Ship anything an inline command just produced, this pass rather than
+        // next.
+        drain_output(MESSAGE_QUEUE_DEPTH);
     }
 
 // Reporting allocates, so if the heap is what failed this can throw again.
@@ -381,15 +408,10 @@ void start_polling() {
                                 (1 << SUPPORT_TASK_CORE),  // affinity mask
                                 &pollingTask       // task handle
         );
-        xTaskCreateAffinitySet(output_loop,  // task
-                                "output",     // name for task
-                                16000,
-                                // 8192,              // size of task stack
-                                0,                 // parameters
-                                2,                 // priority
-                                (1 << SUPPORT_TASK_CORE),  // affinity mask
-                                &outputTask        // task handle
-        );
+        // The polling task also drains message_queue (see drain_output()).
+        // outputTask must stay non-null so Channel::sendLine() enqueues
+        // instead of printing inline in the producer's context.
+        outputTask = pollingTask;
     }
 }
 
@@ -1368,7 +1390,7 @@ QueueHandle_t event_queue;
 
 void protocol_init() {
     event_queue   = xQueueCreate(50, sizeof(EventItem));
-    message_queue = xQueueCreate(15, sizeof(LogMessage));
+    message_queue = xQueueCreate(MESSAGE_QUEUE_DEPTH, sizeof(LogMessage));
     cmd_queue     = xQueueCreate(CMD_QUEUE_DEPTH, sizeof(LineItem));
 }
 

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -144,6 +144,7 @@ void drain_messages() {
         LogMessage message;
         while (xQueueReceive(message_queue, &message, 0) == pdTRUE) {
             process_one_message(message);
+            feed_watchdog();
         }
     } else {
         while (uxQueueMessagesWaiting(message_queue)) {

--- a/FluidNC/src/Protocol.h
+++ b/FluidNC/src/Protocol.h
@@ -115,6 +115,12 @@ void protocol_send_event_from_ISR(const Event* evt, void* arg = 0);
 
 void drain_messages();
 
+// If called on the polling task (the message_queue drainer), dequeue and ship
+// one queued log message immediately and return true; otherwise a no-op that
+// returns false.  enqueue_log_message() uses this so a log burst from the
+// polling task itself cannot block forever on a full queue.
+bool poll_task_drain_one_message();
+
 // Copy a line onto cmd_queue for protocol_main_loop to execute.  Returns false
 // if the queue is full.  Called by execute_line() on the polling task.
 class Channel;

--- a/FluidNC/src/WebUI/WSChannel.cpp
+++ b/FluidNC/src/WebUI/WSChannel.cpp
@@ -157,6 +157,25 @@ namespace WebUI {
             return 0;
         }
 
+        // With a non-blocking flush there is no producer backpressure, so a
+        // client that has stopped draining would grow _output_line without
+        // bound on the polling task's heap.  Check the incoming size against
+        // the backlog limit *before* appending - otherwise one large write
+        // could grow _output_line past WS_OUT_MAX_BACKLOG before the drop
+        // fires, briefly defeating the bounded-heap guarantee this is for.
+        if (_output_line.length() + size > WS_OUT_MAX_BACKLOG) {
+            size_t dropped = _output_line.length();
+            std::string().swap(_output_line);
+            _active = false;  // clear/deactivate first: the diagnostic below can
+                               // throw (it queues through the shared log path),
+                               // and state must not be left half-torn-down if it does.
+            if (auto client = get_client(_server, _clientNum)) {
+                client->close();
+            }
+            log_debug_to(Console, "WebSocket cid#" << _clientNum << " backlog " << dropped << "+" << size << ", closing");
+            return size;
+        }
+
         // Coalesce output: accumulate here and emit at most one frame per
         // WS_OUT_FLUSH_LEN bytes.  The tail of a burst is shipped from
         // pollLine() once output goes idle, or explicitly via flush().  This
@@ -169,19 +188,6 @@ namespace WebUI {
 
         if (_output_line.length() >= WS_OUT_FLUSH_LEN) {
             flush_output(false);  // non-blocking - this runs on the polling task
-        }
-
-        // With a non-blocking flush there is no producer backpressure, so a
-        // client that has stopped draining would grow _output_line without
-        // bound on the polling task's heap.  Drop it once the backlog it
-        // cannot take exceeds WS_OUT_MAX_BACKLOG.
-        if (_output_line.length() > WS_OUT_MAX_BACKLOG) {
-            log_debug_to(Console, "WebSocket cid#" << _clientNum << " backlog " << _output_line.length() << ", closing");
-            std::string().swap(_output_line);
-            if (auto client = get_client(_server, _clientNum)) {
-                client->close();
-            }
-            _active = false;
         }
         return size;
     }

--- a/FluidNC/src/WebUI/WSChannel.cpp
+++ b/FluidNC/src/WebUI/WSChannel.cpp
@@ -146,7 +146,10 @@ namespace WebUI {
     }
 
     void WSChannel::flush() {
-        flush_output(true);
+        // Non-blocking: the tail ships from pollLine() on the next poll pass.
+        // (Was flush_output(true) - a blocking spin that is unacceptable now
+        // that WSChannel::write() runs on the shared polling task.)
+        flush_output(false);
     }
 
     size_t WSChannel::write(const uint8_t* buffer, size_t size) {
@@ -165,7 +168,20 @@ namespace WebUI {
         _output_line.append(reinterpret_cast<const char*>(buffer), size);
 
         if (_output_line.length() >= WS_OUT_FLUSH_LEN) {
-            flush_output(true);
+            flush_output(false);  // non-blocking - this runs on the polling task
+        }
+
+        // With a non-blocking flush there is no producer backpressure, so a
+        // client that has stopped draining would grow _output_line without
+        // bound on the polling task's heap.  Drop it once the backlog it
+        // cannot take exceeds WS_OUT_MAX_BACKLOG.
+        if (_output_line.length() > WS_OUT_MAX_BACKLOG) {
+            log_debug_to(Console, "WebSocket cid#" << _clientNum << " backlog " << _output_line.length() << ", closing");
+            std::string().swap(_output_line);
+            if (auto client = get_client(_server, _clientNum)) {
+                client->close();
+            }
+            _active = false;
         }
         return size;
     }

--- a/FluidNC/src/WebUI/WSChannel.h
+++ b/FluidNC/src/WebUI/WSChannel.h
@@ -63,6 +63,10 @@ namespace WebUI {
         // free heap block during the WebUI load burst.
         static constexpr size_t   WS_OUT_FLUSH_LEN = 1400;
         static constexpr uint32_t WS_OUT_IDLE_MS   = 8;
+        // A client that has stopped draining is dropped once its undelivered
+        // backlog passes this, so write() (on the polling task) never grows
+        // _output_line without bound.  ~8 frames.
+        static constexpr size_t WS_OUT_MAX_BACKLOG = 8 * WS_OUT_FLUSH_LEN;
         std::string               _output_line;
         uint32_t                  _output_pending_since = 0;
         unsigned long             _last_queue_full      = 0;


### PR DESCRIPTION
The dedicated priority-2 `output` task existed to drain `message_queue` and write to channels without a slow/blocked client stalling the command pipeline. Its ~5.5 KB stack + TCB is a heap lever worth taking.

The polling task already runs channel command execution (`execute_line` inline for `$`/`[ESP]` reports). Give it the output drain too:

- `drain_output()`: non-blocking `xQueueReceive` loop, called from `poll_once()` after `pollChannels()` and again after an inline command runs.
- `process_one_message()`: the old `output_loop` body, shared with `drain_messages()`.
- `drain_messages()`: from the polling task, drains inline; from any other task, still waits (keeps channel writes on `SUPPORT_TASK_CORE`).
- `outputTask = pollingTask` so `Channel::sendLine()` keeps enqueuing rather than printing inline in the producer's context.
- `message_queue` 15 -> 128 entries (2 KB): the poll loop drains once per pass instead of a preemptive prio-2 task, so a command that logs a burst before yielding needs the headroom or it self-throttles on `enqueue_log_message()`'s ~250 ms retry.

`WSChannel` is the one channel whose `write()` could block (`send_frame` with `may_block=true` spins up to 250 ms on a full client queue). That is unacceptable on the shared polling task:
- `write()`/`flush()` now use `flush_output(false)`; the tail ships from `pollLine()` as before.
- a client that stops draining is dropped once its undelivered backlog exceeds `WS_OUT_MAX_BACKLOG` (~8 frames), since the non-blocking flush removes the producer backpressure that previously bounded `_output_line`.

Telnet is unaffected - its TX ring was already non-blocking with a time-based stall/disconnect.

### Known limitation: blocking console writes

A blocking UART/USB-CDC console `write()` (TX FIFO full) now stalls the poll pass instead of just the old disposable `output` task. For a fast USB-CDC console this is negligible; for a genuinely slow UART console under a log burst it injects tens-to-hundreds of ms of control-loop jitter, and a permanently wedged console freezes realtime input on all channels (no worse than the pre-merge outcome for anything that matters).

Not mitigated here on purpose: dropping console output would break grbl's send/response flow control and can lose `ALARM:`/`[MSG:` state changes, and a per-message criticality tag (like `TelnetClient::isCriticalLine()`) generalized across every channel and the log path is a much wider change than this branch should carry.

### On-hardware heap measurement (wifi_s3)

`$Heap/Show` before and after a single WebUI connect, this branch vs `main`, both USB-CDC states. Numbers in bytes; "trough" = `min max block` (largest contiguous free block low-water, ~1 kHz sampled).

| config | resting free | resting max block | post-connect free low-water | post-connect max block | trough |
|---|---|---|---|---|---|
| `main`, USB-CDC off | 48724 | 31732 | 21016 | 24564 (fragmented) | ~13000 |
| `main`, USB-CDC on | 42220 | 31732 | **8652** | 21492 (fragmented) | 7668 |
| this branch, USB-CDC off | 63416 | 31732 | 25524 | **31732 (full recovery)** | 10228 |
| this branch, USB-CDC on | 57136 | 31732 | **14180** | **31732 (full recovery)** | 7668 |

- **Resting free: +14.4 KB (USB off) / +14.9 KB (USB on)**, consistent, matching the `output` + WebClient task-stack removal budget.
- **Connect-burst free low-water:** `main` + USB-CDC on grazes 8652 B during a routine single-client connect; this branch holds 14180 B under the same load.
- **Post-burst max block returns to the full 31732** on this branch in both USB modes; `main` stays fragmented at 21-24 KB. Removing the two mid-heap task stacks means the burst allocations leave no permanent hole.
- The **transient largest-block trough (7668 B with USB on) is unchanged** - it is driven by async_tcp burst allocation, out of scope for this branch. This branch raises the floor around it, not the dip itself.
- SD-card auto-mount (`esp_vfs_fat_register`, ~1-5 KB contiguous) intermittently failed `ESP_ERR_NO_MEM` on `main` during the burst; it is a fragmentation/timing race (it also failed at a *higher* free floor than some of its successes), not a headroom threshold, so it is not used as a pass/fail metric here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
