### PR TITLE
Improve soft limit alarm reporting

### DIFF
--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -1670,8 +1670,9 @@ Error gc_execute_line(const char* input_line) {
     }
     // [0. Non-specific/common error-checks and miscellaneous setup]:
     // NOTE: If no line number is present, the value is zero.
-    gc_state.line_number = gc_block.values.n;
-    pl_data->line_number = gc_state.line_number;  // Record data for planner use.
+    gc_state.line_number     = gc_block.values.n;
+    pl_data->line_number     = gc_state.line_number;  // Record data for planner use.
+    pl_data->has_line_number = bitnum_is_true(value_words, GCodeWord::N);
 
     // [1. Comments feedback ]:  NOT SUPPORTED
     // [2. Set feed rate mode ]:

--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -269,7 +269,11 @@ void gc_wco_changed() {
 // In this function, all units and positions are converted and
 // exported to internal functions in terms of (mm, mm/min) and absolute machine
 // coordinates, respectively.
+const char* gc_last_line = "";
+
 Error gc_execute_line(const char* input_line) {
+    gc_last_line = input_line;
+
     char line[128];
     if (strlen(input_line) > 127) {
         return Error::LineLengthExceeded;

--- a/FluidNC/src/GCode.h
+++ b/FluidNC/src/GCode.h
@@ -336,6 +336,12 @@ void gc_init();
 // Execute one block of rs275/ngc/g-code
 Error gc_execute_line(const char* line);
 
+// Raw text of the g-code line currently (or most recently) being executed,
+// as received before whitespace/comment stripping.  Used for diagnostics
+// such as soft limit alarm reports.  Points into the caller's line buffer,
+// which is valid for the duration of the synchronous gc_execute_line() call.
+extern const char* gc_last_line;
+
 // Set g-code parser position. Input in steps.
 void gc_sync_position();
 

--- a/FluidNC/src/InputFile.cpp
+++ b/FluidNC/src/InputFile.cpp
@@ -37,6 +37,11 @@ Error InputFile::readLine(char* line, size_t maxlen) {
         // either: a truncated GCode line is a wrong move, not a short one.
         return Error::FsFailedRead;
     }
+    if (c < 0 && len) {
+        // Hit EOF without a trailing newline, but still got a complete last line.
+        // Count it so lineNumber() reflects the line just returned.
+        ++_line_number;
+    }
     return len || c >= 0 ? Error::Ok : Error::Eof;
 }
 

--- a/FluidNC/src/Kinematics/Cartesian.cpp
+++ b/FluidNC/src/Kinematics/Cartesian.cpp
@@ -47,12 +47,12 @@ namespace Kinematics {
         if (axes->_axis[the_axis]->_softLimits) {
             float amin = std::min(position[the_axis], target[the_axis]);
             if (amin < limitsMinPosition(the_axis)) {
-                limit_error(the_axis, amin);
+                limit_error(the_axis, amin, target, pl_data);
                 return true;
             }
             float amax = std::max(position[the_axis], target[the_axis]);
             if (amax > limitsMaxPosition(the_axis)) {
-                limit_error(the_axis, amax);
+                limit_error(the_axis, amax, target, pl_data);
                 return true;
             }
         }
@@ -187,12 +187,12 @@ namespace Kinematics {
                 // and the minimum extent.
                 float amin = m[a] ? center[a] - radius : std::min(target[the_axis], position[the_axis]);
                 if (amin < limitsMinPosition(the_axis)) {
-                    limit_error(the_axis, amin);
+                    limit_error(the_axis, amin, target, pl_data);
                     return true;
                 }
                 float amax = p[a] ? center[a] + radius : std::max(target[the_axis], position[the_axis]);
                 if (amax > limitsMaxPosition(the_axis)) {
-                    limit_error(the_axis, amax);
+                    limit_error(the_axis, amax, target, pl_data);
                     return true;
                 }
             }
@@ -259,14 +259,14 @@ namespace Kinematics {
         pl_data->limits_checked = true;
     }
 
-    bool Cartesian::invalid_line(float* cartesian) {
+    bool Cartesian::invalid_line(float* cartesian, plan_line_data_t* pl_data) {
         auto axes   = config->_axes;
         auto n_axis = Axes::_numberAxis;
 
         for (axis_t axis = X_AXIS; axis < n_axis; axis++) {
             float coordinate = cartesian[axis];
             if (axes->_axis[axis]->_softLimits && (coordinate < limitsMinPosition(axis) || coordinate > limitsMaxPosition(axis))) {
-                limit_error(axis, coordinate);
+                limit_error(axis, coordinate, cartesian, pl_data);
                 return true;
             }
         }

--- a/FluidNC/src/Kinematics/Cartesian.h
+++ b/FluidNC/src/Kinematics/Cartesian.h
@@ -24,7 +24,7 @@ namespace Kinematics {
         // Kinematic Interface
 
         virtual void constrain_jog(float* cartesian, plan_line_data_t* pl_data, float* position) override;
-        virtual bool invalid_line(float* cartesian) override;
+        virtual bool invalid_line(float* cartesian, plan_line_data_t* pl_data) override;
         virtual bool invalid_arc(float*            target,
                                  plan_line_data_t* pl_data,
                                  float*            position,

--- a/FluidNC/src/Kinematics/Kinematics.cpp
+++ b/FluidNC/src/Kinematics/Kinematics.cpp
@@ -15,9 +15,9 @@ namespace Kinematics {
         return _system->constrain_jog(target, pl_data, position);
     }
 
-    bool Kinematics::invalid_line(float* target) {
+    bool Kinematics::invalid_line(float* target, plan_line_data_t* pl_data) {
         Assert(_system != nullptr, no_system);
-        return _system->invalid_line(target);
+        return _system->invalid_line(target, pl_data);
     }
 
     bool Kinematics::invalid_arc(float*            target,

--- a/FluidNC/src/Kinematics/Kinematics.h
+++ b/FluidNC/src/Kinematics/Kinematics.h
@@ -42,7 +42,7 @@ namespace Kinematics {
         bool transform_cartesian_to_motors(float* motors, float* cartesian);
 
         void constrain_jog(float* target, plan_line_data_t* pl_data, float* position);
-        bool invalid_line(float* target);
+        bool invalid_line(float* target, plan_line_data_t* pl_data);
         bool invalid_arc(float*            target,
                          plan_line_data_t* pl_data,
                          float*            position,
@@ -85,7 +85,7 @@ namespace Kinematics {
         virtual void init_position() = 0;  // used to set the machine position at init
 
         virtual void constrain_jog(float* cartesian, plan_line_data_t* pl_data, float* position) {}
-        virtual bool invalid_line(float* cartesian) { return false; }
+        virtual bool invalid_line(float* cartesian, plan_line_data_t* pl_data) { return false; }
         virtual bool invalid_arc(float*            target,
                                  plan_line_data_t* pl_data,
                                  float*            position,

--- a/FluidNC/src/Kinematics/ParallelDelta.cpp
+++ b/FluidNC/src/Kinematics/ParallelDelta.cpp
@@ -148,8 +148,7 @@ namespace Kinematics {
         float motor_pos[MAX_N_AXIS] = { 0.0 };
 
         if (!transform_cartesian_to_motors(motor_pos, cartesian)) {
-            log_info("Soft limit at " << cartesian[0] << "," << cartesian[1] << "," << cartesian[2]);
-            limit_error();
+            limit_error(cartesian, pl_data);
             return true;
         }
 

--- a/FluidNC/src/Kinematics/ParallelDelta.cpp
+++ b/FluidNC/src/Kinematics/ParallelDelta.cpp
@@ -144,7 +144,7 @@ namespace Kinematics {
 #endif
     }
 
-    bool ParallelDelta::invalid_line(float* cartesian) {
+    bool ParallelDelta::invalid_line(float* cartesian, plan_line_data_t* pl_data) {
         float motor_pos[MAX_N_AXIS] = { 0.0 };
 
         if (!transform_cartesian_to_motors(motor_pos, cartesian)) {

--- a/FluidNC/src/Kinematics/ParallelDelta.h
+++ b/FluidNC/src/Kinematics/ParallelDelta.h
@@ -40,7 +40,7 @@ namespace Kinematics {
         //bool soft_limit_error_exists(float* cartesian) override;
         bool         kinematics_homing(AxisMask& axisMask) override;
         virtual void constrain_jog(float* cartesian, plan_line_data_t* pl_data, float* position) override;
-        virtual bool invalid_line(float* cartesian) override;
+        virtual bool invalid_line(float* cartesian, plan_line_data_t* pl_data) override;
         virtual bool invalid_arc(float*            target,
                                  plan_line_data_t* pl_data,
                                  float*            position,

--- a/FluidNC/src/Limit.cpp
+++ b/FluidNC/src/Limit.cpp
@@ -10,6 +10,8 @@
 #include "Protocol.h"       // protocol_execute_realtime
 #include "Platform.h"       // WEAK_LINK
 #include "Machine/Axis.h"
+#include "GCode.h"  // gc_last_line
+#include "Job.h"    // Job::channel()
 
 #include <freertos/task.h>
 #include <freertos/queue.h>
@@ -58,8 +60,30 @@ bool soft_limit = false;
 // Performs a soft limit check. Called from mcline() only. Assumes the machine has been homed,
 // the workspace volume is in all negative space, and the system is in normal operation.
 // NOTE: Used by jogging to limit travel within soft-limit volume.
-void limit_error(axis_t axis, float coordinate) {
-    log_info("Soft limit on " << Machine::Axes::axisName(axis) << " target:" << coordinate);
+void limit_error(axis_t axis, float coordinate, float* target, plan_line_data_t* pl_data) {
+    log_info("Soft limit exceeded on " << Machine::Axes::axisName(axis) << " axis: target " << coordinate << " mm, limit ["
+                                        << limitsMinPosition(axis) << ", " << limitsMaxPosition(axis) << "] mm");
+
+    if (target) {
+        LogStream ls(MsgLevelInfo, "[MSG:INFO: ");
+        ls << "Commanded mpos:";
+        auto n_axis = Machine::Axes::_numberAxis;
+        for (axis_t a = X_AXIS; a < n_axis; a++) {
+            ls << " " << Machine::Axes::axisName(a) << target[a];
+        }
+    }
+
+    if (gc_last_line && gc_last_line[0]) {
+        log_info("GCode line: " << gc_last_line);
+    }
+
+    Channel* job = Job::channel();
+    if (job) {
+        // Running from a file or macro; report where in the job this occurred.
+        log_info("In " << job->name() << " at line " << job->lineNumber());
+    } else if (pl_data && pl_data->line_number) {
+        log_info("At N" << pl_data->line_number);
+    }
 
     limit_error();
 }

--- a/FluidNC/src/Limit.cpp
+++ b/FluidNC/src/Limit.cpp
@@ -57,12 +57,16 @@ bool ambiguousLimit() {
 
 bool soft_limit = false;
 
-// Performs a soft limit check. Called from mcline() only. Assumes the machine has been homed,
-// the workspace volume is in all negative space, and the system is in normal operation.
-// NOTE: Used by jogging to limit travel within soft-limit volume.
-void limit_error(axis_t axis, float coordinate, float* target, plan_line_data_t* pl_data) {
-    log_info("Soft limit exceeded on " << Machine::Axes::axisName(axis) << " axis: target " << coordinate << " mm, limit ["
-                                        << limitsMinPosition(axis) << ", " << limitsMaxPosition(axis) << "] mm");
+// Logs the commanded mpos, the gcode line that produced it, and the job location
+// (file+line, or N-word), shared by both flavors of limit_error() below. target is
+// the full N-axis position that was commanded, if known.
+static void log_limit_context(float* target, plan_line_data_t* pl_data) {
+    // A clustered move (e.g. dynamic laser power) reports the original un-split
+    // command endpoint rather than the interior segment endpoint that was actually
+    // being planned when the violation was detected.
+    if (pl_data && pl_data->report_target) {
+        target = pl_data->report_target;
+    }
 
     if (target) {
         LogStream ls(MsgLevelInfo, "[MSG:INFO: ");
@@ -84,6 +88,26 @@ void limit_error(axis_t axis, float coordinate, float* target, plan_line_data_t*
     } else if (pl_data && pl_data->line_number) {
         log_info("At N" << pl_data->line_number);
     }
+}
+
+// Performs a soft limit check. Called from mcline() only. Assumes the machine has been homed,
+// the workspace volume is in all negative space, and the system is in normal operation.
+// NOTE: Used by jogging to limit travel within soft-limit volume.
+void limit_error(axis_t axis, float coordinate, float* target, plan_line_data_t* pl_data) {
+    log_info("Soft limit exceeded on " << Machine::Axes::axisName(axis) << " axis: target " << coordinate << " mm, limit ["
+                                        << limitsMinPosition(axis) << ", " << limitsMaxPosition(axis) << "] mm");
+
+    log_limit_context(target, pl_data);
+
+    limit_error();
+}
+
+// Reports a soft limit failure that isn't tied to a single axis/bound, e.g. a
+// commanded position that inverse kinematics cannot reach at all.
+void limit_error(float* target, plan_line_data_t* pl_data) {
+    log_info("Soft limit: commanded position is outside the reachable workspace");
+
+    log_limit_context(target, pl_data);
 
     limit_error();
 }

--- a/FluidNC/src/Limit.cpp
+++ b/FluidNC/src/Limit.cpp
@@ -68,7 +68,7 @@ static void log_limit_context(float* target, plan_line_data_t* pl_data) {
         target = pl_data->report_target;
     }
 
-    if (target) {
+    if (target && atMsgLevel(MsgLevelInfo)) {
         LogStream ls(MsgLevelInfo, "[MSG:INFO: ");
         ls << "Commanded mpos:";
         auto n_axis = Machine::Axes::_numberAxis;
@@ -85,7 +85,9 @@ static void log_limit_context(float* target, plan_line_data_t* pl_data) {
     if (job) {
         // Running from a file or macro; report where in the job this occurred.
         log_info("In " << job->name() << " at line " << job->lineNumber());
-    } else if (pl_data && pl_data->line_number) {
+    } else if (pl_data && pl_data->has_line_number) {
+        // N0 is a valid explicit line number, so has_line_number (not line_number != 0)
+        // is what distinguishes "N0 was given" from "no N-word at all".
         log_info("At N" << pl_data->line_number);
     }
 }

--- a/FluidNC/src/Limit.h
+++ b/FluidNC/src/Limit.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "System.h"
+#include "Planner.h"  // plan_line_data_t
 
 #include <cstdint>
 
@@ -17,7 +18,11 @@ void limits_init();
 MotorMask limits_get_state();
 
 void limit_error();
-void limit_error(axis_t axis, float coordinate);
+
+// axis is the axis whose limit was exceeded, coordinate is the out-of-range value.
+// target, if non-null, is the full commanded mpos (all axes) for the move that was
+// rejected, and pl_data, if non-null, carries the gcode line number for that move.
+void limit_error(axis_t axis, float coordinate, float* target = nullptr, plan_line_data_t* pl_data = nullptr);
 
 float limitsMaxPosition(axis_t axis);
 float limitsMinPosition(axis_t axis);

--- a/FluidNC/src/Limit.h
+++ b/FluidNC/src/Limit.h
@@ -24,6 +24,10 @@ void limit_error();
 // rejected, and pl_data, if non-null, carries the gcode line number for that move.
 void limit_error(axis_t axis, float coordinate, float* target = nullptr, plan_line_data_t* pl_data = nullptr);
 
+// Reports a soft limit failure that isn't tied to a single axis/bound, e.g. a
+// commanded position that inverse kinematics cannot reach at all (ParallelDelta).
+void limit_error(float* target, plan_line_data_t* pl_data);
+
 float limitsMaxPosition(axis_t axis);
 float limitsMinPosition(axis_t axis);
 

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -110,7 +110,7 @@ static bool mc_linear_no_check(float* target, plan_line_data_t* pl_data, float* 
 }
 bool mc_linear(float* target, plan_line_data_t* pl_data, float* position) {
     if (!pl_data->is_jog && !pl_data->limits_checked) {  // soft limits for jogs have already been dealt with
-        if (config->_kinematics->invalid_line(target)) {
+        if (config->_kinematics->invalid_line(target, pl_data)) {
             return false;
         }
     }

--- a/FluidNC/src/MotionControl.cpp
+++ b/FluidNC/src/MotionControl.cpp
@@ -137,6 +137,7 @@ void mc_clustered_linear_move(float* target, plan_line_data_t* pl_data, float* p
 
     for (size_t cluster = 0; cluster < cluster_count; cluster++) {
         plan_line_data_t segment_data = *pl_data;
+        segment_data.report_target    = target;  // full commanded endpoint, for soft limit diagnostics
 
         if (segment_data.motion.inverseTime) {
             // G93 inverse-time feed specifies the total move duration. When one

--- a/FluidNC/src/Planner.h
+++ b/FluidNC/src/Planner.h
@@ -69,6 +69,14 @@ struct plan_line_data_t {
     int32_t      line_number;     // Desired line number to report when executing.
     bool         is_jog;          // true if this was generated due to a jog command
     bool         limits_checked;  // true if soft limits already checked
+
+    // When a move is split into several planner blocks (e.g. clustered spindle-speed
+    // segments), each block's target is an interior point of the original command.
+    // report_target, if set, is the original un-split command endpoint, so that a
+    // soft limit diagnostic reports the position the operator actually commanded
+    // rather than an intermediate segment endpoint. Every plan_line_data_t is either
+    // zero-initialized or memset to zero before use, so this is null unless explicitly set.
+    float* report_target;
 };
 
 void plan_init();

--- a/FluidNC/src/Planner.h
+++ b/FluidNC/src/Planner.h
@@ -66,9 +66,10 @@ struct plan_line_data_t {
     PlMotion     motion;          // Bitflag variable to indicate motion conditions. See defines above.
     SpindleState spindle;         // Spindle enable state
     CoolantState coolant;         // Coolant state
-    int32_t      line_number;     // Desired line number to report when executing.
-    bool         is_jog;          // true if this was generated due to a jog command
-    bool         limits_checked;  // true if soft limits already checked
+    int32_t      line_number;       // Desired line number to report when executing.
+    bool         has_line_number;   // true if an explicit N-word set line_number (N0 is valid and distinct from "no N-word")
+    bool         is_jog;            // true if this was generated due to a jog command
+    bool         limits_checked;    // true if soft limits already checked
 
     // When a move is split into several planner blocks (e.g. clustered spindle-speed
     // segments), each block's target is an interior point of the original command.


### PR DESCRIPTION
## Summary
- When a soft limit alarm fires, report the axis and its configured min/max limit bounds, the full commanded mpos (all axes), the gcode line text that triggered the move, and where it happened in the job (filename + line number when running from SD/macro, falling back to the gcode N-word otherwise).
- Previously the only feedback was the axis name and the single out-of-range target coordinate, with no line/file context.
- `invalid_line()` now takes a `plan_line_data_t*` (matching `invalid_arc()`'s existing signature) so its line number is available at the point of the check; no new global for that.
- The gcode line text is exposed via a `const char*` (`gc_last_line`) that aliases the caller's own line buffer rather than a copy, since the check happens synchronously within `gc_execute_line()` — no extra static RAM.

## Test plan
- [x] `pio run -e macos` builds clean
- [ ] On hardware: trigger a soft limit alarm (a) interactively and (b) from an SD job, and confirm the new report shows axis/limits/mpos/gcode line/file+line as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)